### PR TITLE
fix: add emote metadata to the catalog search query

### DIFF
--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -265,10 +265,7 @@ export const getEmotePlayModeWhere = (filters: CatalogFilters) => {
 }
 
 export const getSearchWhere = (filters: CatalogFilters) => {
-  if (filters.category === NFTCategory.EMOTE || filters.category === NFTCategory.WEARABLE) {
-    return SQL`word::text % lower(${filters.search})`
-  }
-  return SQL`word::text % lower(${filters.search})`
+  return SQL`lower(word::text) % lower(${filters.search})`
 }
 
 export const getIsSoldOutWhere = () => {


### PR DESCRIPTION
The query was missing the JOIN with the metadata id from emotes, so they were filtered out of the search query, only wearables were found by name (metadata)