### PR TITLE
fix: add missing param pickedBy read from auth context

### DIFF
--- a/src/controllers/handlers/catalog-handler.ts
+++ b/src/controllers/handlers/catalog-handler.ts
@@ -22,7 +22,7 @@ export function createCatalogHandler(
     const limit = params.getNumber('first', DEFAULT_PAGE_SIZE)
     const offset = params.getNumber('skip', 0)
     // @TODO: add favorites logic
-    // const pickedBy: string | undefined = context.verification?.auth.toLowerCase()
+    const pickedBy: string | undefined = context.verification?.auth.toLowerCase()
 
     return asJSON(async () => {
       return await catalog.fetch({
@@ -32,7 +32,7 @@ export function createCatalogHandler(
         sortDirection,
         onlyListing,
         onlyMinting,
-        // pickedBy,
+        pickedBy,
         ...getItemsParams(params)
       })
     })

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -1,7 +1,10 @@
 import { Router } from '@well-known-components/http-server'
+import * as authorizationMiddleware from 'decentraland-crypto-middleware'
 import { GlobalContext } from '../types'
 import { createCatalogHandler } from './handlers/catalog-handler'
 import { pingHandler } from './handlers/ping-handler'
+
+const FIVE_MINUTES = 5 * 60 * 1000
 
 // We return the entire router because it will be easier to test than a whole server
 export async function setupRouter(globalContext: GlobalContext): Promise<Router<GlobalContext>> {
@@ -9,7 +12,14 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   const router = new Router<GlobalContext>()
 
   router.get('/ping', pingHandler)
-  router.get('/v1/catalog', createCatalogHandler(components))
+  router.get(
+    '/v1/catalog',
+    authorizationMiddleware.wellKnownComponents({
+      optional: true,
+      expiration: FIVE_MINUTES
+    }),
+    createCatalogHandler(components)
+  )
 
   return router
 }


### PR DESCRIPTION
The `pickedBy` param was commented, we need it to fetch if the items returned were picked by the user that signed the request