### PR TITLE
feat: Add search by utility

### DIFF
--- a/src/migrations/substreams/1715105480588_builder-server-builder-item-utility.ts
+++ b/src/migrations/substreams/1715105480588_builder-server-builder-item-utility.ts
@@ -1,0 +1,33 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+const materializedViewName = 'mv_builder_server_items_utility'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Add utility to the foreign table
+  pgm.sql('ALTER FOREIGN TABLE builder_server_items ADD COLUMN utility text;')
+
+  // New materialized view for the utility
+  pgm.createMaterializedView(
+    materializedViewName,
+    { ifNotExists: true },
+    `SELECT
+      collections.contract_address || '-' || server_items.blockchain_item_id AS item_id,
+      server_items.utility as utility,
+      blockchain_items.created_at
+     FROM
+      builder_server_items server_items, builder_server_collections collections, dcl36.items blockchain_items
+     WHERE server_items.blockchain_item_id IS NOT NULL 
+     AND server_items.utility IS NOT NULL 
+     AND server_items.collection_id = collections.id 
+     AND blockchain_items.id = (collections.contract_address || '-' || server_items.blockchain_item_id);`
+  )
+  pgm.addIndex(materializedViewName, ['item_id'], { name: 'idx_mv_builder_server_items_utility', unique: true })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Drop new materialized view
+  pgm.dropMaterializedView(materializedViewName)
+
+  // Restore old foreign table
+  pgm.sql('ALTER FOREIGN TABLE builder_server_items DROP COLUMN utility;')
+}

--- a/src/migrations/substreams/1715105480588_builder-server-builder-item-utility.ts
+++ b/src/migrations/substreams/1715105480588_builder-server-builder-item-utility.ts
@@ -4,7 +4,7 @@ const materializedViewName = 'mv_builder_server_items_utility'
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   // Add utility to the foreign table
-  pgm.sql('ALTER FOREIGN TABLE builder_server_items ADD COLUMN utility text;')
+  pgm.sql('ALTER FOREIGN TABLE builder_server_items ADD COLUMN IF NOT EXISTS utility text;')
 
   // New materialized view for the utility
   pgm.createMaterializedView(

--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -230,14 +230,12 @@ const getMultiNetworkQuery = (schemas: Record<string, string>, filters: CatalogQ
   // The following code wraps the UNION query in a subquery so we can get the total count of items before applying the limit and offset
   const unionQuery = SQL`SELECT *, COUNT(*) OVER() as total FROM (\n`
   queries.forEach((query, index) => {
-    unionQuery.append('(')
     unionQuery.append(query)
-    unionQuery.append(')')
     if (queries[index + 1]) {
-      unionQuery.append(SQL`\n UNION ALL \n`)
+      unionQuery.append(SQL`\n UNION ALL ( \n`)
     }
   })
-  unionQuery.append(SQL`\n) as temp \n`)
+  unionQuery.append(SQL`\n)) as temp \n`)
   addQuerySort(unionQuery, filters)
   if (limit !== undefined && offset !== undefined) {
     unionQuery.append(SQL`LIMIT ${limit} OFFSET ${offset}`)


### PR DESCRIPTION
This PR makes the item's utility and the utility keyword searchable.
It does so by:
- Altering the builder's server table to include the utility column.
- Creating a materialized view with the builder's server's utilities.
- Creating a new query to search items by utility or by the item having utility (which is underweighted to not surpass the search by name or tag).
- Unifying both search queries (the names and tag ones with the utility one) and returning their unique ids.