### PR TITLE
fix: Materialized builder items utility

### DIFF
--- a/src/migrations/substreams/1715105480588_builder-server-builder-item-utility.ts
+++ b/src/migrations/substreams/1715105480588_builder-server-builder-item-utility.ts
@@ -12,14 +12,12 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     { ifNotExists: true },
     `SELECT
       collections.contract_address || '-' || server_items.blockchain_item_id AS item_id,
-      server_items.utility as utility,
-      blockchain_items.created_at
+      server_items.utility as utility
      FROM
-      builder_server_items server_items, builder_server_collections collections, dcl36.items blockchain_items
+      builder_server_items server_items, builder_server_collections collections
      WHERE server_items.blockchain_item_id IS NOT NULL 
      AND server_items.utility IS NOT NULL 
-     AND server_items.collection_id = collections.id 
-     AND blockchain_items.id = (collections.contract_address || '-' || server_items.blockchain_item_id);`
+     AND server_items.collection_id = collections.id;`
   )
   pgm.addIndex(materializedViewName, ['item_id'], { name: 'idx_mv_builder_server_items_utility', unique: true, ifNotExists: true })
 }

--- a/src/migrations/substreams/1715105480588_builder-server-builder-item-utility.ts
+++ b/src/migrations/substreams/1715105480588_builder-server-builder-item-utility.ts
@@ -21,7 +21,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
      AND server_items.collection_id = collections.id 
      AND blockchain_items.id = (collections.contract_address || '-' || server_items.blockchain_item_id);`
   )
-  pgm.addIndex(materializedViewName, ['item_id'], { name: 'idx_mv_builder_server_items_utility', unique: true })
+  pgm.addIndex(materializedViewName, ['item_id'], { name: 'idx_mv_builder_server_items_utility', unique: true, ifNotExists: true })
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {


### PR DESCRIPTION
This PR does the following:
- Removes the `created_at` column which is not used and requires to know in advance which is the latest schema.
- Adds to the creation of the index the if not exists clause to prevent any issues.