### PR TITLE
feat: use trades cte instead of querying all trades in orders query

### DIFF
--- a/src/logic/trades/materialized-view.ts
+++ b/src/logic/trades/materialized-view.ts
@@ -104,6 +104,9 @@ export async function recreateTradesMaterializedView(db: IPgComponent) {
           MAX(av.token_id)         FILTER (WHERE av.direction = 'sent') AS sent_token_id,
           MAX(av.category)         FILTER (WHERE av.direction = 'sent') AS sent_nft_category,
           MAX(av.item_id)          FILTER (WHERE av.direction = 'sent') AS sent_item_id,
+          MAX(av.nft_id)           FILTER (WHERE av.direction = 'sent') AS sent_nft_id,
+          t.network,
+          t.expires_at,
           CASE
               WHEN COUNT(CASE WHEN st.action = 'cancelled' THEN 1 END) > 0             THEN 'cancelled'
               WHEN t.expires_at < now()::timestamptz(3)                                THEN 'cancelled'

--- a/src/ports/orders/queries.ts
+++ b/src/ports/orders/queries.ts
@@ -1,10 +1,10 @@
 import SQL, { SQLStatement } from 'sql-template-strings'
-import { OrderFilters, OrderSortBy, TradeType } from '@dcl/schemas'
+import { OrderFilters, OrderSortBy } from '@dcl/schemas'
 import { ContractName, getContract } from 'decentraland-transactions'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getEthereumChainId, getPolygonChainId } from '../../logic/chainIds'
 import { getDBNetworks } from '../../utils'
-import { getTradesForTypeQueryWithFilters } from '../trades/queries'
+import { getTradesCTE } from '../catalog/queries'
 import { getWhereStatementFromFilters } from '../utils'
 
 function getOrdersSortByStatement(filters: OrderFilters): SQLStatement {
@@ -63,11 +63,11 @@ export function getTradesOrdersQuery(filters: OrderFilters & { nftIds?: string[]
     .append(
       SQL`'
       END AS marketplace_address,
-      assets -> 'sent' ->> 'category' as category,
-      assets -> 'sent' ->> 'contract_address' as nft_address,
-      (assets -> 'sent' ->> 'token_id')::numeric(78) as token_id,
-      (assets -> 'received' ->> 'amount')::numeric(78) as price,
-      assets -> 'sent' ->> 'item_id' as item_id,
+      sent_nft_category as category,
+      contract_address_sent as nft_address,
+      (sent_token_id)::numeric(78) as token_id,
+      (amount_received)::numeric(78) as price,
+      sent_item_id as item_id,
       (assets -> 'sent' ->> 'issued_id')::numeric(78) as issued_id,
       assets -> 'sent' ->> 'nft_id' as nft_id,
       assets -> 'sent' ->> 'nft_name' as nft_name,
@@ -81,7 +81,10 @@ export function getTradesOrdersQuery(filters: OrderFilters & { nftIds?: string[]
       EXTRACT(EPOCH FROM expires_at) as expires_at,
       network
     FROM (`
-        .append(getTradesForTypeQueryWithFilters(TradeType.PUBLIC_NFT_ORDER, { owner: filters.owner, ids: filters.nftIds }))
+        .append(SQL`SELECT * FROM unified_trades WHERE type = 'public_nft_order' AND status = 'open'`)
+        .append(filters.nftIds ? SQL` AND sent_nft_id = ANY(${filters.nftIds})` : SQL``)
+        .append(filters.owner ? SQL` AND signer = ${filters.owner.toLowerCase()}` : SQL``)
+        // .append(getTradesForTypeQueryWithFilters(TradeType.PUBLIC_NFT_ORDER, { owner: filters.owner, ids: filters.nftIds }))
         .append(SQL`) as trades WHERE signer = assets -> 'sent' ->> 'owner'`)
     )
 }
@@ -181,33 +184,37 @@ export function getOrderAndTradeQueries(filters: OrderFilters & { nftIds?: strin
 export function getOrdersQuery(filters: OrderFilters & { nftIds?: string[] }, prefix = 'combined_orders'): SQLStatement {
   const { orderTradesQuery, legacyOrdersQuery } = getOrderAndTradeQueries(filters)
 
-  return SQL`
+  const { first, skip } = filters
+  return getTradesCTE({ first, skip }).append(
+    SQL`
     SELECT `
-    .append(prefix)
-    .append(
-      SQL`.* FROM (
+      .append(prefix)
+      .append(
+        SQL`.* FROM (
       (`
-        .append(orderTradesQuery)
-        .append(
-          SQL`)
+          .append(orderTradesQuery)
+          .append(
+            SQL`)
       UNION ALL
       (`
-            .append(legacyOrdersQuery)
-            .append(
-              SQL`)
+              .append(legacyOrdersQuery)
+              .append(
+                SQL`)
     ) as `
-            )
-            .append(prefix)
-            .append(getOrdersSortByStatement(filters).append(getOrdersLimitAndOffsetStatement(filters)))
-        )
-    )
+              )
+              .append(prefix)
+              .append(getOrdersSortByStatement(filters).append(getOrdersLimitAndOffsetStatement(filters)))
+          )
+      )
+  )
 }
 
 export function getOrdersCountQuery(filters: OrderFilters & { nftIds?: string[] }): SQLStatement {
   const { orders: ordersFilters, trades: tradesFilters } = getOrdersAndTradesFilters(filters)
 
-  return SQL`
-    WITH aggregated_counts AS (
+  return getTradesCTE({ first: filters.first, skip: filters.skip }).append(
+    SQL`
+    ,aggregated_counts AS (
       SELECT 
         SUM(COALESCE(trades_count, 0)) AS total_trades,
         SUM(COALESCE(orders_count, 0)) AS total_orders
@@ -220,14 +227,14 @@ export function getOrdersCountQuery(filters: OrderFilters & { nftIds?: string[] 
                  COUNT(*) OVER() AS trades_count
           FROM (
             `
-    .append(getTradesOrdersQuery(filters))
-    .append(
-      SQL`
+      .append(getTradesOrdersQuery(filters))
+      .append(
+        SQL`
           ) AS trades_filtered
           `
-        .append(getWhereStatementFromFilters(tradesFilters))
-        .append(
-          SQL`
+          .append(getWhereStatementFromFilters(tradesFilters))
+          .append(
+            SQL`
         ) AS trades_final
         
         UNION ALL
@@ -238,9 +245,9 @@ export function getOrdersCountQuery(filters: OrderFilters & { nftIds?: string[] 
         FROM (
           SELECT id
           FROM `
-            .append(MARKETPLACE_SQUID_SCHEMA)
-            .append(
-              SQL`."order" as ord
+              .append(MARKETPLACE_SQUID_SCHEMA)
+              .append(
+                SQL`."order" as ord
           `.append(getWhereStatementFromFilters(ordersFilters)).append(SQL`
         ) AS orders_filtered
       ) AS counts_combined
@@ -252,7 +259,8 @@ export function getOrdersCountQuery(filters: OrderFilters & { nftIds?: string[] 
       FROM   aggregated_counts
     ) AS combined_counts
   `)
-            )
-        )
-    )
+              )
+          )
+      )
+  )
 }

--- a/src/ports/orders/queries.ts
+++ b/src/ports/orders/queries.ts
@@ -84,7 +84,6 @@ export function getTradesOrdersQuery(filters: OrderFilters & { nftIds?: string[]
         .append(SQL`SELECT * FROM unified_trades WHERE type = 'public_nft_order' AND status = 'open'`)
         .append(filters.nftIds ? SQL` AND sent_nft_id = ANY(${filters.nftIds})` : SQL``)
         .append(filters.owner ? SQL` AND signer = ${filters.owner.toLowerCase()}` : SQL``)
-        // .append(getTradesForTypeQueryWithFilters(TradeType.PUBLIC_NFT_ORDER, { owner: filters.owner, ids: filters.nftIds }))
         .append(SQL`) as trades WHERE signer = assets -> 'sent' ->> 'owner'`)
     )
 }


### PR DESCRIPTION
This PR allows the orders query to use the trades MV instead of having to craft the trades on each query to increase the performance when calling them. 
It also adds some extra fields to the view to provide the fields and allow using the filters that the order query needs.