### PR TITLE
fix: Data type incompatibility

### DIFF
--- a/test/components.ts
+++ b/test/components.ts
@@ -108,7 +108,7 @@ async function initComponents(): Promise<TestComponents> {
   const catalog = await createCatalogComponent({ dappsDatabase: dappsReadDatabase, dappsWriteDatabase, picks }, SEGMENT_WRITE_KEY)
   const schemaValidator = await createSchemaValidatorComponent()
   const balances = createBalanceComponent({ apiKey: COVALENT_API_KEY ?? '' })
-  const trades = createTradesComponent({ dappsDatabase: dappsReadDatabase, eventPublisher, logs })
+  const trades = createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs })
   const bids = createBidsComponents({ dappsDatabase: dappsReadDatabase })
 
   const rentalsSubgraph = await createSubgraphComponent(

--- a/test/integration/trades-controller.spec.ts
+++ b/test/integration/trades-controller.spec.ts
@@ -59,7 +59,7 @@ test('trades controller', function ({ components }) {
           {
             assetType: TradeAssetType.ERC721,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-            tokenId: 'atokenid',
+            tokenId: '100',
             extra: '0x',
             beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
           }
@@ -75,7 +75,7 @@ test('trades controller', function ({ components }) {
             {
               assetType: TradeAssetType.ERC721,
               contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-              tokenId: 'atokenid',
+              tokenId: '100',
               extra: '0x',
               beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
             }
@@ -166,7 +166,7 @@ test('trades controller', function ({ components }) {
             {
               assetType: TradeAssetType.COLLECTION_ITEM,
               contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-              itemId: 'anItemId',
+              itemId: '1',
               extra: '0x',
               beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
             }
@@ -328,7 +328,7 @@ test('trades controller', function ({ components }) {
           {
             assetType: TradeAssetType.ERC721,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-            tokenId: 'atokenid',
+            tokenId: '100',
             extra: '0x',
             beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
           }

--- a/test/unit/lists-handler.spec.ts
+++ b/test/unit/lists-handler.spec.ts
@@ -709,7 +709,7 @@ describe('when getting the lists', () => {
         }
       ]
       getListsMock.mockResolvedValueOnce(dbLists)
-      url = new URL('http://localhost/v1/lists?sortBy=name&sortDirection=asc&itemId=anItemId&q=aName')
+      url = new URL('http://localhost/v1/lists?sortBy=name&sortDirection=asc&itemId=1&q=aName')
       result = getListsHandler({ url, components, verification })
     })
 
@@ -736,7 +736,7 @@ describe('when getting the lists', () => {
         limit: 100,
         sortBy: ListSortBy.NAME,
         sortDirection: ListSortDirection.ASC,
-        itemId: 'anItemId',
+        itemId: '1',
         q: 'aName'
       })
     })

--- a/test/unit/picks-adapters.spec.ts
+++ b/test/unit/picks-adapters.spec.ts
@@ -53,7 +53,7 @@ describe('when transforming DB retrieved pick stats into pick stats', () => {
   let dbPickStats: DBPickStats
   beforeEach(() => {
     dbPickStats = {
-      item_id: 'anItemId',
+      item_id: '1',
       count: '1000'
     }
   })

--- a/test/unit/trades-utils.spec.ts
+++ b/test/unit/trades-utils.spec.ts
@@ -72,7 +72,7 @@ describe('when calling getNotificationEventForTrade function', () => {
         {
           assetType: TradeAssetType.ERC721,
           contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-          tokenId: 'atokenid',
+          tokenId: '100',
           extra: '0x',
           beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
         }
@@ -92,7 +92,7 @@ describe('when calling getNotificationEventForTrade function', () => {
             {
               assetType: TradeAssetType.ERC721,
               contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-              tokenId: 'atokenid',
+              tokenId: '100',
               extra: '0x',
               beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
             }
@@ -163,7 +163,7 @@ describe('when calling getNotificationEventForTrade function', () => {
             {
               assetType: TradeAssetType.COLLECTION_ITEM,
               contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-              itemId: 'anItemId',
+              itemId: '1',
               extra: '0x',
               beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
             }
@@ -274,7 +274,7 @@ describe('when validating trade by type', () => {
         {
           assetType: TradeAssetType.ERC721,
           contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-          tokenId: 'atokenid',
+          tokenId: '100',
           extra: '0x',
           beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
         }
@@ -293,7 +293,7 @@ describe('when validating trade by type', () => {
           {
             assetType: TradeAssetType.ERC721,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
-            tokenId: 'atokenid',
+            tokenId: '100',
             extra: '0x'
           }
         ]
@@ -351,7 +351,7 @@ describe('when validating trade by type', () => {
           {
             assetType: TradeAssetType.ERC721,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-            tokenId: 'atokenid',
+            tokenId: '100',
             extra: '0x',
             beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
           },
@@ -388,7 +388,7 @@ describe('when validating trade by type', () => {
           {
             assetType: TradeAssetType.COLLECTION_ITEM,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
-            itemId: 'anitemid',
+            itemId: '1',
             extra: '0x'
           }
         ]
@@ -405,7 +405,7 @@ describe('when validating trade by type', () => {
           {
             assetType: TradeAssetType.ERC721,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-            tokenId: 'atokenId',
+            tokenId: '100',
             extra: '0x',
             beneficiary: '0x123'
           }
@@ -446,7 +446,7 @@ describe('when validating trade by type', () => {
           {
             assetType: TradeAssetType.ERC721,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-            tokenId: 'atokenid',
+            tokenId: '100',
             extra: '0x',
             beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
           },
@@ -481,7 +481,7 @@ describe('when validating trade by type', () => {
           {
             assetType: TradeAssetType.ERC721,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
-            tokenId: 'atokenid',
+            tokenId: '100',
             extra: '0x'
           }
         ]
@@ -504,7 +504,7 @@ describe('when validating trade by type', () => {
           {
             assetType: TradeAssetType.ERC721,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
-            tokenId: 'atokenId',
+            tokenId: '100',
             extra: '0x'
           }
         ]
@@ -521,7 +521,7 @@ describe('when validating trade by type', () => {
           {
             assetType: TradeAssetType.ERC721,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-            tokenId: 'atokenId',
+            tokenId: '100',
             extra: '0x',
             beneficiary: '0x123'
           }
@@ -562,7 +562,7 @@ describe('when validating trade by type', () => {
           {
             assetType: TradeAssetType.ERC721,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
-            tokenId: 'atokenid',
+            tokenId: '100',
             extra: '0x',
             beneficiary: '0x9d32aac179153a991e832550d9f96441ea27763b'
           },
@@ -597,7 +597,7 @@ describe('when validating trade by type', () => {
           {
             assetType: TradeAssetType.COLLECTION_ITEM,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
-            itemId: 'anitemid',
+            itemId: '1',
             extra: '0x'
           }
         ]


### PR DESCRIPTION
This PR fixes the data type incompatibility in the integration tests for the token and item IDs being a string but filtering as ID in the squids' tables