### PR TITLE
fix: trade network

### DIFF
--- a/src/ports/orders/queries.ts
+++ b/src/ports/orders/queries.ts
@@ -42,7 +42,7 @@ export function getTradesOrdersQuery(): string {
       id::text,
       id as trade_id,
       CASE
-        WHEN LOWER(network) = 'polygon' then '${marketplacePolygon.address}'
+        WHEN LOWER(network) = 'matic' then '${marketplacePolygon.address}'
       ELSE '${marketplaceEthereum.address}'
       END AS marketplace_address,
       assets -> 'sent' ->> 'category' as category,


### PR DESCRIPTION
Fix trades network name when assigning the right marketplace contract (use MATIC that is the one defined in schemas instead of polygon)