### PR TITLE
fix: nft id calculation

### DIFF
--- a/src/adapters/nfts/index.ts
+++ b/src/adapters/nfts/index.ts
@@ -71,7 +71,7 @@ export function fromDBNFTToNFT(dbNFT: DBNFT): NFT {
     contractAddress: dbNFT.contract_address,
     createdAt: fromSecondsToMilliseconds(Number(dbNFT.created_at)),
     data: getDataFromDBNFT(dbNFT),
-    id: dbNFT.id,
+    id: `${dbNFT.contract_address}-${dbNFT.token_id}`,
     image: dbNFT.image || '',
     issuedId: dbNFT.issued_id,
     itemId: dbNFT.item_id,

--- a/test/unit/nfts-adapters.spec.ts
+++ b/test/unit/nfts-adapters.spec.ts
@@ -61,7 +61,7 @@ describe('fromDBNFTToNFT', () => {
           isSmart: dbNFT.item_type === ItemType.SMART_WEARABLE_V1
         }
       },
-      id: dbNFT.id,
+      id: `${dbNFT.contract_address}-${dbNFT.token_id}`,
       image: dbNFT.image,
       issuedId: dbNFT.issued_id,
       itemId: dbNFT.item_id,
@@ -127,7 +127,7 @@ describe('fromDBNFTToNFT', () => {
           }
         }
       },
-      id: dbNFT.id,
+      id: `${dbNFT.contract_address}-${dbNFT.token_id}`,
       image: dbNFT.image,
       issuedId: dbNFT.issued_id,
       itemId: dbNFT.item_id,
@@ -182,7 +182,7 @@ describe('fromDBNFTToNFT', () => {
           subdomain: dbNFT.subdomain as string
         }
       },
-      id: dbNFT.id,
+      id: `${dbNFT.contract_address}-${dbNFT.token_id}`,
       image: dbNFT.image,
       issuedId: dbNFT.issued_id,
       itemId: dbNFT.item_id,
@@ -241,7 +241,7 @@ describe('fromDBNFTToNFT', () => {
           parcels: dbNFT.estate_parcels || []
         }
       },
-      id: dbNFT.id,
+      id: `${dbNFT.contract_address}-${dbNFT.token_id}`,
       image: dbNFT.image,
       issuedId: dbNFT.issued_id,
       itemId: dbNFT.item_id,
@@ -306,7 +306,7 @@ describe('fromDBNFTToNFT', () => {
           hasGeometry: dbNFT.has_geometry || false
         }
       },
-      id: dbNFT.id,
+      id: `${dbNFT.contract_address}-${dbNFT.token_id}`,
       image: dbNFT.image,
       issuedId: dbNFT.issued_id,
       itemId: dbNFT.item_id,


### PR DESCRIPTION
The id store in the db for ens and lands have the type appended as a prefix. `ens-#contractAddr-#tokenId` we need the id to only be the `#contractAddr-#tokenId`