### PR TITLE
feat: add /owners endpoint

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -22,6 +22,7 @@ import { createItemsComponent } from './ports/items'
 import { createJobComponent } from './ports/job'
 import { createNFTsComponent } from './ports/nfts/component'
 import { createOrdersComponent } from './ports/orders/component'
+import { createOwnersComponent } from './ports/owners/component'
 import { createPricesComponents } from './ports/prices'
 import { createRankingsComponent } from './ports/rankings/component'
 import { createRentalsComponent } from './ports/rentals/components'
@@ -115,6 +116,7 @@ export async function initComponents(): Promise<AppComponents> {
   const bids = await createBidsComponents({ dappsDatabase: dappsReadDatabase })
   const nfts = await createNFTsComponent({ dappsDatabase: dappsReadDatabase, config, rentals })
   const orders = await createOrdersComponent({ dappsDatabase: dappsReadDatabase })
+  const owners = createOwnersComponent({ dappsDatabase: dappsReadDatabase })
   const sales = await createSalesComponents({ dappsDatabase: dappsReadDatabase })
   const prices = await createPricesComponents({ dappsDatabase: dappsReadDatabase })
   const trendings = await createTrendingsComponent({ dappsDatabase: dappsReadDatabase, items, picks })
@@ -161,6 +163,7 @@ export async function initComponents(): Promise<AppComponents> {
     eventPublisher,
     nfts,
     orders,
+    owners,
     rentals,
     sales,
     prices,

--- a/src/components.ts
+++ b/src/components.ts
@@ -116,7 +116,7 @@ export async function initComponents(): Promise<AppComponents> {
   const bids = await createBidsComponents({ dappsDatabase: dappsReadDatabase })
   const nfts = await createNFTsComponent({ dappsDatabase: dappsReadDatabase, config, rentals })
   const orders = await createOrdersComponent({ dappsDatabase: dappsReadDatabase })
-  const owners = createOwnersComponent({ dappsDatabase: dappsReadDatabase })
+  const owners = createOwnersComponent({ dappsDatabase: dappsReadDatabase, logs })
   const sales = await createSalesComponents({ dappsDatabase: dappsReadDatabase })
   const prices = await createPricesComponents({ dappsDatabase: dappsReadDatabase })
   const trendings = await createTrendingsComponent({ dappsDatabase: dappsReadDatabase, items, picks })

--- a/src/controllers/handlers/owners-handler.ts
+++ b/src/controllers/handlers/owners-handler.ts
@@ -1,0 +1,46 @@
+import { isErrorWithMessage } from '../../logic/errors'
+import { Params } from '../../logic/http/params'
+import { OwnersSortBy } from '../../ports/owners/types'
+import { HandlerContextWithPath, StatusCode } from '../../types'
+
+export async function getOwnersHandler(context: Pick<HandlerContextWithPath<'owners', '/v1/owners'>, 'components' | 'url'>) {
+  try {
+    const {
+      components: { owners }
+    } = context
+
+    const params = new Params(context.url.searchParams)
+
+    const contractAddress = params.getString('contractAddress')
+    const itemId = params.getString('itemId')
+    const sortBy = params.getValue<OwnersSortBy>('sortBy', OwnersSortBy) || OwnersSortBy.ISSUED_ID
+    const orderDirection = params.getString('orderDirection') || 'desc'
+    const first = params.getNumber('first')
+    const skip = params.getNumber('skip')
+
+    const { data, total } = await owners.fetchAndCount({
+      contractAddress,
+      itemId,
+      orderDirection,
+      sortBy,
+      first,
+      skip
+    })
+
+    return {
+      status: StatusCode.OK,
+      body: {
+        data,
+        total
+      }
+    }
+  } catch (e) {
+    return {
+      status: StatusCode.BAD_REQUEST,
+      body: {
+        ok: false,
+        message: isErrorWithMessage(e) ? e.message : 'Could not fetch owners'
+      }
+    }
+  }
+}

--- a/src/controllers/handlers/owners-handler.ts
+++ b/src/controllers/handlers/owners-handler.ts
@@ -18,6 +18,16 @@ export async function getOwnersHandler(context: Pick<HandlerContextWithPath<'own
     const first = params.getNumber('first')
     const skip = params.getNumber('skip')
 
+    if (!contractAddress || !itemId) {
+      return {
+        status: StatusCode.BAD_REQUEST,
+        body: {
+          ok: false,
+          message: 'contractAddress and itemId are necessary params.'
+        }
+      }
+    }
+
     const { data, total } = await owners.fetchAndCount({
       contractAddress,
       itemId,

--- a/src/controllers/handlers/owners-handler.ts
+++ b/src/controllers/handlers/owners-handler.ts
@@ -23,7 +23,7 @@ export async function getOwnersHandler(context: Pick<HandlerContextWithPath<'own
         status: StatusCode.BAD_REQUEST,
         body: {
           ok: false,
-          message: 'contractAddress and itemId are necessary params.'
+          message: 'itemId and contractAddress are necessary params.'
         }
       }
     }

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -10,6 +10,7 @@ import { setupFavoritesRouter } from './handlers/favorites/routes'
 import { getItemsHandler } from './handlers/items-handler'
 import { getNFTsHandler } from './handlers/nfts-handler'
 import { getOrdersHandler } from './handlers/orders-handler'
+import { getOwnersHandler } from './handlers/owners-handler'
 import { pingHandler } from './handlers/ping-handler'
 import { getPricesHandler } from './handlers/prices-handler'
 import { getRankingsHandler } from './handlers/rankings-handler'
@@ -100,6 +101,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   )
 
   router.get('/v1/orders', getOrdersHandler)
+  router.get('/v1/owners', getOwnersHandler)
 
   router.get(
     '/v1/items',

--- a/src/ports/owners/component.ts
+++ b/src/ports/owners/component.ts
@@ -1,0 +1,54 @@
+import { PoolClient } from 'pg'
+import { AppComponents } from '../../types'
+import { getOwnersQuery } from './queries'
+import { IOwnersComponent, OwnerCountDBRow, OwnerDBRow, OwnersFilters, OwnersSortBy } from './types'
+
+export const BAD_REQUEST_ERROR_MESSAGE = "Couldn't fetch owners with the filters provided"
+
+export function createOwnersComponent(options: { dappsDatabase: Pick<AppComponents, 'dappsDatabase'>['dappsDatabase'] }): IOwnersComponent {
+  const { dappsDatabase } = options
+
+  async function fetchAndCount(
+    filters: OwnersFilters & {
+      sortBy?: OwnersSortBy
+      first?: number
+      skip?: number
+    }
+  ) {
+    if (filters.itemId === undefined || !filters.contractAddress) {
+      throw new Error('itemId and contractAddress are necessary params.')
+    }
+
+    let client: PoolClient | undefined = undefined
+    try {
+      client = await dappsDatabase.getPool().connect()
+
+      const ownersQuery = getOwnersQuery(filters)
+      const ownersCountQuery = getOwnersQuery(filters, true)
+
+      const [owners, ownersCount] = await Promise.all([
+        client.query<OwnerDBRow>(ownersQuery),
+        client.query<OwnerCountDBRow>(ownersCountQuery)
+      ])
+
+      const results = owners.rows.map((owner: OwnerDBRow) => ({
+        issuedId: owner.issued_id,
+        ownerId: owner.owner,
+        tokenId: owner.token_id
+      }))
+
+      return {
+        data: results,
+        total: Number(ownersCount.rows[0].count)
+      }
+    } catch (e) {
+      throw new Error(BAD_REQUEST_ERROR_MESSAGE)
+    } finally {
+      client?.release()
+    }
+  }
+
+  return {
+    fetchAndCount
+  }
+}

--- a/src/ports/owners/component.ts
+++ b/src/ports/owners/component.ts
@@ -1,12 +1,17 @@
 import { PoolClient } from 'pg'
+import { isErrorWithMessage } from '../../logic/errors'
 import { AppComponents } from '../../types'
 import { getOwnersQuery } from './queries'
 import { IOwnersComponent, OwnerCountDBRow, OwnerDBRow, OwnersFilters, OwnersSortBy } from './types'
 
 export const BAD_REQUEST_ERROR_MESSAGE = "Couldn't fetch owners with the filters provided"
 
-export function createOwnersComponent(options: { dappsDatabase: Pick<AppComponents, 'dappsDatabase'>['dappsDatabase'] }): IOwnersComponent {
-  const { dappsDatabase } = options
+export function createOwnersComponent(options: {
+  dappsDatabase: Pick<AppComponents, 'dappsDatabase'>['dappsDatabase']
+  logs: Pick<AppComponents, 'logs'>['logs']
+}): IOwnersComponent {
+  const { dappsDatabase, logs } = options
+  const logger = logs.getLogger('Owners component')
 
   async function fetchAndCount(
     filters: OwnersFilters & {
@@ -42,6 +47,7 @@ export function createOwnersComponent(options: { dappsDatabase: Pick<AppComponen
         total: Number(ownersCount.rows[0].count)
       }
     } catch (e) {
+      logger.error(`Couldn't fetch owners with the filters provided: ${isErrorWithMessage(e) ? e.message : 'Unknown'}`)
       throw new Error(BAD_REQUEST_ERROR_MESSAGE)
     } finally {
       client?.release()

--- a/src/ports/owners/component.ts
+++ b/src/ports/owners/component.ts
@@ -20,10 +20,6 @@ export function createOwnersComponent(options: {
       skip?: number
     }
   ) {
-    if (filters.itemId === undefined || !filters.contractAddress) {
-      throw new Error('itemId and contractAddress are necessary params.')
-    }
-
     let client: PoolClient | undefined = undefined
     try {
       client = await dappsDatabase.getPool().connect()

--- a/src/ports/owners/queries.ts
+++ b/src/ports/owners/queries.ts
@@ -19,12 +19,12 @@ export const getOwnersQuery = (
 
   const query = SQL`SELECT `
     .append(fields)
-    .append(` FROM `)
+    .append(' FROM ')
     .append(MARKETPLACE_SQUID_SCHEMA)
-    .append(`.nft AS nft`)
-    .append(` LEFT JOIN `)
+    .append('.nft AS nft')
+    .append(' LEFT JOIN ')
     .append(MARKETPLACE_SQUID_SCHEMA)
-    .append(`.account AS account ON nft.owner_id = account.id`)
+    .append('.account AS account ON nft.owner_id = account.id')
 
   const where = [
     contractAddress ? SQL`nft.contract_address = ${contractAddress}` : undefined,
@@ -32,12 +32,12 @@ export const getOwnersQuery = (
   ].filter(Boolean)
 
   if (where.length) {
-    query.append(` WHERE `)
+    query.append(' WHERE ')
     where.forEach((whereClause, index) => {
       if (whereClause) {
         query.append(whereClause)
         if (index < where.length - 1) {
-          query.append(` AND `)
+          query.append(' AND ')
         }
       }
     })

--- a/src/ports/owners/queries.ts
+++ b/src/ports/owners/queries.ts
@@ -1,0 +1,63 @@
+import SQL from 'sql-template-strings'
+import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
+import { OwnersFilters, OwnersSortBy } from './types'
+
+export const OWNERS_QUERY_DEFAULT_OFFSET = 0
+export const OWNERS_QUERY_DEFAULT_LIMIT = 20
+
+export const getOwnersQuery = (
+  filters: OwnersFilters & {
+    sortBy?: OwnersSortBy
+    first?: number
+    skip?: number
+  },
+  isCount = false
+) => {
+  const { contractAddress, skip, first, sortBy, itemId } = filters
+
+  const fields = isCount ? SQL`COUNT(*)` : SQL`nft.issued_id, account.address as owner, nft.token_id`
+
+  const query = SQL`SELECT `
+    .append(fields)
+    .append(` FROM `)
+    .append(MARKETPLACE_SQUID_SCHEMA)
+    .append(`.nft AS nft`)
+    .append(` LEFT JOIN `)
+    .append(MARKETPLACE_SQUID_SCHEMA)
+    .append(`.account AS account ON nft.owner_id = account.id`)
+
+  const where = [
+    contractAddress ? SQL`nft.contract_address = ${contractAddress}` : undefined,
+    itemId ? SQL`nft.item_blockchain_id = ${itemId}` : undefined
+  ].filter(Boolean)
+
+  if (where.length) {
+    query.append(` WHERE `)
+    where.forEach((whereClause, index) => {
+      if (whereClause) {
+        query.append(whereClause)
+        if (index < where.length - 1) {
+          query.append(` AND `)
+        }
+      }
+    })
+  }
+
+  if (!isCount) {
+    if (sortBy) {
+      switch (sortBy) {
+        case OwnersSortBy.ISSUED_ID:
+          query.append(SQL` ORDER BY nft.issued_id`)
+          break
+        default:
+          break
+      }
+      query.append(filters.orderDirection === 'asc' ? SQL` ASC` : SQL` DESC`)
+    }
+    query.append(skip !== undefined ? SQL` OFFSET ${skip}` : SQL` OFFSET ${OWNERS_QUERY_DEFAULT_OFFSET}`)
+
+    query.append(first !== undefined ? SQL` LIMIT ${first}` : SQL` LIMIT ${OWNERS_QUERY_DEFAULT_LIMIT}`)
+  }
+
+  return query
+}

--- a/src/ports/owners/types.ts
+++ b/src/ports/owners/types.ts
@@ -5,9 +5,9 @@ export type Owner = {
 }
 
 export type OwnersFilters = {
-  contractAddress?: string
+  contractAddress: string
+  itemId: string
   first?: number
-  itemId?: string
   skip?: number
   orderDirection?: string
 }

--- a/src/ports/owners/types.ts
+++ b/src/ports/owners/types.ts
@@ -1,0 +1,37 @@
+export type Owner = {
+  issuedId: string
+  ownerId: string
+  tokenId: string
+}
+
+export type OwnersFilters = {
+  contractAddress?: string
+  first?: number
+  itemId?: string
+  skip?: number
+  orderDirection?: string
+}
+
+export enum OwnersSortBy {
+  ISSUED_ID = 'issuedId'
+}
+
+export type OwnerDBRow = {
+  issued_id: string
+  owner: string
+  token_id: string
+}
+
+export type OwnerCountDBRow = {
+  count: string
+}
+
+export interface IOwnersComponent {
+  fetchAndCount(
+    filters: OwnersFilters & {
+      sortBy?: OwnersSortBy
+      first?: number
+      skip?: number
+    }
+  ): Promise<{ data: Owner[]; total: number }>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ import { IItemsComponent } from './ports/items'
 import { IJobComponent } from './ports/job'
 import { INFTsComponent } from './ports/nfts/types'
 import { IOrdersComponent } from './ports/orders/types'
+import { IOwnersComponent } from './ports/owners/types'
 import { IPricesComponent } from './ports/prices'
 import { IItemsDayDataComponent } from './ports/rankings/types'
 import { IRentalsComponent } from './ports/rentals/types'
@@ -66,6 +67,7 @@ export type BaseComponents = {
   eventPublisher: IEventPublisherComponent
   nfts: INFTsComponent
   orders: IOrdersComponent
+  owners: IOwnersComponent
   rentals: IRentalsComponent
   sales: ISalesComponent
   trendings: ITrendingsComponent

--- a/test/components.ts
+++ b/test/components.ts
@@ -25,6 +25,7 @@ import { IItemsComponent, createItemsComponent } from '../src/ports/items'
 import { createJobComponent } from '../src/ports/job'
 import { createNFTsComponent } from '../src/ports/nfts/component'
 import { createOrdersComponent } from '../src/ports/orders/component'
+import { createOwnersComponent } from '../src/ports/owners/component'
 import { createPricesComponents } from '../src/ports/prices'
 import { createRankingsComponent } from '../src/ports/rankings/component'
 import { createRentalsComponent } from '../src/ports/rentals/components'
@@ -119,6 +120,7 @@ async function initComponents(): Promise<TestComponents> {
 
   const nfts = createNFTsComponent({ dappsDatabase: dappsReadDatabase, config, rentals })
   const orders = createOrdersComponent({ dappsDatabase: dappsReadDatabase })
+  const owners = createOwnersComponent({ dappsDatabase: dappsReadDatabase })
   const sales = createSalesComponents({ dappsDatabase: dappsReadDatabase })
   const prices = createPricesComponents({ dappsDatabase: dappsReadDatabase })
   // Mock the start function to avoid connecting to a local database
@@ -160,6 +162,7 @@ async function initComponents(): Promise<TestComponents> {
     eventPublisher,
     nfts,
     orders,
+    owners,
     rentals,
     sales,
     prices,

--- a/test/components.ts
+++ b/test/components.ts
@@ -120,7 +120,7 @@ async function initComponents(): Promise<TestComponents> {
 
   const nfts = createNFTsComponent({ dappsDatabase: dappsReadDatabase, config, rentals })
   const orders = createOrdersComponent({ dappsDatabase: dappsReadDatabase })
-  const owners = createOwnersComponent({ dappsDatabase: dappsReadDatabase })
+  const owners = createOwnersComponent({ dappsDatabase: dappsReadDatabase, logs })
   const sales = createSalesComponents({ dappsDatabase: dappsReadDatabase })
   const prices = createPricesComponents({ dappsDatabase: dappsReadDatabase })
   // Mock the start function to avoid connecting to a local database

--- a/test/integration/owners-controller.spec.ts
+++ b/test/integration/owners-controller.spec.ts
@@ -1,0 +1,68 @@
+import { test } from '../components'
+
+test('when getting owners', function ({ components }) {
+  const contractAddress = '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d'
+  const itemId = '0'
+
+  describe('and no owners exist for the contract and item', () => {
+    it('should respond with a 200 and an empty array of owners', async () => {
+      const { localFetch } = components
+      const response = await localFetch.fetch(`/v1/owners?contractAddress=${contractAddress}&itemId=${itemId}`)
+      const responseBody = await response.json()
+      expect(response.status).toEqual(200)
+      expect(responseBody).toEqual({ data: [], total: 0 })
+    })
+  })
+
+  describe('when missing required parameters', () => {
+    it('should respond with a 400 when contractAddress is missing', async () => {
+      const { localFetch } = components
+      const response = await localFetch.fetch(`/v1/owners?itemId=${itemId}`)
+      const responseBody = await response.json()
+      expect(response.status).toEqual(400)
+      expect(responseBody).toEqual({
+        ok: false,
+        message: "Couldn't fetch owners with the filters provided"
+      })
+    })
+
+    it('should respond with a 400 when itemId is missing', async () => {
+      const { localFetch } = components
+      const response = await localFetch.fetch(`/v1/owners?contractAddress=${contractAddress}`)
+      const responseBody = await response.json()
+      expect(response.status).toEqual(400)
+      expect(responseBody).toEqual({
+        ok: false,
+        message: "Couldn't fetch owners with the filters provided"
+      })
+    })
+
+    it('should respond with a 400 when both parameters are missing', async () => {
+      const { localFetch } = components
+      const response = await localFetch.fetch('/v1/owners')
+      const responseBody = await response.json()
+      expect(response.status).toEqual(400)
+      expect(responseBody).toEqual({
+        ok: false,
+        message: "Couldn't fetch owners with the filters provided"
+      })
+    })
+  })
+
+  describe('when called with pagination parameters', () => {
+    it('should respond with a 200 and handle pagination correctly', async () => {
+      const { localFetch } = components
+      const response = await localFetch.fetch(
+        `/v1/owners?contractAddress=${contractAddress}&itemId=${itemId}&first=10&skip=0&sortBy=issuedId&orderDirection=desc`
+      )
+      const responseBody = await response.json()
+      expect(response.status).toEqual(200)
+      expect(responseBody).toEqual(
+        expect.objectContaining({
+          data: expect.any(Array),
+          total: expect.any(Number)
+        })
+      )
+    })
+  })
+})

--- a/test/integration/owners-controller.spec.ts
+++ b/test/integration/owners-controller.spec.ts
@@ -22,7 +22,7 @@ test('when getting owners', function ({ components }) {
       expect(response.status).toEqual(400)
       expect(responseBody).toEqual({
         ok: false,
-        message: "Couldn't fetch owners with the filters provided"
+        message: "itemId and contractAddress are necessary params."
       })
     })
 
@@ -33,7 +33,7 @@ test('when getting owners', function ({ components }) {
       expect(response.status).toEqual(400)
       expect(responseBody).toEqual({
         ok: false,
-        message: "Couldn't fetch owners with the filters provided"
+        message: "itemId and contractAddress are necessary params."
       })
     })
 
@@ -44,7 +44,7 @@ test('when getting owners', function ({ components }) {
       expect(response.status).toEqual(400)
       expect(responseBody).toEqual({
         ok: false,
-        message: "Couldn't fetch owners with the filters provided"
+        message: "itemId and contractAddress are necessary params."
       })
     })
   })

--- a/test/integration/owners-controller.spec.ts
+++ b/test/integration/owners-controller.spec.ts
@@ -22,7 +22,7 @@ test('when getting owners', function ({ components }) {
       expect(response.status).toEqual(400)
       expect(responseBody).toEqual({
         ok: false,
-        message: "itemId and contractAddress are necessary params."
+        message: 'itemId and contractAddress are necessary params.'
       })
     })
 
@@ -33,7 +33,7 @@ test('when getting owners', function ({ components }) {
       expect(response.status).toEqual(400)
       expect(responseBody).toEqual({
         ok: false,
-        message: "itemId and contractAddress are necessary params."
+        message: 'itemId and contractAddress are necessary params.'
       })
     })
 
@@ -44,7 +44,7 @@ test('when getting owners', function ({ components }) {
       expect(response.status).toEqual(400)
       expect(responseBody).toEqual({
         ok: false,
-        message: "itemId and contractAddress are necessary params."
+        message: 'itemId and contractAddress are necessary params.'
       })
     })
   })

--- a/test/unit/owners-handler.spec.ts
+++ b/test/unit/owners-handler.spec.ts
@@ -94,14 +94,6 @@ describe('getOwnersHandler', () => {
           message: 'itemId and contractAddress are necessary params.'
         }
       })
-      expect(context.components.owners.fetchAndCount).toHaveBeenCalledWith({
-        contractAddress: undefined,
-        itemId: undefined,
-        orderDirection: 'desc',
-        sortBy: OwnersSortBy.ISSUED_ID,
-        first: undefined,
-        skip: undefined
-      })
     })
   })
 

--- a/test/unit/owners-handler.spec.ts
+++ b/test/unit/owners-handler.spec.ts
@@ -11,7 +11,7 @@ describe('getOwnersHandler', () => {
       context = {
         components: {
           owners: {
-            fetchAndCount: jest.fn().mockResolvedValue({ data: [], total: 0 })
+            fetchAndCount: jest.fn().mockResolvedValueOnce({ data: [], total: 0 })
           }
         },
         url: new URL('http://example.com/v1/owners?contractAddress=0x123&itemId=0')

--- a/test/unit/owners-handler.spec.ts
+++ b/test/unit/owners-handler.spec.ts
@@ -1,0 +1,149 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { getOwnersHandler } from '../../src/controllers/handlers/owners-handler'
+import { OwnersSortBy } from '../../src/ports/owners/types'
+import { HandlerContextWithPath, StatusCode } from '../../src/types'
+
+let context: Pick<HandlerContextWithPath<'owners', '/v1/owners'>, 'components' | 'url'>
+
+describe('getOwnersHandler', () => {
+  describe('when get owners call is successful', () => {
+    beforeEach(() => {
+      context = {
+        components: {
+          owners: {
+            fetchAndCount: jest.fn().mockResolvedValue({ data: [], total: 0 })
+          }
+        },
+        url: new URL('http://example.com/v1/owners?contractAddress=0x123&itemId=0')
+      }
+    })
+
+    it('should return owners data and total count when successful', async () => {
+      const result = await getOwnersHandler(context)
+
+      expect(result).toEqual({
+        status: StatusCode.OK,
+        body: {
+          data: [],
+          total: 0
+        }
+      })
+      expect(context.components.owners.fetchAndCount).toHaveBeenCalledWith({
+        contractAddress: '0x123',
+        itemId: '0',
+        orderDirection: 'desc',
+        sortBy: OwnersSortBy.ISSUED_ID,
+        first: undefined,
+        skip: undefined
+      })
+    })
+  })
+
+  describe('when get owners call throws an error', () => {
+    beforeEach(() => {
+      context = {
+        components: {
+          owners: {
+            fetchAndCount: jest.fn().mockRejectedValue(new Error('Test error'))
+          }
+        },
+        url: new URL('http://example.com/v1/owners?contractAddress=0x123&itemId=0')
+      }
+    })
+
+    it('should return a bad request error when an error occurs', async () => {
+      const result = await getOwnersHandler(context)
+
+      expect(result).toEqual({
+        status: StatusCode.BAD_REQUEST,
+        body: {
+          ok: false,
+          message: 'Test error'
+        }
+      })
+      expect(context.components.owners.fetchAndCount).toHaveBeenCalledWith({
+        contractAddress: '0x123',
+        itemId: '0',
+        orderDirection: 'desc',
+        sortBy: OwnersSortBy.ISSUED_ID,
+        first: undefined,
+        skip: undefined
+      })
+    })
+  })
+
+  describe('when missing required parameters', () => {
+    beforeEach(() => {
+      context = {
+        components: {
+          owners: {
+            fetchAndCount: jest.fn().mockRejectedValue(new Error('itemId and contractAddress are necessary params.'))
+          }
+        },
+        url: new URL('http://example.com/v1/owners')
+      }
+    })
+
+    it('should return a bad request error when required parameters are missing', async () => {
+      const result = await getOwnersHandler(context)
+
+      expect(result).toEqual({
+        status: StatusCode.BAD_REQUEST,
+        body: {
+          ok: false,
+          message: 'itemId and contractAddress are necessary params.'
+        }
+      })
+      expect(context.components.owners.fetchAndCount).toHaveBeenCalledWith({
+        contractAddress: undefined,
+        itemId: undefined,
+        orderDirection: 'desc',
+        sortBy: OwnersSortBy.ISSUED_ID,
+        first: undefined,
+        skip: undefined
+      })
+    })
+  })
+
+  describe('when called with sorting parameters', () => {
+    beforeEach(() => {
+      context = {
+        components: {
+          owners: {
+            fetchAndCount: jest.fn().mockResolvedValue({
+              data: [
+                { issuedId: '1', ownerId: '0xabc', tokenId: '100' },
+                { issuedId: '2', ownerId: '0xdef', tokenId: '101' }
+              ],
+              total: 2
+            })
+          }
+        },
+        url: new URL('http://example.com/v1/owners?contractAddress=0x123&itemId=0&sortBy=issuedId&orderDirection=asc&first=10&skip=0')
+      }
+    })
+
+    it('should pass all parameters correctly including sorting', async () => {
+      const result = await getOwnersHandler(context)
+
+      expect(result).toEqual({
+        status: StatusCode.OK,
+        body: {
+          data: [
+            { issuedId: '1', ownerId: '0xabc', tokenId: '100' },
+            { issuedId: '2', ownerId: '0xdef', tokenId: '101' }
+          ],
+          total: 2
+        }
+      })
+      expect(context.components.owners.fetchAndCount).toHaveBeenCalledWith({
+        contractAddress: '0x123',
+        itemId: '0',
+        orderDirection: 'asc',
+        sortBy: OwnersSortBy.ISSUED_ID,
+        first: 10,
+        skip: 0
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds the `/owner` endpoint that the nft-server has but runs an optimized version of the SQL query