### PR TITLE
fix: create extension error

### DIFF
--- a/src/migrations/dapps/1722423701641_fdw-setup.ts
+++ b/src/migrations/dapps/1722423701641_fdw-setup.ts
@@ -11,7 +11,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   const builderServerDBUser = await config.requireString('BUILDER_SERVER_DB_USER')
   const builderServerDBPassword = await config.requireString('BUILDER_SERVER_DB_PASSWORD')
 
-  pgm.sql('CREATE EXTENSION IF NOT EXISTS postgres_fdw;')
   pgm.sql(`
             CREATE SERVER IF NOT EXISTS builder_server
             FOREIGN DATA WRAPPER postgres_fdw

--- a/test/db/init-marketplace-schema.sh
+++ b/test/db/init-marketplace-schema.sh
@@ -25,4 +25,5 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     CREATE TABLE squid_marketplace."emote" ("id" character varying NOT NULL, "name" text NOT NULL, "description" text NOT NULL, "collection" text NOT NULL, "category" character varying(13) NOT NULL, "loop" boolean NOT NULL, "rarity" character varying(9) NOT NULL, "body_shapes" character varying(10) array, "has_sound" boolean, "has_geometry" boolean, CONSTRAINT "PK_c08d432f6b22ef550be511163ac" PRIMARY KEY ("id"));
 
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    CREATE EXTENSION IF NOT EXISTS "postgres_fdw";
 EOSQL


### PR DESCRIPTION
Remove create extension from migrations as the user doesn;t have superuser permissions. The extension will be added manualy