### PR TITLE
feat: introduce trades endpoint to recreate MV

### DIFF
--- a/src/controllers/handlers/trades-handler.ts
+++ b/src/controllers/handlers/trades-handler.ts
@@ -203,3 +203,31 @@ export async function getTradeAcceptedEventHandler(
     }
   }
 }
+
+export async function recreateTradesMaterializedViewHandler(
+  context: Pick<HandlerContextWithPath<'trades', '/v1/trades/materialized-view/recreate'>, 'components'>
+) {
+  try {
+    const {
+      components: { trades }
+    } = context
+
+    await trades.recreateMaterializedView()
+
+    return {
+      status: StatusCode.OK,
+      body: {
+        ok: true,
+        message: 'Materialized view recreated successfully'
+      }
+    }
+  } catch (e) {
+    return {
+      status: StatusCode.INTERNAL_SERVER_ERROR,
+      body: {
+        ok: false,
+        message: isErrorWithMessage(e) ? e.message : 'Could not recreate materialized view'
+      }
+    }
+  }
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -1,5 +1,6 @@
 import { Router } from '@well-known-components/http-server'
 import * as authorizationMiddleware from 'decentraland-crypto-middleware'
+import { createTradesViewAuthMiddleware } from '../logic/http/auth'
 import { TradeCreationSchema } from '../ports/trades/schemas'
 import { GlobalContext } from '../types'
 import { createBalanceHandler } from './handlers/balance-handler'
@@ -15,7 +16,13 @@ import { getPricesHandler } from './handlers/prices-handler'
 import { getRankingsHandler } from './handlers/rankings-handler'
 import { getSalesHandler } from './handlers/sales-handler'
 import { getStatsHandler } from './handlers/stats-handler'
-import { addTradeHandler, getTradeAcceptedEventHandler, getTradeHandler, getTradesHandler } from './handlers/trades-handler'
+import {
+  addTradeHandler,
+  getTradeAcceptedEventHandler,
+  getTradeHandler,
+  getTradesHandler,
+  recreateTradesMaterializedViewHandler
+} from './handlers/trades-handler'
 import { createTransakHandler } from './handlers/transak-handler'
 import { getTrendingsHandler } from './handlers/trending-handler'
 import { getVolumeHandler } from './handlers/volume-handler'
@@ -112,6 +119,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   router.get('/v1/stats/:category/:stat', getStatsHandler)
   router.get('/v1/rankings/:entity/:timeframe', getRankingsHandler)
   router.get('/v1/volume/:timeframe', getVolumeHandler)
+  router.post('/v1/trades/materialized-view/recreate', createTradesViewAuthMiddleware(), recreateTradesMaterializedViewHandler)
 
   setupFavoritesRouter(router, { components })
 

--- a/src/logic/http/auth.ts
+++ b/src/logic/http/auth.ts
@@ -6,7 +6,7 @@ export async function validateApiToken(
   apiTokenHeaderName = 'x-api-token'
 ): Promise<boolean> {
   const { config } = context.components
-  const expectedApiToken = await config.getString('TRADES_API_TOKEN')
+  const expectedApiToken = await config.getString('MARKETPLACE_SERVER_TRADES_API_TOKEN')
 
   if (!expectedApiToken) {
     return false

--- a/src/logic/http/auth.ts
+++ b/src/logic/http/auth.ts
@@ -18,13 +18,14 @@ export async function validateApiToken(
 
 export function createTradesViewAuthMiddleware(apiTokenHeaderName = 'x-api-token') {
   return async function tradesViewAuthMiddleware(
-    context: Pick<HandlerContextWithPath<'config', string>, 'components' | 'request'>,
+    context: Pick<HandlerContextWithPath<'config' | 'logs', string>, 'components' | 'request'>,
     next: () => Promise<IHttpServerComponent.IResponse>
   ) {
     const isValid = await validateApiToken(context, apiTokenHeaderName)
+    const { logs } = context.components
 
     if (!isValid) {
-      console.log('[tradesViewAuthMiddleware] Invalid token, returning unauthorized')
+      logs.getLogger('tradesViewAuthMiddleware').error('[tradesViewAuthMiddleware] Invalid token, returning unauthorized')
       return {
         status: StatusCode.UNAUTHORIZED,
         body: {

--- a/src/logic/http/auth.ts
+++ b/src/logic/http/auth.ts
@@ -1,0 +1,39 @@
+import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { HandlerContextWithPath, StatusCode } from '../../types'
+
+export async function validateApiToken(
+  context: Pick<HandlerContextWithPath<'config', string>, 'components' | 'request'>,
+  apiTokenHeaderName = 'x-api-token'
+): Promise<boolean> {
+  const { config } = context.components
+  const expectedApiToken = await config.getString('TRADES_API_TOKEN')
+
+  if (!expectedApiToken) {
+    return false
+  }
+
+  const providedApiToken = context.request.headers.get(apiTokenHeaderName)
+  return providedApiToken === expectedApiToken
+}
+
+export function createTradesViewAuthMiddleware(apiTokenHeaderName = 'x-api-token') {
+  return async function tradesViewAuthMiddleware(
+    context: Pick<HandlerContextWithPath<'config', string>, 'components' | 'request'>,
+    next: () => Promise<IHttpServerComponent.IResponse>
+  ) {
+    const isValid = await validateApiToken(context, apiTokenHeaderName)
+
+    if (!isValid) {
+      console.log('[tradesViewAuthMiddleware] Invalid token, returning unauthorized')
+      return {
+        status: StatusCode.UNAUTHORIZED,
+        body: {
+          ok: false,
+          message: 'Unauthorized'
+        }
+      }
+    }
+
+    return next()
+  }
+}

--- a/src/logic/trades/materialized-view.ts
+++ b/src/logic/trades/materialized-view.ts
@@ -1,0 +1,222 @@
+import { IPgComponent } from '@well-known-components/pg-component'
+import { ContractName, getContract } from 'decentraland-transactions'
+import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
+import { getEthereumChainId, getPolygonChainId } from '../chainIds'
+
+export const TRADES_MV_NAME = 'mv_trades'
+
+export async function recreateTradesMaterializedView(db: IPgComponent) {
+  const marketplacePolygon = getContract(ContractName.OffChainMarketplace, getPolygonChainId())
+  const marketplaceEthereum = getContract(ContractName.OffChainMarketplace, getEthereumChainId())
+
+  // Start transaction
+  const client = await db.getPool().connect()
+  try {
+    await client.query('BEGIN')
+
+    // Drop triggers
+    await client.query('DROP TRIGGER IF EXISTS refresh_trades_mv_on_trades ON marketplace.trades')
+    await client.query(`DROP TRIGGER IF EXISTS refresh_trades_mv_on_nft ON ${MARKETPLACE_SQUID_SCHEMA}.nft`)
+    await client.query(`DROP TRIGGER IF EXISTS refresh_trades_mv_on_item ON ${MARKETPLACE_SQUID_SCHEMA}.item`)
+    await client.query('DROP TRIGGER IF EXISTS refresh_trades_mv_on_squid_trades_trade ON squid_trades.trade')
+    await client.query('DROP TRIGGER IF EXISTS refresh_trades_mv_on_signature_index ON squid_trades.signature_index')
+
+    // Drop materialized view
+    await client.query(`DROP MATERIALIZED VIEW IF EXISTS marketplace.${TRADES_MV_NAME}`)
+
+    // Drop function
+    await client.query('DROP FUNCTION IF EXISTS refresh_trades_mv()')
+
+    // Create materialized view
+    await client.query(`
+      CREATE MATERIALIZED VIEW marketplace.${TRADES_MV_NAME} AS
+      WITH trades_owner_ok AS (
+          SELECT t.id
+          FROM marketplace.trades t
+          JOIN marketplace.trade_assets ta ON t.id = ta.trade_id
+          LEFT JOIN marketplace.trade_assets_erc721 erc721_asset ON ta.id = erc721_asset.asset_id
+          LEFT JOIN ${MARKETPLACE_SQUID_SCHEMA}.nft nft
+          ON  ta.contract_address = nft.contract_address
+          AND ta.direction = 'sent'
+          AND nft.token_id = erc721_asset.token_id::numeric
+          WHERE t.type IN ('public_item_order', 'public_nft_order')
+          GROUP BY t.id
+          HAVING bool_and(ta.direction != 'sent' OR nft.owner_address = t.signer)
+      )
+      SELECT
+          t.id,
+          t.created_at,
+          t.type,
+          t.signer,
+          MAX(CASE WHEN av.direction = 'sent'     THEN av.contract_address END) AS contract_address_sent,
+          MAX(CASE WHEN av.direction = 'received' THEN av.amount END)          AS amount_received,
+          MAX(CASE WHEN av.direction = 'sent'     THEN av.available END)       AS available,
+          json_object_agg(
+              av.direction,
+              json_build_object(
+                  'contract_address', av.contract_address,
+                  'direction',        av.direction,
+                  'beneficiary',      av.beneficiary,
+                  'extra',            av.extra,
+                  'token_id',         av.token_id,
+                  'item_id',          av.item_id,
+                  'amount',           av.amount,
+                  'creator',          av.creator,
+                  'owner',            av.nft_owner,
+                  'category',         av.category,
+                  'nft_id',           av.nft_id,
+                  'issued_id',        av.issued_id,
+                  'nft_name',         av.nft_name
+              )
+          ) AS assets,
+
+          MAX(av.contract_address) FILTER (WHERE av.direction = 'sent') AS sent_contract_address,
+          MAX(av.token_id)         FILTER (WHERE av.direction = 'sent') AS sent_token_id,
+          MAX(av.category)         FILTER (WHERE av.direction = 'sent') AS sent_nft_category,
+
+          CASE
+              WHEN COUNT(CASE WHEN st.action = 'cancelled' THEN 1 END) > 0             THEN 'cancelled'
+              WHEN t.expires_at < now()::timestamptz(3)                                THEN 'cancelled'
+              WHEN (
+                  (si_signer.index IS NOT NULL
+                      AND si_signer.index != (t.checks ->> 'signerSignatureIndex')::int)
+                  OR (si_signer.index IS NULL
+                      AND (t.checks ->> 'signerSignatureIndex')::int != 0)
+                  )
+                                                                                      THEN 'cancelled'
+              WHEN (
+                  (si_contract.index IS NOT NULL
+                      AND si_contract.index != (t.checks ->> 'contractSignatureIndex')::int)
+                  OR (si_contract.index IS NULL
+                      AND (t.checks ->> 'contractSignatureIndex')::int != 0)
+                  )
+                                                                                      THEN 'cancelled'
+              WHEN COUNT(CASE WHEN st.action = 'executed' THEN 1 END)
+                  >= (t.checks ->> 'uses')::int                                       THEN 'sold'
+              ELSE 'open'
+          END AS status
+
+      FROM marketplace.trades      AS t
+      JOIN trades_owner_ok         AS ok
+      ON t.id = ok.id
+
+      JOIN (
+          SELECT
+              ta.id,
+              ta.trade_id,
+              ta.contract_address,
+              ta.direction,
+              ta.beneficiary,
+              ta.extra,
+              erc721_asset.token_id,
+              erc20_asset.amount,
+              item.creator,
+              item.available,
+              nft.owner_address      AS nft_owner,
+              nft.category,
+              nft.id                AS nft_id,
+              nft.issued_id         AS issued_id,
+              nft.name             AS nft_name,
+              coalesce(nft.item_blockchain_id::text, item_asset.item_id) AS item_id
+          FROM marketplace.trade_assets AS ta
+          LEFT JOIN marketplace.trade_assets_erc721 AS erc721_asset
+              ON ta.id = erc721_asset.asset_id
+          LEFT JOIN marketplace.trade_assets_erc20 AS erc20_asset
+              ON ta.id = erc20_asset.asset_id
+          LEFT JOIN marketplace.trade_assets_item AS item_asset
+              ON ta.id = item_asset.asset_id
+          LEFT JOIN ${MARKETPLACE_SQUID_SCHEMA}.item AS item
+              ON ta.contract_address = item.collection_id
+              AND item_asset.item_id::numeric = item.blockchain_id
+          LEFT JOIN ${MARKETPLACE_SQUID_SCHEMA}.nft AS nft
+              ON ta.contract_address = nft.contract_address
+              AND erc721_asset.token_id::numeric = nft.token_id
+      ) AS av
+      ON t.id = av.trade_id
+
+      LEFT JOIN squid_trades.trade AS st
+      ON st.signature = t.hashed_signature
+
+      LEFT JOIN squid_trades.signature_index AS si_signer
+      ON LOWER(si_signer.address) = LOWER(t.signer)
+
+      LEFT JOIN (
+          SELECT *
+          FROM squid_trades.signature_index idx
+          WHERE LOWER(idx.address) IN (
+              '${marketplacePolygon.address}',
+              '${marketplaceEthereum.address}'
+          )
+      ) AS si_contract
+      ON t.network = si_contract.network
+
+      WHERE t.type IN ('public_item_order', 'public_nft_order')
+      GROUP BY
+          t.id,
+          t.type,
+          t.created_at,
+          t.network,
+          t.chain_id,
+          t.signer,
+          t.checks,
+          si_contract.index,
+          si_signer.index;
+    `)
+
+    // Create index
+    await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_trades_id ON marketplace.${TRADES_MV_NAME} (id)`)
+
+    // Create refresh function
+    await client.query(`
+      CREATE OR REPLACE FUNCTION refresh_trades_mv()
+          RETURNS TRIGGER
+          LANGUAGE plpgsql
+          AS $$
+          BEGIN
+          REFRESH MATERIALIZED VIEW CONCURRENTLY marketplace.${TRADES_MV_NAME};
+          RETURN NULL;
+      END;
+      $$;
+    `)
+
+    // Create triggers
+    await client.query(`
+      CREATE TRIGGER refresh_trades_mv_on_trades
+      AFTER INSERT OR UPDATE OR DELETE
+      ON marketplace.trades
+      FOR EACH STATEMENT
+      EXECUTE FUNCTION refresh_trades_mv();
+
+      CREATE TRIGGER refresh_trades_mv_on_nft
+      AFTER INSERT OR UPDATE OR DELETE
+      ON ${MARKETPLACE_SQUID_SCHEMA}.nft
+      FOR EACH STATEMENT
+      EXECUTE FUNCTION refresh_trades_mv();
+
+      CREATE TRIGGER refresh_trades_mv_on_item
+      AFTER INSERT OR UPDATE OR DELETE
+      ON ${MARKETPLACE_SQUID_SCHEMA}.item
+      FOR EACH STATEMENT
+      EXECUTE FUNCTION refresh_trades_mv();
+
+      CREATE TRIGGER refresh_trades_mv_on_squid_trades_trade
+      AFTER INSERT OR UPDATE OR DELETE
+      ON squid_trades.trade
+      FOR EACH STATEMENT
+      EXECUTE FUNCTION refresh_trades_mv();
+
+      CREATE TRIGGER refresh_trades_mv_on_signature_index
+      AFTER INSERT OR UPDATE OR DELETE
+      ON squid_trades.signature_index
+      FOR EACH STATEMENT
+      EXECUTE FUNCTION refresh_trades_mv();
+    `)
+
+    await client.query('COMMIT')
+  } catch (error) {
+    await client.query('ROLLBACK')
+    throw error
+  } finally {
+    client.release()
+  }
+}

--- a/src/migrations/dapps/1718991797670_trades-and-asset-trades-table.ts
+++ b/src/migrations/dapps/1718991797670_trades-and-asset-trades-table.ts
@@ -110,6 +110,16 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       item_id: { type: 'text', notNull: true }
     }
   )
+
+  // pgm.sql('GRANT SELECT ON ALL TABLES IN SCHEMA marketplace TO mv_trades_owner;')
+  pgm.sql(`
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'mv_trades_owner') THEN
+        EXECUTE 'GRANT SELECT ON ALL TABLES IN SCHEMA marketplace TO mv_trades_owner';
+      END IF;
+    END $$;
+`)
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -2,6 +2,7 @@ import SQL from 'sql-template-strings'
 import { Event, TradeAssetDirection, TradeCreation } from '@dcl/schemas'
 import { fromDbTradeAndDBTradeAssetWithValueListToTrade } from '../../adapters/trades/trades'
 import { isErrorWithMessage } from '../../logic/errors'
+import { recreateTradesMaterializedView } from '../../logic/trades/materialized-view'
 import { validateAssetOwnership, validateTradeSignature } from '../../logic/trades/utils'
 import { AppComponents } from '../../types'
 import {
@@ -137,10 +138,15 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
     }
   }
 
+  async function recreateMaterializedView() {
+    await recreateTradesMaterializedView(pg)
+  }
+
   return {
     getTrades,
     addTrade,
     getTrade,
-    getTradeAcceptedEvent
+    getTradeAcceptedEvent,
+    recreateMaterializedView
   }
 }

--- a/src/ports/trades/types.ts
+++ b/src/ports/trades/types.ts
@@ -5,6 +5,7 @@ export type ITradesComponent = {
   addTrade(body: TradeCreation, signer: string): Promise<Trade>
   getTrade(id: string): Promise<Trade>
   getTradeAcceptedEvent(hashedSignature: string, acceptedDate: number, caller: string): Promise<Event>
+  recreateMaterializedView(): Promise<void>
 }
 
 export enum TradeEvent {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ import { IRentalsComponent } from './ports/rentals/types'
 import { ISalesComponent } from './ports/sales'
 import { ISchemaValidatorComponent } from './ports/schema-validator'
 import { IStatsComponent } from './ports/stats/types'
-import { ITradesComponent } from './ports/trades'
+import { ITradesComponent } from './ports/trades/types'
 import { ITransakComponent } from './ports/transak/types'
 import { ITrendingsComponent } from './ports/trendings/types'
 import { IVolumeComponent } from './ports/volume/types'
@@ -109,7 +109,8 @@ export enum StatusCode {
   LOCKED = 423,
   CONFLICT = 409,
   ERROR = 500,
-  UNPROCESSABLE_CONTENT = 422
+  UNPROCESSABLE_CONTENT = 422,
+  INTERNAL_SERVER_ERROR = 500
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/db/init-marketplace-schema.sh
+++ b/test/db/init-marketplace-schema.sh
@@ -12,6 +12,11 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     GRANT ALL PRIVILEGES ON SCHEMA squid_marketplace TO testuser;
     GRANT ALL PRIVILEGES ON SCHEMA squid_trades TO testuser;
 
+    CREATE ROLE mv_trades_owner NOLOGIN;
+    GRANT mv_trades_owner TO dapps_marketplace_user;
+    GRANT USAGE ON SCHEMA marketplace TO mv_trades_owner;
+    GRANT CREATE ON SCHEMA marketplace TO mv_trades_owner;
+
     -- SET UP EXTENSIONS
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
     CREATE EXTENSION IF NOT EXISTS "postgres_fdw";

--- a/test/db/init-marketplace-schema.sh
+++ b/test/db/init-marketplace-schema.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL    
-    -- CREATE THE ROLE AND ASSIGN IT TO THE PREVIOUSLY CREATED DB
-    CREATE ROLE testuser WITH LOGIN PASSWORD 'testpassword';
-
-
-    SET ROLE testuser;
-    CREATE SCHEMA marketplace;
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+	CREATE SCHEMA marketplace;
     CREATE SCHEMA squid_marketplace;
     CREATE SCHEMA squid_trades;
 
     CREATE ROLE mv_trades_owner NOLOGIN;
-    GRANT mv_trades_owner TO testuser;
     GRANT USAGE ON SCHEMA marketplace TO mv_trades_owner;
     GRANT CREATE ON SCHEMA marketplace TO mv_trades_owner;
     GRANT SELECT ON ALL TABLES IN SCHEMA marketplace TO mv_trades_owner;

--- a/test/db/init-marketplace-schema.sh
+++ b/test/db/init-marketplace-schema.sh
@@ -16,6 +16,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     GRANT mv_trades_owner TO testuser;
     GRANT USAGE ON SCHEMA marketplace TO mv_trades_owner;
     GRANT CREATE ON SCHEMA marketplace TO mv_trades_owner;
+    GRANT SELECT ON ALL TABLES IN SCHEMA marketplace TO mv_trades_owner;
 
     -- SET UP EXTENSIONS
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/test/db/init-marketplace-schema.sh
+++ b/test/db/init-marketplace-schema.sh
@@ -17,6 +17,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     GRANT USAGE ON SCHEMA marketplace TO mv_trades_owner;
     GRANT CREATE ON SCHEMA marketplace TO mv_trades_owner;
     GRANT SELECT ON ALL TABLES IN SCHEMA marketplace TO mv_trades_owner;
+    GRANT ALL PRIVILEGES ON SCHEMA squid_marketplace TO mv_trades_owner;
 
     -- SET UP EXTENSIONS
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/test/db/init-marketplace-schema.sh
+++ b/test/db/init-marketplace-schema.sh
@@ -13,7 +13,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     GRANT ALL PRIVILEGES ON SCHEMA squid_trades TO testuser;
 
     CREATE ROLE mv_trades_owner NOLOGIN;
-    GRANT mv_trades_owner TO dapps_marketplace_user;
+    GRANT mv_trades_owner TO testuser;
     GRANT USAGE ON SCHEMA marketplace TO mv_trades_owner;
     GRANT CREATE ON SCHEMA marketplace TO mv_trades_owner;
 

--- a/test/db/init-marketplace-schema.sh
+++ b/test/db/init-marketplace-schema.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-	CREATE SCHEMA marketplace;
-    CREATE SCHEMA squid_marketplace;
-    CREATE SCHEMA squid_trades;
-    
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL    
     -- CREATE THE ROLE AND ASSIGN IT TO THE PREVIOUSLY CREATED DB
     CREATE ROLE testuser WITH LOGIN PASSWORD 'testpassword';
-    GRANT ALL PRIVILEGES ON SCHEMA marketplace TO testuser;
-    GRANT ALL PRIVILEGES ON SCHEMA squid_marketplace TO testuser;
-    GRANT ALL PRIVILEGES ON SCHEMA squid_trades TO testuser;
+
+
+    SET ROLE testuser;
+    CREATE SCHEMA marketplace;
+    CREATE SCHEMA squid_marketplace;
+    CREATE SCHEMA squid_trades;
 
     CREATE ROLE mv_trades_owner NOLOGIN;
     GRANT mv_trades_owner TO testuser;


### PR DESCRIPTION
# Add Endpoint to Recreate Trades Materialized View

## Overview
This PR adds a new protected endpoint that allows administrators to manually trigger the recreation of the trades materialized view. This provides an on-demand way to refresh the view without requiring a database migration or server restart.

## Changes
- Added a new endpoint: `POST /v1/trades/materialized-view/recreate`
- Implemented API token authentication to protect the endpoint
- Created a dedicated middleware for trades view authentication
- Added unit tests for the new handler

## Technical Details
- The endpoint is protected by an API token that must be provided in the `x-api-token` header
- The token value is configured via the `TRADES_API_TOKEN` environment variable
- All operations are executed within a transaction to ensure data consistency
- The endpoint returns appropriate status codes:
  - 200 OK when the view is successfully recreated
  - 401 Unauthorized when the API token is invalid
  - 500 Internal Server Error when an error occurs during recreation

## Why
The trades materialized view occasionally needs to be refreshed to ensure data consistency, especially after a squid promotion. Previously, this required a migration or manual database operation. This endpoint provides a safer, more controlled way to perform this operation through the API.

## Testing
- Unit tests verify both successful recreation and error handling
- The endpoint has been manually tested in development environment