### PR TITLE
feat: Add fingerprinting estate contract check

### DIFF
--- a/src/logic/trades/utils.ts
+++ b/src/logic/trades/utils.ts
@@ -155,7 +155,7 @@ export async function isEstateFingerprintValid(
   const provider = new JsonRpcProvider(getRPCUrlByChainId(chainId))
   const contract = new Contract(contractAddress, abi, provider)
   const estateFingerprint = await contract.getFingerprint(tokenId)
-  return estateFingerprint === fingerprint
+  return estateFingerprint.toLowerCase() === fingerprint.toLowerCase()
 }
 
 export async function validateAssetOwnership(asset: ERC721TradeAsset, signer: string, chainId: ChainId): Promise<boolean> {

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -55,7 +55,7 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
       throw new InvalidTradeStructureError(trade.type)
     }
     // Validate if estate trade is correct
-    if (isEstateChain(trade.chainId) && !isValidEstateTrade(trade)) {
+    if (isEstateChain(trade.chainId) && !(await isValidEstateTrade(trade))) {
       throw new InvalidEstateTrade()
     }
 
@@ -65,7 +65,7 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
     }
 
     // validate right ownership
-    if (isERC721TradeAsset(trade.sent[0]) && !(await validateAssetOwnership(trade.sent[0], signer, trade.network, trade.chainId))) {
+    if (isERC721TradeAsset(trade.sent[0]) && !(await validateAssetOwnership(trade.sent[0], signer, trade.chainId))) {
       throw new InvalidOwnerError()
     }
 

--- a/src/ports/trades/utils.ts
+++ b/src/ports/trades/utils.ts
@@ -14,6 +14,7 @@ import {
 } from '@dcl/schemas'
 import { fromTradeAndAssetsToEventNotification } from '../../adapters/trades/trades'
 import { getMarketplaceContracts } from '../../logic/contracts'
+import { isEstateFingerprintValid } from '../../logic/trades/utils'
 import { getBidsQuery } from '../bids/queries'
 import { getItemByItemIdQuery, getItemsQuery } from '../items/queries'
 import { DBItem } from '../items/types'
@@ -48,26 +49,28 @@ export function isEstateChain(chainId: ChainId): boolean {
   return chainId !== ChainId.MATIC_AMOY && chainId !== ChainId.MATIC_MAINNET
 }
 
-export function isValidEstateTrade(trade: TradeCreation): boolean {
+export async function isValidEstateTrade(trade: TradeCreation): Promise<boolean> {
   const contracts = getMarketplaceContracts(trade.chainId)
   const estateContract = contracts.find(contract => contract.name === 'Estates')
   if (!estateContract) {
     throw new EstateContractNotFoundForChainId(trade.chainId)
   }
 
-  // Check if the trade contains an estate with an empty extra field (all estates must have the extra field which is the fingerprint)
-  const isSentEstateTradeWrong = trade.sent.some(
-    asset => asset.contractAddress.toLowerCase() === estateContract.address.toLowerCase() && isBytesEmpty(asset.extra)
-  )
-  const isReceivedEstateTradeWrong = trade.received.some(
-    asset => asset.contractAddress.toLowerCase() === estateContract.address.toLowerCase() && isBytesEmpty(asset.extra)
+  const assets = [...trade.sent, ...trade.received]
+  const areEstatesFingerprintsValid = await Promise.all(
+    assets.map(async asset => {
+      // Only check if the asset is an estate
+      if (asset.contractAddress.toLowerCase() === estateContract.address.toLowerCase()) {
+        return (
+          !isBytesEmpty(asset.extra) &&
+          (await isEstateFingerprintValid(estateContract.address, (asset as ERC721TradeAsset)?.tokenId, trade.chainId, asset.extra))
+        )
+      }
+      return true
+    })
   )
 
-  if (isSentEstateTradeWrong || isReceivedEstateTradeWrong) {
-    return false
-  }
-
-  return true
+  return areEstatesFingerprintsValid.every(Boolean)
 }
 
 export async function validateTradeByType(trade: TradeCreation, client: IPgComponent): Promise<boolean> {

--- a/src/ports/trades/utils.ts
+++ b/src/ports/trades/utils.ts
@@ -57,20 +57,18 @@ export async function isValidEstateTrade(trade: TradeCreation): Promise<boolean>
   }
 
   const assets = [...trade.sent, ...trade.received]
-  const areEstatesFingerprintsValid = await Promise.all(
-    assets.map(async asset => {
-      // Only check if the asset is an estate
-      if (asset.contractAddress.toLowerCase() === estateContract.address.toLowerCase()) {
-        return (
-          !isBytesEmpty(asset.extra) &&
-          (await isEstateFingerprintValid(estateContract.address, (asset as ERC721TradeAsset)?.tokenId, trade.chainId, asset.extra))
-        )
-      }
-      return true
-    })
-  )
+  // Checks trades one by one to prevent unnecessary checks. This should be changed when implementing bundles or the cart system.
+  for (const asset of assets) {
+    // Only check if the asset is an estate
+    if (asset.contractAddress.toLowerCase() === estateContract.address.toLowerCase()) {
+      return (
+        !isBytesEmpty(asset.extra) &&
+        (await isEstateFingerprintValid(estateContract.address, (asset as ERC721TradeAsset)?.tokenId, trade.chainId, asset.extra))
+      )
+    }
+  }
 
-  return areEstatesFingerprintsValid.every(Boolean)
+  return true
 }
 
 export async function validateTradeByType(trade: TradeCreation, client: IPgComponent): Promise<boolean> {

--- a/test/unit/trades-component.spec.ts
+++ b/test/unit/trades-component.spec.ts
@@ -143,7 +143,7 @@ describe('when adding a new trade', () => {
   describe('when the trade structure is not valid for a given type', () => {
     beforeEach(() => {
       jest.spyOn(utils, 'validateTradeByType').mockResolvedValue(false)
-      jest.spyOn(utils, 'isValidEstateTrade').mockReturnValueOnce(true)
+      jest.spyOn(utils, 'isValidEstateTrade').mockResolvedValueOnce(true)
     })
 
     it('should throw an InvalidTradeStructureError', async () => {
@@ -155,7 +155,7 @@ describe('when adding a new trade', () => {
     beforeEach(() => {
       jest.spyOn(signatureUtils, 'validateTradeSignature').mockReturnValue(false)
       jest.spyOn(utils, 'validateTradeByType').mockResolvedValue(true)
-      jest.spyOn(utils, 'isValidEstateTrade').mockReturnValueOnce(true)
+      jest.spyOn(utils, 'isValidEstateTrade').mockResolvedValueOnce(true)
     })
 
     it('should throw an InvalidTradeSignatureError', async () => {
@@ -168,7 +168,7 @@ describe('when adding a new trade', () => {
       mockTrade.chainId = ChainId.ETHEREUM_SEPOLIA
       jest.spyOn(signatureUtils, 'validateTradeSignature').mockReturnValue(true)
       jest.spyOn(utils, 'validateTradeByType').mockResolvedValue(true)
-      jest.spyOn(utils, 'isValidEstateTrade').mockReturnValueOnce(false)
+      jest.spyOn(utils, 'isValidEstateTrade').mockResolvedValueOnce(false)
     })
 
     it('should throw an EstateTradeWithoutFingerprintError', async () => {
@@ -189,7 +189,7 @@ describe('when adding a new trade', () => {
     beforeEach(async () => {
       jest.spyOn(signatureUtils, 'validateTradeSignature').mockReturnValue(true)
       jest.spyOn(utils, 'validateTradeByType').mockResolvedValue(true)
-      jest.spyOn(utils, 'isValidEstateTrade').mockReturnValueOnce(true)
+      jest.spyOn(utils, 'isValidEstateTrade').mockResolvedValueOnce(true)
       mockPgQuery = jest.fn()
       ;(mockPg.withTransaction as jest.Mock).mockImplementation((fn, _onError) => fn({ query: mockPgQuery }))
 

--- a/test/unit/trades-utils.spec.ts
+++ b/test/unit/trades-utils.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '@dcl/schemas'
 import { getCategoryFromDBItem } from '../../src/adapters/items'
 import * as chainIdUtils from '../../src/logic/chainIds'
+import * as tradeLogicUtils from '../../src/logic/trades/utils'
 import { getItemByItemIdQuery } from '../../src/ports/items/queries'
 import { DBItem, ItemType } from '../../src/ports/items/types'
 import { getNftByTokenIdQuery } from '../../src/ports/nfts/queries'
@@ -277,12 +278,12 @@ describe("when validating the trade to see if it's a correct estate trade", () =
       trade.chainId = ChainId.AVALANCHE_MAINNET
     })
 
-    it('should throw the EstateContractNotFoundForChainId error', () => {
-      return expect(() => isValidEstateTrade(trade)).toThrow(new EstateContractNotFoundForChainId(ChainId.AVALANCHE_MAINNET))
+    it('should reject to throw the EstateContractNotFoundForChainId error', () => {
+      return expect(isValidEstateTrade(trade)).rejects.toThrow(new EstateContractNotFoundForChainId(ChainId.AVALANCHE_MAINNET))
     })
   })
 
-  describe('and the sent asset is an estate without fingerprint', () => {
+  describe("and there's a sent asset which is an estate without fingerprint", () => {
     beforeEach(() => {
       trade.sent = [
         {
@@ -295,11 +296,11 @@ describe("when validating the trade to see if it's a correct estate trade", () =
     })
 
     it('should return false', () => {
-      expect(isValidEstateTrade(trade)).toBe(false)
+      return expect(isValidEstateTrade(trade)).resolves.toBe(false)
     })
   })
 
-  describe('and the received asset is an estate without fingerprint', () => {
+  describe("and there's a received asset is an estate without fingerprint", () => {
     beforeEach(() => {
       trade.received = [
         {
@@ -313,7 +314,7 @@ describe("when validating the trade to see if it's a correct estate trade", () =
     })
 
     it('should return false', () => {
-      expect(isValidEstateTrade(trade)).toBe(false)
+      return expect(isValidEstateTrade(trade)).resolves.toBe(false)
     })
   })
 
@@ -329,8 +330,24 @@ describe("when validating the trade to see if it's a correct estate trade", () =
       ]
     })
 
-    it('should return true', () => {
-      expect(isValidEstateTrade(trade)).toBe(true)
+    describe('and the fingerprint is equal than the one in the contract', () => {
+      beforeEach(() => {
+        jest.spyOn(tradeLogicUtils, 'isEstateFingerprintValid').mockResolvedValue(true)
+      })
+
+      it('should return true', () => {
+        return expect(isValidEstateTrade(trade)).resolves.toBe(true)
+      })
+    })
+
+    describe('and the fingerprint is different than the one in the contract', () => {
+      beforeEach(() => {
+        jest.spyOn(tradeLogicUtils, 'isEstateFingerprintValid').mockResolvedValue(false)
+      })
+
+      it('should return false', () => {
+        return expect(isValidEstateTrade(trade)).resolves.toBe(false)
+      })
     })
   })
 
@@ -347,8 +364,24 @@ describe("when validating the trade to see if it's a correct estate trade", () =
       ]
     })
 
-    it('should return true', () => {
-      expect(isValidEstateTrade(trade)).toBe(true)
+    describe('and the fingerprint is equal than the one in the contract', () => {
+      beforeEach(() => {
+        jest.spyOn(tradeLogicUtils, 'isEstateFingerprintValid').mockResolvedValue(true)
+      })
+
+      it('should return true', () => {
+        return expect(isValidEstateTrade(trade)).resolves.toBe(true)
+      })
+    })
+
+    describe('and the fingerprint is different than the one in the contract', () => {
+      beforeEach(() => {
+        jest.spyOn(tradeLogicUtils, 'isEstateFingerprintValid').mockResolvedValue(false)
+      })
+
+      it('should return false', () => {
+        return expect(isValidEstateTrade(trade)).resolves.toBe(false)
+      })
     })
   })
 })


### PR DESCRIPTION
This PR adds the fingerprint estate check, meaning that all assets in a trade that are estates are checked to see if their fingerprint match with the one in the blockchain before being added.