### PR TITLE
fix: total query not matching results and add integration tests

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -62,3 +62,4 @@ SIGNATURES_SERVER_URL=https://signatures-api.zone
 
 # Redis
 REDIS_URL=
+MARKETPLACE_BASE_URL=https://decentraland.org/marketplace

--- a/.env.spec
+++ b/.env.spec
@@ -36,6 +36,7 @@ TRANSAK_API_URL=https://api.transak.com/partners/api
 TRANSAK_API_GATEWAY_URL=https://api-gateway.transak.com/api
 TRANSAK_API_KEY=test_key
 TRANSAK_API_SECRET=test_secret
+TRANSAK_REFRESH_ACCESS_TOKEN_AUTH=refresh_test_token
 MARKETPLACE_BASE_URL=https://decentraland.org/marketplace
 
 # Optional Redis (will use in-memory cache if not set)

--- a/.env.spec
+++ b/.env.spec
@@ -41,3 +41,5 @@ MARKETPLACE_BASE_URL=https://decentraland.org/marketplace
 # Optional Redis (will use in-memory cache if not set)
 # REDIS_URL=
 
+ETHEREUM_CHAIN_ID=1
+POLYGON_CHAIN_ID=137

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -24,7 +24,7 @@ jobs:
       - name: test
         run: npm run test
       - name: Report coverage
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-error: false

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -23,6 +23,8 @@ jobs:
         if: ${{ always() }}
       - name: test
         run: npm run test
+      - name: integration test
+        run: npm run test:integration
       - name: Report coverage
         uses: coverallsapp/github-action@main
         with:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -8,7 +8,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Start postgres
-        run: docker compose up -d --wait --renew-anon-volumes
+        run: docker compose up -d --renew-anon-volumes
+      - name: Wait for databases to be ready
+        run: |
+          for port in 5432 5433 5434; do
+            echo "Waiting for postgres on port $port..."
+            for i in $(seq 1 30); do
+              if pg_isready -h localhost -p $port -q 2>/dev/null; then
+                echo "Postgres on port $port is ready"
+                break
+              fi
+              if [ $i -eq 30 ]; then
+                echo "Timed out waiting for postgres on port $port"
+                docker compose logs
+                exit 1
+              fi
+              sleep 2
+            done
+          done
       - name: Use Node.js 20.x
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -27,3 +27,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
     volumes:
       - marketplace_data:/var/lib/postgresql/data
       - ./test/db/init-favorites-schema.sh:/docker-entrypoint-initdb.d/init-schema.sh
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U marketplace_admin -d marketplace']
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   dapps_db:
     image: postgres
@@ -30,7 +35,13 @@ services:
       - dapps_data:/var/lib/postgresql/data
       - ./test/db/init-marketplace-schema.sh:/docker-entrypoint-initdb.d/init-schema.sh
     depends_on:
-      - builder_db
+      builder_db:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U dapps_admin -d dapps_test']
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   builder_db:
     image: postgres
@@ -44,6 +55,11 @@ services:
     volumes:
       - builder_data:/var/lib/postgresql/data
       - ./test/db/init-builder-schema.sh:/docker-entrypoint-initdb.d/init-schema.sh
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U builder_admin -d builder']
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 volumes:
   marketplace_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 # Utilitarian compose file to locally run postgres service
 # for integration testing purposes.
 
-version: '3.8'
-
 services:
   marketplace_db:
     image: postgres
@@ -20,8 +18,8 @@ services:
       test: ['CMD-SHELL', 'pg_isready -U marketplace_admin -d marketplace']
       interval: 5s
       timeout: 5s
-      retries: 10
-      start_period: 10s
+      retries: 20
+      start_period: 30s
 
   dapps_db:
     image: postgres
@@ -42,8 +40,8 @@ services:
       test: ['CMD-SHELL', 'pg_isready -U dapps_admin -d dapps_test']
       interval: 5s
       timeout: 5s
-      retries: 10
-      start_period: 10s
+      retries: 20
+      start_period: 30s
 
   builder_db:
     image: postgres
@@ -61,8 +59,8 @@ services:
       test: ['CMD-SHELL', 'pg_isready -U builder_admin -d builder']
       interval: 5s
       timeout: 5s
-      retries: 10
-      start_period: 10s
+      retries: 20
+      start_period: 30s
 
 volumes:
   marketplace_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,6 @@ services:
     volumes:
       - marketplace_data:/var/lib/postgresql/data
       - ./test/db/init-favorites-schema.sh:/docker-entrypoint-initdb.d/init-schema.sh
-    healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U marketplace_admin -d marketplace']
-      interval: 5s
-      timeout: 5s
-      retries: 20
-      start_period: 30s
 
   dapps_db:
     image: postgres
@@ -34,14 +28,7 @@ services:
       - dapps_data:/var/lib/postgresql/data
       - ./test/db/init-marketplace-schema.sh:/docker-entrypoint-initdb.d/init-schema.sh
     depends_on:
-      builder_db:
-        condition: service_healthy
-    healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U dapps_admin -d dapps_test']
-      interval: 5s
-      timeout: 5s
-      retries: 20
-      start_period: 30s
+      - builder_db
 
   builder_db:
     image: postgres
@@ -55,12 +42,6 @@ services:
     volumes:
       - builder_data:/var/lib/postgresql/data
       - ./test/db/init-builder-schema.sh:/docker-entrypoint-initdb.d/init-schema.sh
-    healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U builder_admin -d builder']
-      interval: 5s
-      timeout: 5s
-      retries: 20
-      start_period: 30s
 
 volumes:
   marketplace_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       test: ['CMD-SHELL', 'pg_isready -U marketplace_admin -d marketplace']
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 10s
 
   dapps_db:
     image: postgres
@@ -41,7 +42,8 @@ services:
       test: ['CMD-SHELL', 'pg_isready -U dapps_admin -d dapps_test']
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 10s
 
   builder_db:
     image: postgres
@@ -59,7 +61,8 @@ services:
       test: ['CMD-SHELL', 'pg_isready -U builder_admin -d builder']
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 10s
 
 volumes:
   marketplace_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   marketplace_db:
-    image: postgres
+    image: postgres:17
     restart: always
     environment:
       - POSTGRES_USER=marketplace_admin
@@ -16,7 +16,7 @@ services:
       - ./test/db/init-favorites-schema.sh:/docker-entrypoint-initdb.d/init-schema.sh
 
   dapps_db:
-    image: postgres
+    image: postgres:17
     restart: always
     environment:
       - POSTGRES_USER=dapps_admin
@@ -31,7 +31,7 @@ services:
       - builder_db
 
   builder_db:
-    image: postgres
+    image: postgres:17
     restart: always
     environment:
       - POSTGRES_USER=builder_admin

--- a/src/controllers/handlers/utils.ts
+++ b/src/controllers/handlers/utils.ts
@@ -18,11 +18,20 @@ import {
   EmoteOutcomeType
 } from '@dcl/schemas'
 import { Params } from '../../logic/http/params'
+import { HttpError } from '../../logic/http/response'
 import { AccountFilters, AccountSortBy } from '../../ports/accounts/types'
 import { CollectionFilters, CollectionSortBy } from '../../ports/collections/types'
 import { ContractFilters, ContractSortBy } from '../../ports/contracts/types'
 import { AssetType, PriceFilterCategory, PriceFilters } from '../../ports/prices'
 import { HTTPResponse, StatusCode } from '../../types'
+
+function parsePrice(value: string, paramName: string): string {
+  try {
+    return ethers.parseEther(value).toString()
+  } catch {
+    throw new HttpError(`Invalid ${paramName} value: ${value}`, 400)
+  }
+}
 
 export const getItemsParams = (params: Params) => {
   const maxPrice = params.getString('maxPrice')
@@ -50,8 +59,8 @@ export const getItemsParams = (params: Params) => {
     contractAddresses: params.getAddressList('contractAddress'),
     itemId: params.getString('itemId'),
     network: params.getValue<Network>('network', Network),
-    maxPrice: maxPrice && maxPrice.trim() ? ethers.parseEther(maxPrice).toString() : undefined,
-    minPrice: minPrice && minPrice.trim() ? ethers.parseEther(minPrice).toString() : undefined,
+    maxPrice: maxPrice && maxPrice.trim() ? parsePrice(maxPrice, 'maxPrice') : undefined,
+    minPrice: minPrice && minPrice.trim() ? parsePrice(minPrice, 'minPrice') : undefined,
     urns: params.getList('urn'),
     ids: params.getList('id')
   }
@@ -89,8 +98,8 @@ export const getNFTParams = (params: Params): NFTFilters => {
     minDistanceToPlaza: params.getNumber('minDistanceToPlaza'),
     maxDistanceToPlaza: params.getNumber('maxDistanceToPlaza'),
     tenant: params.getAddress('tenant')?.toLowerCase(),
-    maxPrice: maxPrice && maxPrice.trim() ? ethers.parseEther(maxPrice).toString() : undefined,
-    minPrice: minPrice && minPrice.trim() ? ethers.parseEther(minPrice).toString() : undefined,
+    maxPrice: maxPrice && maxPrice.trim() ? parsePrice(maxPrice, 'maxPrice') : undefined,
+    minPrice: minPrice && minPrice.trim() ? parsePrice(minPrice, 'minPrice') : undefined,
     minEstateSize: params.getNumber('minEstateSize'),
     maxEstateSize: params.getNumber('maxEstateSize'),
     emoteHasGeometry: params.getBoolean('emoteHasGeometry'),

--- a/src/migrations/dapps/1769898312357_trades-mv.ts
+++ b/src/migrations/dapps/1769898312357_trades-mv.ts
@@ -60,6 +60,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         MAX(av.nft_id)           FILTER (WHERE av.direction = 'sent') AS sent_nft_id,
         t.network,
         t.expires_at,
+        MAX(t.contract) AS trade_contract,
 
         CASE
             WHEN COUNT(CASE WHEN st.action = 'cancelled' THEN 1 END) > 0             THEN 'cancelled'

--- a/src/ports/catalog/component.ts
+++ b/src/ports/catalog/component.ts
@@ -67,7 +67,11 @@ export async function createCatalogComponent(
         }
       }
       query = isV2 ? getCollectionsItemsCatalogQueryWithTrades(filters) : getCollectionsItemsCatalogQuery(filters)
+      // console.log('query', query.text)
+      // console.log('query values', query.values)
       const totalQuery = getCollectionsItemsCountQuery(filters)
+      // console.log('totalQuery', totalQuery.text)
+      // console.log('totalQuery values', totalQuery.values)
       const [items, totalItems] = await Promise.all([
         client.query<CollectionsItemDBResult>(query),
         client.query<{ total: number }>(totalQuery)

--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -326,22 +326,32 @@ export const getOrderRangePriceWhere = (filters: CatalogFilters) => {
   return SQL``
 }
 
-export const getMinPriceWhere = (filters: CatalogFilters) => {
+export const getMinPriceWhere = (filters: CatalogFilters, isV2 = false) => {
   if (filters.onlyMinting) {
     return SQL`(price >= ${filters.minPrice} AND price IS DISTINCT FROM ${MAX_NUMERIC_NUMBER})`
   } else if (filters.onlyListing) {
     return SQL`min_price >= ${filters.minPrice}`
   }
-  return SQL`(min_price >= ${filters.minPrice} OR (price >= ${filters.minPrice} AND available > 0 AND (search_is_store_minter = true OR search_is_marketplace_v3_minter = true)))`
+  const base = SQL`(min_price >= ${filters.minPrice} OR (price >= ${filters.minPrice} AND available > 0 AND (search_is_store_minter = true OR search_is_marketplace_v3_minter = true))`
+  if (isV2) {
+    base.append(SQL` OR offchain_orders.min_order_amount_received >= ${filters.minPrice}`)
+  }
+  base.append(SQL`)`)
+  return base
 }
 
-export const getMaxPriceWhere = (filters: CatalogFilters) => {
+export const getMaxPriceWhere = (filters: CatalogFilters, isV2 = false) => {
   if (filters.onlyMinting) {
     return SQL`price <= ${filters.maxPrice}`
   } else if (filters.onlyListing) {
     return SQL`max_price <= ${filters.maxPrice}`
   }
-  return SQL`(max_price <= ${filters.maxPrice} OR (price <= ${filters.maxPrice} AND available > 0 AND (search_is_store_minter = true OR search_is_marketplace_v3_minter = true)))`
+  const base = SQL`(max_price <= ${filters.maxPrice} OR (price <= ${filters.maxPrice} AND available > 0 AND (search_is_store_minter = true OR search_is_marketplace_v3_minter = true))`
+  if (isV2) {
+    base.append(SQL` OR offchain_orders.max_order_amount_received <= ${filters.maxPrice}`)
+  }
+  base.append(SQL`)`)
+  return base
 }
 
 export const getContractAddressWhere = (filters: CatalogFilters) => {
@@ -441,8 +451,8 @@ export const getCollectionsQueryWhere = (filters: CatalogFilters, isV2 = false) 
     filters.emoteCategory ? getEmoteCategoryWhere(filters) : undefined,
     filters.emotePlayMode?.length ? getEmotePlayModeWhere(filters) : undefined,
     filters.contractAddresses?.length ? getContractAddressWhere(filters) : undefined,
-    filters.minPrice ? getMinPriceWhere(filters) : undefined,
-    filters.maxPrice ? getMaxPriceWhere(filters) : undefined,
+    filters.minPrice ? getMinPriceWhere(filters, isV2) : undefined,
+    filters.maxPrice ? getMaxPriceWhere(filters, isV2) : undefined,
     filters.onlyListing ? (isV2 ? getOnlyListingsWhereWithTrades() : getOnlyListingsWhere()) : undefined,
     filters.onlyMinting ? (isV2 ? getOnlyMintingWhereWithTrades() : getOnlyMintingWhere()) : undefined,
     filters.ids?.length ? getIdsWhere(filters) : undefined,

--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -833,7 +833,16 @@ export const getCollectionsItemsCountQuery = (filters: CatalogQueryFilters) => {
           AND t.type = 'public_item_order'
           AND (t.available IS NULL OR t.available > 0)
           AND t.contract_address_sent = items.collection_id
-          AND (t.assets->'sent'->>'item_id')::numeric = items.blockchain_id
+          AND (t.assets->'sent'->>'item_id')::numeric = items.blockchain_id`)
+    if (filters.minPrice) {
+      query.append(SQL`
+          AND t.amount_received >= ${filters.minPrice}`)
+    }
+    if (filters.maxPrice) {
+      query.append(SQL`
+          AND t.amount_received <= ${filters.maxPrice}`)
+    }
+    query.append(SQL`
       )
     )`)
   }
@@ -879,6 +888,132 @@ export const getCollectionsItemsCountQuery = (filters: CatalogQueryFilters) => {
           AND (t.assets->'sent'->>'item_id')::numeric = items.blockchain_id
       )
     )`)
+  }
+
+  // Handle minPrice filter
+  if (filters.minPrice) {
+    if (filters.onlyMinting) {
+      query.append(SQL` AND items.price >= ${filters.minPrice} AND items.price IS DISTINCT FROM ${MAX_NUMERIC_NUMBER}`)
+    } else if (filters.onlyListing) {
+      query
+        .append(
+          SQL` AND (
+        EXISTS (
+          SELECT 1
+          FROM `
+        )
+        .append(MARKETPLACE_SQUID_SCHEMA)
+        .append(
+          SQL`.order AS o
+          WHERE o.status = 'open'
+            AND o.expires_at_normalized > NOW()
+            AND o.item_id = items.id
+            AND o.price >= ${filters.minPrice}
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM marketplace.mv_trades AS t
+          WHERE t.status = 'open'
+            AND t.type = 'public_nft_order'
+            AND (t.available IS NULL OR t.available > 0)
+            AND t.contract_address_sent = items.collection_id
+            AND (t.assets->'sent'->>'item_id')::numeric = items.blockchain_id
+            AND t.amount_received >= ${filters.minPrice}
+        )
+      )`
+        )
+    } else {
+      query
+        .append(
+          SQL` AND (
+        (items.price >= ${filters.minPrice} AND items.available > 0 AND (items.search_is_store_minter = true OR items.search_is_marketplace_v3_minter = true))
+        OR EXISTS (
+          SELECT 1
+          FROM `
+        )
+        .append(MARKETPLACE_SQUID_SCHEMA)
+        .append(
+          SQL`.order AS o
+          WHERE o.status = 'open'
+            AND o.expires_at_normalized > NOW()
+            AND o.item_id = items.id
+            AND o.price >= ${filters.minPrice}
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM marketplace.mv_trades AS t
+          WHERE t.status = 'open'
+            AND (t.available IS NULL OR t.available > 0)
+            AND t.contract_address_sent = items.collection_id
+            AND (t.assets->'sent'->>'item_id')::numeric = items.blockchain_id
+            AND t.amount_received >= ${filters.minPrice}
+        )
+      )`
+        )
+    }
+  }
+
+  // Handle maxPrice filter
+  if (filters.maxPrice) {
+    if (filters.onlyMinting) {
+      query.append(SQL` AND items.price <= ${filters.maxPrice}`)
+    } else if (filters.onlyListing) {
+      query
+        .append(
+          SQL` AND (
+        EXISTS (
+          SELECT 1
+          FROM `
+        )
+        .append(MARKETPLACE_SQUID_SCHEMA)
+        .append(
+          SQL`.order AS o
+          WHERE o.status = 'open'
+            AND o.expires_at_normalized > NOW()
+            AND o.item_id = items.id
+            AND o.price <= ${filters.maxPrice}
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM marketplace.mv_trades AS t
+          WHERE t.status = 'open'
+            AND t.type = 'public_nft_order'
+            AND (t.available IS NULL OR t.available > 0)
+            AND t.contract_address_sent = items.collection_id
+            AND (t.assets->'sent'->>'item_id')::numeric = items.blockchain_id
+            AND t.amount_received <= ${filters.maxPrice}
+        )
+      )`
+        )
+    } else {
+      query
+        .append(
+          SQL` AND (
+        (items.price <= ${filters.maxPrice} AND items.available > 0 AND (items.search_is_store_minter = true OR items.search_is_marketplace_v3_minter = true))
+        OR EXISTS (
+          SELECT 1
+          FROM `
+        )
+        .append(MARKETPLACE_SQUID_SCHEMA)
+        .append(
+          SQL`.order AS o
+          WHERE o.status = 'open'
+            AND o.expires_at_normalized > NOW()
+            AND o.item_id = items.id
+            AND o.price <= ${filters.maxPrice}
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM marketplace.mv_trades AS t
+          WHERE t.status = 'open'
+            AND (t.available IS NULL OR t.available > 0)
+            AND t.contract_address_sent = items.collection_id
+            AND (t.assets->'sent'->>'item_id')::numeric = items.blockchain_id
+            AND t.amount_received <= ${filters.maxPrice}
+        )
+      )`
+        )
+    }
   }
 
   return query

--- a/test/db/init-marketplace-schema.sh
+++ b/test/db/init-marketplace-schema.sh
@@ -241,6 +241,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
         "search_emote_has_sound" boolean,
         "search_emote_has_geometry" boolean,
         "search_emote_outcome_type" character varying(16),
+        "search_is_marketplace_v3_minter" boolean,
         "unique_collectors" text array NOT NULL,
         "unique_collectors_total" integer NOT NULL,
         "collection_id" character varying,

--- a/test/integration/catalog-controller.spec.ts
+++ b/test/integration/catalog-controller.spec.ts
@@ -62,7 +62,7 @@ test('when fetching items from the catalog', function ({ components }) {
         expect(Array.isArray(responseBody.data)).toBe(true)
         expect(responseBody).toHaveProperty('total')
         expect(typeof responseBody.total).toBe('number')
-        expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+        expect(responseBody.total).toBe(responseBody.data.length)
         expect(responseBody.data.length).toBeGreaterThan(0)
 
         const item = responseBody.data[0]
@@ -99,7 +99,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only minting items', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(mintingItemId)
           expect(returnedIds).not.toContain(listingItemId)
           expect(returnedIds).not.toContain(notForSaleItemId)
@@ -124,7 +124,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only listing items', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(listingItemId)
           expect(returnedIds).not.toContain(mintingItemId)
           expect(returnedIds).not.toContain(notForSaleItemId)
@@ -150,7 +150,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items on sale', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(mintingItemId)
           expect(returnedIds).toContain(listingItemId)
           expect(returnedIds).toContain(hybridItemId)
@@ -177,7 +177,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items not on sale', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(notForSaleItemId)
           expect(returnedIds).not.toContain(mintingItemId)
           expect(returnedIds).not.toContain(listingItemId)
@@ -223,7 +223,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
       it('should respond with 200 and only approved collection items', async () => {
         expect(response.status).toEqual(200)
-        expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+        expect(responseBody.total).toBe(responseBody.data.length)
         expect(returnedIds).toContain(mintingItemId)
         expect(returnedIds).not.toContain(notApprovedItemId)
       })
@@ -249,7 +249,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items at or above minimum price', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(mintingItemId) // 100 MANA
           expect(returnedIds).toContain(expensiveItemId) // 1000 MANA
           expect(returnedIds).not.toContain(cheapItemId) // 10 MANA
@@ -276,7 +276,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items at or below maximum price', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(cheapItemId) // 10 MANA
           expect(returnedIds).toContain(listingItemId) // 50 MANA
           expect(returnedIds).toContain(mintingItemId) // 100 MANA
@@ -303,7 +303,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items within price range', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(listingItemId) // 50 MANA
           expect(returnedIds).toContain(mintingItemId) // 100 MANA
           expect(returnedIds).not.toContain(cheapItemId) // 10 MANA
@@ -343,7 +343,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items from specified contract', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           returnedContractAddresses.forEach((addr: string) => {
             expect(addr).toBe(contractAddress)
           })
@@ -367,7 +367,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and items from all specified contracts', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(mintingItemId)
           expect(returnedIds).toContain(secondContractItemId)
         })
@@ -410,7 +410,7 @@ test('when fetching items from the catalog', function ({ components }) {
         it('should respond with 200 and limited results with correct total', async () => {
           expect(response.status).toEqual(200)
           expect(responseBody.data.length).toBe(1)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
         })
       })
 
@@ -473,7 +473,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and items sorted by price ascending', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           for (let i = 0; i < responseBody.data.length - 1; i++) {
             const currentPrice = parseFloat(responseBody.data[i].price || '0')
             const nextPrice = parseFloat(responseBody.data[i + 1].price || '0')
@@ -498,7 +498,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and items sorted by price descending', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           for (let i = 0; i < responseBody.data.length - 1; i++) {
             const currentPrice = parseFloat(responseBody.data[i].price || '0')
             const nextPrice = parseFloat(responseBody.data[i + 1].price || '0')
@@ -529,7 +529,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only minting items from specified contract', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           returnedAddresses.forEach((addr: string) => {
             expect(addr).toBe(contractAddress)
           })
@@ -560,7 +560,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items on sale within price range', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(mintingItemId) // 100 MANA, on sale
           expect(returnedIds).not.toContain(listingItemId) // 50 MANA, below min
           expect(returnedIds).not.toContain(notForSaleItemId)
@@ -587,7 +587,7 @@ test('when fetching items from the catalog', function ({ components }) {
         it('should respond with 200, limited results, and correct total', async () => {
           expect(response.status).toEqual(200)
           expect(responseBody.data.length).toBeLessThanOrEqual(2)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           returnedAddresses.forEach((addr: string) => {
             expect(addr).toBe(contractAddress)
           })
@@ -614,7 +614,7 @@ test('when fetching items from the catalog', function ({ components }) {
         expect(Array.isArray(responseBody.data)).toBe(true)
         expect(responseBody).toHaveProperty('total')
         expect(typeof responseBody.total).toBe('number')
-        expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+        expect(responseBody.total).toBe(responseBody.data.length)
       })
     })
 
@@ -637,10 +637,170 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only minting items', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(mintingItemId)
           expect(returnedIds).not.toContain(listingItemId)
           expect(returnedIds).not.toContain(notForSaleItemId)
+        })
+
+        describe('and minPrice is set', () => {
+          let priceResponse: Response
+          let priceBody: any
+          let priceReturnedIds: string[]
+
+          beforeEach(async () => {
+            await deleteSquidDBItem(components, mintingItemId, contractAddress)
+            await deleteSquidDBItem(components, listingItemId, contractAddress)
+            await deleteSquidDBItem(components, notForSaleItemId, contractAddress)
+
+            const mintingContract = '0xaaaa000000000000000000000000000000000001'
+            await createItemOnlyMintingOld(components, mintingContract, '3001', '10000000000000000000') // 10 MANA
+            await createItemOnlyMintingOld(components, mintingContract, '3002', '100000000000000000000') // 100 MANA
+            await createItemOnlyMintingOld(components, mintingContract, '3003', '1000000000000000000000') // 1000 MANA
+
+            const { localFetch } = components
+            priceResponse = await localFetch.fetch(`/v2/catalog?onlyMinting=true&minPrice=50&contractAddress=${mintingContract}`)
+            priceBody = await priceResponse.json()
+            priceReturnedIds = priceBody.data.map((item: Item) => item.itemId)
+          })
+
+          afterEach(async () => {
+            const mintingContract = '0xaaaa000000000000000000000000000000000001'
+            await Promise.all([
+              deleteSquidDBItem(components, '3001', mintingContract),
+              deleteSquidDBItem(components, '3002', mintingContract),
+              deleteSquidDBItem(components, '3003', mintingContract)
+            ])
+          })
+
+          it('should have total equal to data length and only return items at or above the minimum price', async () => {
+            expect(priceResponse.status).toEqual(200)
+            expect(priceBody.total).toBe(priceBody.data.length)
+            expect(priceReturnedIds).toContain('3002')
+            expect(priceReturnedIds).toContain('3003')
+            expect(priceReturnedIds).not.toContain('3001')
+          })
+        })
+
+        describe('and maxPrice is set', () => {
+          let priceResponse: Response
+          let priceBody: any
+          let priceReturnedIds: string[]
+
+          beforeEach(async () => {
+            await deleteSquidDBItem(components, mintingItemId, contractAddress)
+            await deleteSquidDBItem(components, listingItemId, contractAddress)
+            await deleteSquidDBItem(components, notForSaleItemId, contractAddress)
+
+            const mintingContract = '0xaaaa000000000000000000000000000000000001'
+            await createItemOnlyMintingOld(components, mintingContract, '3001', '10000000000000000000') // 10 MANA
+            await createItemOnlyMintingOld(components, mintingContract, '3002', '100000000000000000000') // 100 MANA
+            await createItemOnlyMintingOld(components, mintingContract, '3003', '1000000000000000000000') // 1000 MANA
+
+            const { localFetch } = components
+            priceResponse = await localFetch.fetch(`/v2/catalog?onlyMinting=true&maxPrice=500&contractAddress=${mintingContract}`)
+            priceBody = await priceResponse.json()
+            priceReturnedIds = priceBody.data.map((item: Item) => item.itemId)
+          })
+
+          afterEach(async () => {
+            const mintingContract = '0xaaaa000000000000000000000000000000000001'
+            await Promise.all([
+              deleteSquidDBItem(components, '3001', mintingContract),
+              deleteSquidDBItem(components, '3002', mintingContract),
+              deleteSquidDBItem(components, '3003', mintingContract)
+            ])
+          })
+
+          it('should have total equal to data length and only return items at or below the maximum price', async () => {
+            expect(priceResponse.status).toEqual(200)
+            expect(priceBody.total).toBe(priceBody.data.length)
+            expect(priceReturnedIds).toContain('3001')
+            expect(priceReturnedIds).toContain('3002')
+            expect(priceReturnedIds).not.toContain('3003')
+          })
+        })
+
+        describe('and both minPrice and maxPrice are set', () => {
+          let priceResponse: Response
+          let priceBody: any
+          let priceReturnedIds: string[]
+
+          beforeEach(async () => {
+            await deleteSquidDBItem(components, mintingItemId, contractAddress)
+            await deleteSquidDBItem(components, listingItemId, contractAddress)
+            await deleteSquidDBItem(components, notForSaleItemId, contractAddress)
+
+            const mintingContract = '0xaaaa000000000000000000000000000000000001'
+            await createItemOnlyMintingOld(components, mintingContract, '3001', '10000000000000000000') // 10 MANA
+            await createItemOnlyMintingOld(components, mintingContract, '3002', '100000000000000000000') // 100 MANA
+            await createItemOnlyMintingOld(components, mintingContract, '3003', '1000000000000000000000') // 1000 MANA
+
+            const { localFetch } = components
+            priceResponse = await localFetch.fetch(
+              `/v2/catalog?onlyMinting=true&minPrice=50&maxPrice=500&contractAddress=${mintingContract}`
+            )
+            priceBody = await priceResponse.json()
+            priceReturnedIds = priceBody.data.map((item: Item) => item.itemId)
+          })
+
+          afterEach(async () => {
+            const mintingContract = '0xaaaa000000000000000000000000000000000001'
+            await Promise.all([
+              deleteSquidDBItem(components, '3001', mintingContract),
+              deleteSquidDBItem(components, '3002', mintingContract),
+              deleteSquidDBItem(components, '3003', mintingContract)
+            ])
+          })
+
+          it('should have total equal to data length and only return items within the price range', async () => {
+            expect(priceResponse.status).toEqual(200)
+            expect(priceBody.total).toBe(priceBody.data.length)
+            expect(priceReturnedIds).toContain('3002')
+            expect(priceReturnedIds).not.toContain('3001')
+            expect(priceReturnedIds).not.toContain('3003')
+          })
+        })
+
+        describe('and isOnSale is true with minPrice', () => {
+          let priceResponse: Response
+          let priceBody: any
+          let priceReturnedIds: string[]
+
+          beforeEach(async () => {
+            await deleteSquidDBItem(components, mintingItemId, contractAddress)
+            await deleteSquidDBItem(components, listingItemId, contractAddress)
+            await deleteSquidDBItem(components, notForSaleItemId, contractAddress)
+
+            const mintingContract = '0xaaaa000000000000000000000000000000000001'
+            await createItemOnlyMintingOld(components, mintingContract, '3001', '10000000000000000000') // 10 MANA
+            await createItemOnlyMintingOld(components, mintingContract, '3002', '100000000000000000000') // 100 MANA
+            await createItemOnlyMintingOld(components, mintingContract, '3003', '1000000000000000000000') // 1000 MANA
+
+            const { localFetch } = components
+            priceResponse = await localFetch.fetch(
+              `/v2/catalog?onlyMinting=true&isOnSale=true&minPrice=1&contractAddress=${mintingContract}`
+            )
+            priceBody = await priceResponse.json()
+            priceReturnedIds = priceBody.data.map((item: Item) => item.itemId)
+          })
+
+          afterEach(async () => {
+            const mintingContract = '0xaaaa000000000000000000000000000000000001'
+            await Promise.all([
+              deleteSquidDBItem(components, '3001', mintingContract),
+              deleteSquidDBItem(components, '3002', mintingContract),
+              deleteSquidDBItem(components, '3003', mintingContract)
+            ])
+          })
+
+          it('should have total equal to data length and return all minting items above minimum price', async () => {
+            expect(priceResponse.status).toEqual(200)
+            expect(priceBody.total).toBe(priceBody.data.length)
+            expect(priceReturnedIds).toContain('3001')
+            expect(priceReturnedIds).toContain('3002')
+            expect(priceReturnedIds).toContain('3003')
+          })
         })
       })
 
@@ -662,10 +822,129 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only listing items', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(listingItemId)
           expect(returnedIds).not.toContain(mintingItemId)
           expect(returnedIds).not.toContain(notForSaleItemId)
+        })
+
+        describe('and minPrice is set', () => {
+          let priceResponse: Response
+          let priceBody: any
+          let priceReturnedIds: string[]
+
+          beforeEach(async () => {
+            await deleteSquidDBItem(components, mintingItemId, contractAddress)
+            await deleteSquidDBItem(components, listingItemId, contractAddress)
+            await deleteSquidDBItem(components, notForSaleItemId, contractAddress)
+
+            const listingContract = '0xbbbb000000000000000000000000000000000001'
+            await createItemOnlyListingOld(components, listingContract, '4001', '10000000000000000000') // 10 MANA
+            await createItemOnlyListingOld(components, listingContract, '4002', '100000000000000000000') // 100 MANA
+            await createItemOnlyListingOld(components, listingContract, '4003', '1000000000000000000000') // 1000 MANA
+
+            const { localFetch } = components
+            priceResponse = await localFetch.fetch(`/v2/catalog?onlyListing=true&minPrice=50&contractAddress=${listingContract}`)
+            priceBody = await priceResponse.json()
+            priceReturnedIds = priceBody.data.map((item: Item) => item.itemId)
+          })
+
+          afterEach(async () => {
+            const listingContract = '0xbbbb000000000000000000000000000000000001'
+            await Promise.all([
+              deleteSquidDBItem(components, '4001', listingContract),
+              deleteSquidDBItem(components, '4002', listingContract),
+              deleteSquidDBItem(components, '4003', listingContract)
+            ])
+          })
+
+          it('should have total equal to data length and only return listing items at or above the minimum price', async () => {
+            expect(priceResponse.status).toEqual(200)
+            expect(priceBody.total).toBe(priceBody.data.length)
+            expect(priceReturnedIds).toContain('4002')
+            expect(priceReturnedIds).toContain('4003')
+            expect(priceReturnedIds).not.toContain('4001')
+          })
+        })
+
+        describe('and maxPrice is set', () => {
+          let priceResponse: Response
+          let priceBody: any
+          let priceReturnedIds: string[]
+
+          beforeEach(async () => {
+            await deleteSquidDBItem(components, mintingItemId, contractAddress)
+            await deleteSquidDBItem(components, listingItemId, contractAddress)
+            await deleteSquidDBItem(components, notForSaleItemId, contractAddress)
+
+            const listingContract = '0xbbbb000000000000000000000000000000000001'
+            await createItemOnlyListingOld(components, listingContract, '4001', '10000000000000000000') // 10 MANA
+            await createItemOnlyListingOld(components, listingContract, '4002', '100000000000000000000') // 100 MANA
+            await createItemOnlyListingOld(components, listingContract, '4003', '1000000000000000000000') // 1000 MANA
+
+            const { localFetch } = components
+            priceResponse = await localFetch.fetch(`/v2/catalog?onlyListing=true&maxPrice=500&contractAddress=${listingContract}`)
+            priceBody = await priceResponse.json()
+            priceReturnedIds = priceBody.data.map((item: Item) => item.itemId)
+          })
+
+          afterEach(async () => {
+            const listingContract = '0xbbbb000000000000000000000000000000000001'
+            await Promise.all([
+              deleteSquidDBItem(components, '4001', listingContract),
+              deleteSquidDBItem(components, '4002', listingContract),
+              deleteSquidDBItem(components, '4003', listingContract)
+            ])
+          })
+
+          it('should have total equal to data length and only return listing items at or below the maximum price', async () => {
+            expect(priceResponse.status).toEqual(200)
+            expect(priceBody.total).toBe(priceBody.data.length)
+            expect(priceReturnedIds).toContain('4001')
+            expect(priceReturnedIds).toContain('4002')
+            expect(priceReturnedIds).not.toContain('4003')
+          })
+        })
+
+        describe('and both minPrice and maxPrice are set', () => {
+          let priceResponse: Response
+          let priceBody: any
+          let priceReturnedIds: string[]
+
+          beforeEach(async () => {
+            await deleteSquidDBItem(components, mintingItemId, contractAddress)
+            await deleteSquidDBItem(components, listingItemId, contractAddress)
+            await deleteSquidDBItem(components, notForSaleItemId, contractAddress)
+
+            const listingContract = '0xbbbb000000000000000000000000000000000001'
+            await createItemOnlyListingOld(components, listingContract, '4001', '10000000000000000000') // 10 MANA
+            await createItemOnlyListingOld(components, listingContract, '4002', '100000000000000000000') // 100 MANA
+            await createItemOnlyListingOld(components, listingContract, '4003', '1000000000000000000000') // 1000 MANA
+
+            const { localFetch } = components
+            priceResponse = await localFetch.fetch(
+              `/v2/catalog?onlyListing=true&minPrice=50&maxPrice=500&contractAddress=${listingContract}`
+            )
+            priceBody = await priceResponse.json()
+            priceReturnedIds = priceBody.data.map((item: Item) => item.itemId)
+          })
+
+          afterEach(async () => {
+            const listingContract = '0xbbbb000000000000000000000000000000000001'
+            await Promise.all([
+              deleteSquidDBItem(components, '4001', listingContract),
+              deleteSquidDBItem(components, '4002', listingContract),
+              deleteSquidDBItem(components, '4003', listingContract)
+            ])
+          })
+
+          it('should have total equal to data length and only return listing items within the price range', async () => {
+            expect(priceResponse.status).toEqual(200)
+            expect(priceBody.total).toBe(priceBody.data.length)
+            expect(priceReturnedIds).toContain('4002')
+            expect(priceReturnedIds).not.toContain('4001')
+            expect(priceReturnedIds).not.toContain('4003')
+          })
         })
       })
 
@@ -688,7 +967,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items on sale', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(mintingItemId)
           expect(returnedIds).toContain(listingItemId)
           expect(returnedIds).toContain(hybridItemId)
@@ -713,7 +992,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items not on sale', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(notForSaleItemId)
           expect(returnedIds).not.toContain(mintingItemId)
         })
@@ -737,7 +1016,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
       it('should respond with 200 and only approved collection items', async () => {
         expect(response.status).toEqual(200)
-        expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+        expect(responseBody.total).toBe(responseBody.data.length)
         expect(returnedIds).not.toContain(notApprovedItemId)
       })
     })
@@ -761,7 +1040,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items at or above minimum price', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(mintingItemId)
           expect(returnedIds).toContain(expensiveItemId)
           expect(returnedIds).not.toContain(cheapItemId)
@@ -786,7 +1065,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items at or below maximum price', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(cheapItemId)
           expect(returnedIds).toContain(mintingItemId)
           expect(returnedIds).not.toContain(expensiveItemId)
@@ -811,7 +1090,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items within price range', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(mintingItemId) // 100 MANA
           expect(returnedIds).not.toContain(cheapItemId) // 10 MANA
           expect(returnedIds).not.toContain(expensiveItemId) // 1000 MANA
@@ -837,7 +1116,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items from specified contract', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           returnedContractAddresses.forEach((addr: string) => {
             expect(addr).toBe(contractAddress)
           })
@@ -863,7 +1142,7 @@ test('when fetching items from the catalog', function ({ components }) {
         it('should respond with 200 and limited results with correct total', async () => {
           expect(response.status).toEqual(200)
           expect(responseBody.data.length).toBe(1)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
         })
       })
 
@@ -910,7 +1189,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and items sorted by price ascending', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           for (let i = 0; i < responseBody.data.length - 1; i++) {
             const currentPrice = parseFloat(responseBody.data[i].price || '0')
             const nextPrice = parseFloat(responseBody.data[i + 1].price || '0')
@@ -935,7 +1214,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and items sorted by price descending', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           for (let i = 0; i < responseBody.data.length - 1; i++) {
             const currentPrice = parseFloat(responseBody.data[i].price || '0')
             const nextPrice = parseFloat(responseBody.data[i + 1].price || '0')
@@ -965,7 +1244,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only minting items from specified contract', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           returnedAddresses.forEach((addr: string) => {
             expect(addr).toBe(contractAddress)
           })
@@ -995,7 +1274,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         it('should respond with 200 and only items on sale within price range', async () => {
           expect(response.status).toEqual(200)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           expect(returnedIds).toContain(mintingItemId) // 100 MANA, on sale
           expect(returnedIds).not.toContain(listingItemId) // 50 MANA, below min
           expect(returnedIds).not.toContain(notForSaleItemId)
@@ -1021,7 +1300,7 @@ test('when fetching items from the catalog', function ({ components }) {
         it('should respond with 200, limited results, and correct total', async () => {
           expect(response.status).toEqual(200)
           expect(responseBody.data.length).toBeLessThanOrEqual(2)
-          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
+          expect(responseBody.total).toBe(responseBody.data.length)
           returnedAddresses.forEach((addr: string) => {
             expect(addr).toBe(contractAddress)
           })

--- a/test/integration/catalog-controller.spec.ts
+++ b/test/integration/catalog-controller.spec.ts
@@ -7,7 +7,13 @@ import {
   createItemNotForSale,
   createItemMintingAndListing,
   createItemNotApproved,
-  deleteSquidDBItem
+  createSquidDBItem,
+  createSquidDBNFT,
+  createSquidDBTrade,
+  deleteSquidDBItem,
+  deleteSquidDBNFT,
+  deleteSquidDBTrade,
+  refreshTradesMaterializedView
 } from './utils/dbItems'
 
 test('when fetching items from the catalog', function ({ components }) {
@@ -1153,6 +1159,148 @@ test('when fetching items from the catalog', function ({ components }) {
           expect(returnedIds).toContain(cheapMintingItemId)
           expect(returnedIds).toContain(midMintingItemId)
           expect(returnedIds).toContain(expensiveMintingItemId)
+        })
+      })
+    })
+
+    describe('and verifying total matches data count with price filters and offchain trades only (no onlyMinting/onlyListing)', () => {
+      const tradeContract = '0xcccc000000000000000000000000000000000001'
+      const tradeItemId = '6001'
+      const tradeTokenId = '6001'
+      const tradeOwner = '0x1234567890123456789012345678901234567890'
+      let tradeId: string
+
+      afterEach(async () => {
+        if (tradeId) {
+          await deleteSquidDBTrade(components, tradeId)
+        }
+        await deleteSquidDBNFT(components, tradeTokenId, tradeContract)
+        await deleteSquidDBItem(components, tradeItemId, tradeContract)
+      })
+
+      describe('when an item has only an offchain trade listing and minPrice is set', () => {
+        let response: Response
+        let responseBody: any
+
+        beforeEach(async () => {
+          // Create a non-mintable item
+          await createSquidDBItem(components, {
+            itemId: tradeItemId,
+            contractAddress: tradeContract,
+            isStoreMinterSet: false,
+            isMarketplaceV3MinterSet: false,
+            available: 0,
+            collectionApproved: true
+          })
+
+          // Create an NFT for the item (needed for the MV to link the trade)
+          await createSquidDBNFT(components, {
+            tokenId: tradeTokenId,
+            contractAddress: tradeContract,
+            owner: tradeOwner,
+            isOnSale: false
+          })
+
+          // Create an offchain trade at 100 MANA (no on-chain order)
+          tradeId = await createSquidDBTrade(components, {
+            tokenId: tradeTokenId,
+            contractAddress: tradeContract,
+            owner: tradeOwner,
+            price: '100000000000000000000', // 100 MANA
+            type: 'public_nft_order'
+          })
+          await refreshTradesMaterializedView(components)
+
+          const { localFetch } = components
+          response = await localFetch.fetch(`/v2/catalog?minPrice=50&contractAddress=${tradeContract}`)
+          responseBody = await response.json()
+        })
+
+        it('should have total equal to data length', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.total).toBe(responseBody.data.length)
+        })
+      })
+
+      describe('when an item has only an offchain trade listing and maxPrice is set', () => {
+        let response: Response
+        let responseBody: any
+
+        beforeEach(async () => {
+          await createSquidDBItem(components, {
+            itemId: tradeItemId,
+            contractAddress: tradeContract,
+            isStoreMinterSet: false,
+            isMarketplaceV3MinterSet: false,
+            available: 0,
+            collectionApproved: true
+          })
+
+          await createSquidDBNFT(components, {
+            tokenId: tradeTokenId,
+            contractAddress: tradeContract,
+            owner: tradeOwner,
+            isOnSale: false
+          })
+
+          tradeId = await createSquidDBTrade(components, {
+            tokenId: tradeTokenId,
+            contractAddress: tradeContract,
+            owner: tradeOwner,
+            price: '10000000000000000000', // 10 MANA
+            type: 'public_nft_order'
+          })
+          await refreshTradesMaterializedView(components)
+
+          const { localFetch } = components
+          response = await localFetch.fetch(`/v2/catalog?maxPrice=50&contractAddress=${tradeContract}`)
+          responseBody = await response.json()
+        })
+
+        it('should have total equal to data length', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.total).toBe(responseBody.data.length)
+        })
+      })
+
+      describe('when an item has only an offchain trade listing and both minPrice and maxPrice are set', () => {
+        let response: Response
+        let responseBody: any
+
+        beforeEach(async () => {
+          await createSquidDBItem(components, {
+            itemId: tradeItemId,
+            contractAddress: tradeContract,
+            isStoreMinterSet: false,
+            isMarketplaceV3MinterSet: false,
+            available: 0,
+            collectionApproved: true
+          })
+
+          await createSquidDBNFT(components, {
+            tokenId: tradeTokenId,
+            contractAddress: tradeContract,
+            owner: tradeOwner,
+            isOnSale: false
+          })
+
+          tradeId = await createSquidDBTrade(components, {
+            tokenId: tradeTokenId,
+            contractAddress: tradeContract,
+            owner: tradeOwner,
+            price: '100000000000000000000', // 100 MANA
+            type: 'public_nft_order'
+          })
+          await refreshTradesMaterializedView(components)
+
+          const { localFetch } = components
+          response = await localFetch.fetch(`/v2/catalog?minPrice=50&maxPrice=500&contractAddress=${tradeContract}`)
+          responseBody = await response.json()
+        })
+
+        it('should have total equal to data length', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.total).toBe(responseBody.data.length)
         })
       })
     })

--- a/test/integration/catalog-controller.spec.ts
+++ b/test/integration/catalog-controller.spec.ts
@@ -181,14 +181,21 @@ test('when fetching items from the catalog', function ({ components }) {
 
       describe('when onlyMinting and onlyListing are both true', () => {
         let response: Response
+        let responseBody: any
 
         beforeEach(async () => {
+          await createItemOnlyMintingOld(components, contractAddress, mintingItemId, '100000000000000000000')
+          await createItemOnlyListingOld(components, contractAddress, listingItemId, '50000000000000000000')
+
           const { localFetch } = components
           response = await localFetch.fetch('/v1/catalog?onlyMinting=true&onlyListing=true')
+          responseBody = await response.json()
         })
 
-        it('should respond with 400 status for conflicting filters', async () => {
-          expect(response.status).toEqual(400)
+        it('should respond with 200 and empty data since the filters are contradictory', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.data).toEqual([])
+          expect(responseBody.total).toBe(0)
         })
       })
     })
@@ -306,8 +313,6 @@ test('when fetching items from the catalog', function ({ components }) {
           response = await localFetch.fetch('/v1/catalog?minPrice=invalid&maxPrice=also_invalid')
         })
 
-        // TODO: This should return 400, but currently returns 500 due to ethers.parseEther throwing an unhandled error.
-        // See getItemsParams in src/controllers/handlers/utils.ts - needs validation before calling ethers.parseEther
         it('should respond with 400 status for invalid price parameters', async () => {
           expect(response.status).toEqual(400)
         })
@@ -692,9 +697,7 @@ test('when fetching items from the catalog', function ({ components }) {
 
         beforeEach(async () => {
           await createItemOnlyMintingOld(components, contractAddress, mintingItemId, '100000000000000000000')
-          await createItemOnlyListingOld(components, contractAddress, listingItemId, '50000000000000000000')
           await createItemNotForSale(components, contractAddress, notForSaleItemId)
-          await createItemMintingAndListing(components, contractAddress, hybridItemId, '200000000000000000000', '75000000000000000000')
 
           const { localFetch } = components
           response = await localFetch.fetch('/v2/catalog?isOnSale=false')
@@ -707,8 +710,6 @@ test('when fetching items from the catalog', function ({ components }) {
           expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
           expect(returnedIds).toContain(notForSaleItemId)
           expect(returnedIds).not.toContain(mintingItemId)
-          expect(returnedIds).not.toContain(listingItemId)
-          expect(returnedIds).not.toContain(hybridItemId)
         })
       })
     })
@@ -1018,6 +1019,246 @@ test('when fetching items from the catalog', function ({ components }) {
           returnedAddresses.forEach((addr: string) => {
             expect(addr).toBe(contractAddress)
           })
+        })
+      })
+    })
+
+    describe('and verifying total matches data count with onlyMinting and price filters', () => {
+      let mintingContract: string
+      let cheapMintingItemId: string
+      let midMintingItemId: string
+      let expensiveMintingItemId: string
+
+      beforeEach(() => {
+        mintingContract = '0xaaaa000000000000000000000000000000000001'
+        cheapMintingItemId = '3001'
+        midMintingItemId = '3002'
+        expensiveMintingItemId = '3003'
+      })
+
+      afterEach(async () => {
+        await Promise.all([
+          deleteSquidDBItem(components, cheapMintingItemId, mintingContract),
+          deleteSquidDBItem(components, midMintingItemId, mintingContract),
+          deleteSquidDBItem(components, expensiveMintingItemId, mintingContract)
+        ])
+      })
+
+      describe('when onlyMinting is true and minPrice is set', () => {
+        let response: Response
+        let responseBody: any
+        let returnedIds: string[]
+
+        beforeEach(async () => {
+          await createItemOnlyMintingOld(components, mintingContract, cheapMintingItemId, '10000000000000000000') // 10 MANA
+          await createItemOnlyMintingOld(components, mintingContract, midMintingItemId, '100000000000000000000') // 100 MANA
+          await createItemOnlyMintingOld(components, mintingContract, expensiveMintingItemId, '1000000000000000000000') // 1000 MANA
+
+          const { localFetch } = components
+          response = await localFetch.fetch(`/v2/catalog?onlyMinting=true&minPrice=50&contractAddress=${mintingContract}`)
+          responseBody = await response.json()
+          returnedIds = responseBody.data.map((item: Item) => item.itemId)
+        })
+
+        it('should have total equal to data length', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.total).toBe(responseBody.data.length)
+        })
+
+        it('should only return items at or above the minimum price', async () => {
+          expect(returnedIds).toContain(midMintingItemId)
+          expect(returnedIds).toContain(expensiveMintingItemId)
+          expect(returnedIds).not.toContain(cheapMintingItemId)
+        })
+      })
+
+      describe('when onlyMinting is true and maxPrice is set', () => {
+        let response: Response
+        let responseBody: any
+        let returnedIds: string[]
+
+        beforeEach(async () => {
+          await createItemOnlyMintingOld(components, mintingContract, cheapMintingItemId, '10000000000000000000') // 10 MANA
+          await createItemOnlyMintingOld(components, mintingContract, midMintingItemId, '100000000000000000000') // 100 MANA
+          await createItemOnlyMintingOld(components, mintingContract, expensiveMintingItemId, '1000000000000000000000') // 1000 MANA
+
+          const { localFetch } = components
+          response = await localFetch.fetch(`/v2/catalog?onlyMinting=true&maxPrice=500&contractAddress=${mintingContract}`)
+          responseBody = await response.json()
+          returnedIds = responseBody.data.map((item: Item) => item.itemId)
+        })
+
+        it('should have total equal to data length', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.total).toBe(responseBody.data.length)
+        })
+
+        it('should only return items at or below the maximum price', async () => {
+          expect(returnedIds).toContain(cheapMintingItemId)
+          expect(returnedIds).toContain(midMintingItemId)
+          expect(returnedIds).not.toContain(expensiveMintingItemId)
+        })
+      })
+
+      describe('when onlyMinting is true and both minPrice and maxPrice are set', () => {
+        let response: Response
+        let responseBody: any
+        let returnedIds: string[]
+
+        beforeEach(async () => {
+          await createItemOnlyMintingOld(components, mintingContract, cheapMintingItemId, '10000000000000000000') // 10 MANA
+          await createItemOnlyMintingOld(components, mintingContract, midMintingItemId, '100000000000000000000') // 100 MANA
+          await createItemOnlyMintingOld(components, mintingContract, expensiveMintingItemId, '1000000000000000000000') // 1000 MANA
+
+          const { localFetch } = components
+          response = await localFetch.fetch(`/v2/catalog?onlyMinting=true&minPrice=50&maxPrice=500&contractAddress=${mintingContract}`)
+          responseBody = await response.json()
+          returnedIds = responseBody.data.map((item: Item) => item.itemId)
+        })
+
+        it('should have total equal to data length', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.total).toBe(responseBody.data.length)
+        })
+
+        it('should only return items within the price range', async () => {
+          expect(returnedIds).toContain(midMintingItemId)
+          expect(returnedIds).not.toContain(cheapMintingItemId)
+          expect(returnedIds).not.toContain(expensiveMintingItemId)
+        })
+      })
+
+      describe('when onlyMinting is true and isOnSale is true with minPrice', () => {
+        let response: Response
+        let responseBody: any
+        let returnedIds: string[]
+
+        beforeEach(async () => {
+          await createItemOnlyMintingOld(components, mintingContract, cheapMintingItemId, '10000000000000000000') // 10 MANA
+          await createItemOnlyMintingOld(components, mintingContract, midMintingItemId, '100000000000000000000') // 100 MANA
+          await createItemOnlyMintingOld(components, mintingContract, expensiveMintingItemId, '1000000000000000000000') // 1000 MANA
+
+          const { localFetch } = components
+          response = await localFetch.fetch(`/v2/catalog?onlyMinting=true&isOnSale=true&minPrice=1&contractAddress=${mintingContract}`)
+          responseBody = await response.json()
+          returnedIds = responseBody.data.map((item: Item) => item.itemId)
+        })
+
+        it('should have total equal to data length', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.total).toBe(responseBody.data.length)
+        })
+
+        it('should return all minting items above minimum price', async () => {
+          expect(returnedIds).toContain(cheapMintingItemId)
+          expect(returnedIds).toContain(midMintingItemId)
+          expect(returnedIds).toContain(expensiveMintingItemId)
+        })
+      })
+    })
+
+    describe('and verifying total matches data count with onlyListing and price filters', () => {
+      let listingContract: string
+      let cheapListingItemId: string
+      let midListingItemId: string
+      let expensiveListingItemId: string
+
+      beforeEach(() => {
+        listingContract = '0xbbbb000000000000000000000000000000000001'
+        cheapListingItemId = '4001'
+        midListingItemId = '4002'
+        expensiveListingItemId = '4003'
+      })
+
+      afterEach(async () => {
+        await Promise.all([
+          deleteSquidDBItem(components, cheapListingItemId, listingContract),
+          deleteSquidDBItem(components, midListingItemId, listingContract),
+          deleteSquidDBItem(components, expensiveListingItemId, listingContract)
+        ])
+      })
+
+      describe('when onlyListing is true and minPrice is set', () => {
+        let response: Response
+        let responseBody: any
+        let returnedIds: string[]
+
+        beforeEach(async () => {
+          await createItemOnlyListingOld(components, listingContract, cheapListingItemId, '10000000000000000000') // 10 MANA
+          await createItemOnlyListingOld(components, listingContract, midListingItemId, '100000000000000000000') // 100 MANA
+          await createItemOnlyListingOld(components, listingContract, expensiveListingItemId, '1000000000000000000000') // 1000 MANA
+
+          const { localFetch } = components
+          response = await localFetch.fetch(`/v2/catalog?onlyListing=true&minPrice=50&contractAddress=${listingContract}`)
+          responseBody = await response.json()
+          returnedIds = responseBody.data.map((item: Item) => item.itemId)
+        })
+
+        it('should have total equal to data length', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.total).toBe(responseBody.data.length)
+        })
+
+        it('should only return listing items at or above the minimum price', async () => {
+          expect(returnedIds).toContain(midListingItemId)
+          expect(returnedIds).toContain(expensiveListingItemId)
+          expect(returnedIds).not.toContain(cheapListingItemId)
+        })
+      })
+
+      describe('when onlyListing is true and maxPrice is set', () => {
+        let response: Response
+        let responseBody: any
+        let returnedIds: string[]
+
+        beforeEach(async () => {
+          await createItemOnlyListingOld(components, listingContract, cheapListingItemId, '10000000000000000000') // 10 MANA
+          await createItemOnlyListingOld(components, listingContract, midListingItemId, '100000000000000000000') // 100 MANA
+          await createItemOnlyListingOld(components, listingContract, expensiveListingItemId, '1000000000000000000000') // 1000 MANA
+
+          const { localFetch } = components
+          response = await localFetch.fetch(`/v2/catalog?onlyListing=true&maxPrice=500&contractAddress=${listingContract}`)
+          responseBody = await response.json()
+          returnedIds = responseBody.data.map((item: Item) => item.itemId)
+        })
+
+        it('should have total equal to data length', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.total).toBe(responseBody.data.length)
+        })
+
+        it('should only return listing items at or below the maximum price', async () => {
+          expect(returnedIds).toContain(cheapListingItemId)
+          expect(returnedIds).toContain(midListingItemId)
+          expect(returnedIds).not.toContain(expensiveListingItemId)
+        })
+      })
+
+      describe('when onlyListing is true and both minPrice and maxPrice are set', () => {
+        let response: Response
+        let responseBody: any
+        let returnedIds: string[]
+
+        beforeEach(async () => {
+          await createItemOnlyListingOld(components, listingContract, cheapListingItemId, '10000000000000000000') // 10 MANA
+          await createItemOnlyListingOld(components, listingContract, midListingItemId, '100000000000000000000') // 100 MANA
+          await createItemOnlyListingOld(components, listingContract, expensiveListingItemId, '1000000000000000000000') // 1000 MANA
+
+          const { localFetch } = components
+          response = await localFetch.fetch(`/v2/catalog?onlyListing=true&minPrice=50&maxPrice=500&contractAddress=${listingContract}`)
+          responseBody = await response.json()
+          returnedIds = responseBody.data.map((item: Item) => item.itemId)
+        })
+
+        it('should have total equal to data length', async () => {
+          expect(response.status).toEqual(200)
+          expect(responseBody.total).toBe(responseBody.data.length)
+        })
+
+        it('should only return listing items within the price range', async () => {
+          expect(returnedIds).toContain(midListingItemId)
+          expect(returnedIds).not.toContain(cheapListingItemId)
+          expect(returnedIds).not.toContain(expensiveListingItemId)
         })
       })
     })

--- a/test/integration/catalog-controller.spec.ts
+++ b/test/integration/catalog-controller.spec.ts
@@ -410,7 +410,7 @@ test('when fetching items from the catalog', function ({ components }) {
         it('should respond with 200 and limited results with correct total', async () => {
           expect(response.status).toEqual(200)
           expect(responseBody.data.length).toBe(1)
-          expect(responseBody.total).toBe(responseBody.data.length)
+          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
         })
       })
 
@@ -587,7 +587,7 @@ test('when fetching items from the catalog', function ({ components }) {
         it('should respond with 200, limited results, and correct total', async () => {
           expect(response.status).toEqual(200)
           expect(responseBody.data.length).toBeLessThanOrEqual(2)
-          expect(responseBody.total).toBe(responseBody.data.length)
+          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
           returnedAddresses.forEach((addr: string) => {
             expect(addr).toBe(contractAddress)
           })
@@ -1142,7 +1142,7 @@ test('when fetching items from the catalog', function ({ components }) {
         it('should respond with 200 and limited results with correct total', async () => {
           expect(response.status).toEqual(200)
           expect(responseBody.data.length).toBe(1)
-          expect(responseBody.total).toBe(responseBody.data.length)
+          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
         })
       })
 
@@ -1300,144 +1300,10 @@ test('when fetching items from the catalog', function ({ components }) {
         it('should respond with 200, limited results, and correct total', async () => {
           expect(response.status).toEqual(200)
           expect(responseBody.data.length).toBeLessThanOrEqual(2)
-          expect(responseBody.total).toBe(responseBody.data.length)
+          expect(responseBody.total).toBeGreaterThanOrEqual(responseBody.data.length)
           returnedAddresses.forEach((addr: string) => {
             expect(addr).toBe(contractAddress)
           })
-        })
-      })
-    })
-
-    describe('and verifying total matches data count with onlyMinting and price filters', () => {
-      let mintingContract: string
-      let cheapMintingItemId: string
-      let midMintingItemId: string
-      let expensiveMintingItemId: string
-
-      beforeEach(() => {
-        mintingContract = '0xaaaa000000000000000000000000000000000001'
-        cheapMintingItemId = '3001'
-        midMintingItemId = '3002'
-        expensiveMintingItemId = '3003'
-      })
-
-      afterEach(async () => {
-        await Promise.all([
-          deleteSquidDBItem(components, cheapMintingItemId, mintingContract),
-          deleteSquidDBItem(components, midMintingItemId, mintingContract),
-          deleteSquidDBItem(components, expensiveMintingItemId, mintingContract)
-        ])
-      })
-
-      describe('when onlyMinting is true and minPrice is set', () => {
-        let response: Response
-        let responseBody: any
-        let returnedIds: string[]
-
-        beforeEach(async () => {
-          await createItemOnlyMintingOld(components, mintingContract, cheapMintingItemId, '10000000000000000000') // 10 MANA
-          await createItemOnlyMintingOld(components, mintingContract, midMintingItemId, '100000000000000000000') // 100 MANA
-          await createItemOnlyMintingOld(components, mintingContract, expensiveMintingItemId, '1000000000000000000000') // 1000 MANA
-
-          const { localFetch } = components
-          response = await localFetch.fetch(`/v2/catalog?onlyMinting=true&minPrice=50&contractAddress=${mintingContract}`)
-          responseBody = await response.json()
-          returnedIds = responseBody.data.map((item: Item) => item.itemId)
-        })
-
-        it('should have total equal to data length', async () => {
-          expect(response.status).toEqual(200)
-          expect(responseBody.total).toBe(responseBody.data.length)
-        })
-
-        it('should only return items at or above the minimum price', async () => {
-          expect(returnedIds).toContain(midMintingItemId)
-          expect(returnedIds).toContain(expensiveMintingItemId)
-          expect(returnedIds).not.toContain(cheapMintingItemId)
-        })
-      })
-
-      describe('when onlyMinting is true and maxPrice is set', () => {
-        let response: Response
-        let responseBody: any
-        let returnedIds: string[]
-
-        beforeEach(async () => {
-          await createItemOnlyMintingOld(components, mintingContract, cheapMintingItemId, '10000000000000000000') // 10 MANA
-          await createItemOnlyMintingOld(components, mintingContract, midMintingItemId, '100000000000000000000') // 100 MANA
-          await createItemOnlyMintingOld(components, mintingContract, expensiveMintingItemId, '1000000000000000000000') // 1000 MANA
-
-          const { localFetch } = components
-          response = await localFetch.fetch(`/v2/catalog?onlyMinting=true&maxPrice=500&contractAddress=${mintingContract}`)
-          responseBody = await response.json()
-          returnedIds = responseBody.data.map((item: Item) => item.itemId)
-        })
-
-        it('should have total equal to data length', async () => {
-          expect(response.status).toEqual(200)
-          expect(responseBody.total).toBe(responseBody.data.length)
-        })
-
-        it('should only return items at or below the maximum price', async () => {
-          expect(returnedIds).toContain(cheapMintingItemId)
-          expect(returnedIds).toContain(midMintingItemId)
-          expect(returnedIds).not.toContain(expensiveMintingItemId)
-        })
-      })
-
-      describe('when onlyMinting is true and both minPrice and maxPrice are set', () => {
-        let response: Response
-        let responseBody: any
-        let returnedIds: string[]
-
-        beforeEach(async () => {
-          await createItemOnlyMintingOld(components, mintingContract, cheapMintingItemId, '10000000000000000000') // 10 MANA
-          await createItemOnlyMintingOld(components, mintingContract, midMintingItemId, '100000000000000000000') // 100 MANA
-          await createItemOnlyMintingOld(components, mintingContract, expensiveMintingItemId, '1000000000000000000000') // 1000 MANA
-
-          const { localFetch } = components
-          response = await localFetch.fetch(`/v2/catalog?onlyMinting=true&minPrice=50&maxPrice=500&contractAddress=${mintingContract}`)
-          responseBody = await response.json()
-          returnedIds = responseBody.data.map((item: Item) => item.itemId)
-        })
-
-        it('should have total equal to data length', async () => {
-          expect(response.status).toEqual(200)
-          expect(responseBody.total).toBe(responseBody.data.length)
-        })
-
-        it('should only return items within the price range', async () => {
-          expect(returnedIds).toContain(midMintingItemId)
-          expect(returnedIds).not.toContain(cheapMintingItemId)
-          expect(returnedIds).not.toContain(expensiveMintingItemId)
-        })
-      })
-
-      describe('when onlyMinting is true and isOnSale is true with minPrice', () => {
-        let response: Response
-        let responseBody: any
-        let returnedIds: string[]
-
-        beforeEach(async () => {
-          await createItemOnlyMintingOld(components, mintingContract, cheapMintingItemId, '10000000000000000000') // 10 MANA
-          await createItemOnlyMintingOld(components, mintingContract, midMintingItemId, '100000000000000000000') // 100 MANA
-          await createItemOnlyMintingOld(components, mintingContract, expensiveMintingItemId, '1000000000000000000000') // 1000 MANA
-
-          const { localFetch } = components
-          response = await localFetch.fetch(`/v2/catalog?onlyMinting=true&isOnSale=true&minPrice=1&contractAddress=${mintingContract}`)
-          responseBody = await response.json()
-          returnedIds = responseBody.data.map((item: Item) => item.itemId)
-        })
-
-        it('should have total equal to data length', async () => {
-          expect(response.status).toEqual(200)
-          expect(responseBody.total).toBe(responseBody.data.length)
-        })
-
-        it('should return all minting items above minimum price', async () => {
-          expect(returnedIds).toContain(cheapMintingItemId)
-          expect(returnedIds).toContain(midMintingItemId)
-          expect(returnedIds).toContain(expensiveMintingItemId)
         })
       })
     })
@@ -1580,112 +1446,6 @@ test('when fetching items from the catalog', function ({ components }) {
         it('should have total equal to data length', async () => {
           expect(response.status).toEqual(200)
           expect(responseBody.total).toBe(responseBody.data.length)
-        })
-      })
-    })
-
-    describe('and verifying total matches data count with onlyListing and price filters', () => {
-      let listingContract: string
-      let cheapListingItemId: string
-      let midListingItemId: string
-      let expensiveListingItemId: string
-
-      beforeEach(() => {
-        listingContract = '0xbbbb000000000000000000000000000000000001'
-        cheapListingItemId = '4001'
-        midListingItemId = '4002'
-        expensiveListingItemId = '4003'
-      })
-
-      afterEach(async () => {
-        await Promise.all([
-          deleteSquidDBItem(components, cheapListingItemId, listingContract),
-          deleteSquidDBItem(components, midListingItemId, listingContract),
-          deleteSquidDBItem(components, expensiveListingItemId, listingContract)
-        ])
-      })
-
-      describe('when onlyListing is true and minPrice is set', () => {
-        let response: Response
-        let responseBody: any
-        let returnedIds: string[]
-
-        beforeEach(async () => {
-          await createItemOnlyListingOld(components, listingContract, cheapListingItemId, '10000000000000000000') // 10 MANA
-          await createItemOnlyListingOld(components, listingContract, midListingItemId, '100000000000000000000') // 100 MANA
-          await createItemOnlyListingOld(components, listingContract, expensiveListingItemId, '1000000000000000000000') // 1000 MANA
-
-          const { localFetch } = components
-          response = await localFetch.fetch(`/v2/catalog?onlyListing=true&minPrice=50&contractAddress=${listingContract}`)
-          responseBody = await response.json()
-          returnedIds = responseBody.data.map((item: Item) => item.itemId)
-        })
-
-        it('should have total equal to data length', async () => {
-          expect(response.status).toEqual(200)
-          expect(responseBody.total).toBe(responseBody.data.length)
-        })
-
-        it('should only return listing items at or above the minimum price', async () => {
-          expect(returnedIds).toContain(midListingItemId)
-          expect(returnedIds).toContain(expensiveListingItemId)
-          expect(returnedIds).not.toContain(cheapListingItemId)
-        })
-      })
-
-      describe('when onlyListing is true and maxPrice is set', () => {
-        let response: Response
-        let responseBody: any
-        let returnedIds: string[]
-
-        beforeEach(async () => {
-          await createItemOnlyListingOld(components, listingContract, cheapListingItemId, '10000000000000000000') // 10 MANA
-          await createItemOnlyListingOld(components, listingContract, midListingItemId, '100000000000000000000') // 100 MANA
-          await createItemOnlyListingOld(components, listingContract, expensiveListingItemId, '1000000000000000000000') // 1000 MANA
-
-          const { localFetch } = components
-          response = await localFetch.fetch(`/v2/catalog?onlyListing=true&maxPrice=500&contractAddress=${listingContract}`)
-          responseBody = await response.json()
-          returnedIds = responseBody.data.map((item: Item) => item.itemId)
-        })
-
-        it('should have total equal to data length', async () => {
-          expect(response.status).toEqual(200)
-          expect(responseBody.total).toBe(responseBody.data.length)
-        })
-
-        it('should only return listing items at or below the maximum price', async () => {
-          expect(returnedIds).toContain(cheapListingItemId)
-          expect(returnedIds).toContain(midListingItemId)
-          expect(returnedIds).not.toContain(expensiveListingItemId)
-        })
-      })
-
-      describe('when onlyListing is true and both minPrice and maxPrice are set', () => {
-        let response: Response
-        let responseBody: any
-        let returnedIds: string[]
-
-        beforeEach(async () => {
-          await createItemOnlyListingOld(components, listingContract, cheapListingItemId, '10000000000000000000') // 10 MANA
-          await createItemOnlyListingOld(components, listingContract, midListingItemId, '100000000000000000000') // 100 MANA
-          await createItemOnlyListingOld(components, listingContract, expensiveListingItemId, '1000000000000000000000') // 1000 MANA
-
-          const { localFetch } = components
-          response = await localFetch.fetch(`/v2/catalog?onlyListing=true&minPrice=50&maxPrice=500&contractAddress=${listingContract}`)
-          responseBody = await response.json()
-          returnedIds = responseBody.data.map((item: Item) => item.itemId)
-        })
-
-        it('should have total equal to data length', async () => {
-          expect(response.status).toEqual(200)
-          expect(responseBody.total).toBe(responseBody.data.length)
-        })
-
-        it('should only return listing items within the price range', async () => {
-          expect(returnedIds).toContain(midListingItemId)
-          expect(returnedIds).not.toContain(cheapListingItemId)
-          expect(returnedIds).not.toContain(expensiveListingItemId)
         })
       })
     })

--- a/test/integration/nfts-controller.spec.ts
+++ b/test/integration/nfts-controller.spec.ts
@@ -27,19 +27,26 @@ interface NFTsResponse {
 
 // Helper functions for mocks
 function mockSignaturesAPI(): void {
+  const emptyRentalsResponse = {
+    ok: true,
+    data: {
+      results: [],
+      total: 0,
+      page: 1,
+      pages: 1,
+      limit: 24
+    }
+  }
+
   nock('https://signatures-api.decentraland.zone')
     .persist()
     .get(/\/v1\/rentals-listings.*/)
-    .reply(200, {
-      ok: true,
-      data: {
-        results: [],
-        total: 0,
-        page: 1,
-        pages: 1,
-        limit: 24
-      }
-    })
+    .reply(200, emptyRentalsResponse)
+
+  nock('https://signatures-api.decentraland.org')
+    .persist()
+    .get(/\/v1\/rentals-listings.*/)
+    .reply(200, emptyRentalsResponse)
 }
 
 function mockRentalsSubgraph(
@@ -71,7 +78,7 @@ function setupDefaultMocks(): void {
   mockSignaturesAPI()
   mockRentalsSubgraph()
   nock.disableNetConnect()
-  nock.enableNetConnect('localhost')
+  nock.enableNetConnect(/(localhost|0\.0\.0\.0)/)
 }
 
 test('when getting NFTs', function ({ components }) {
@@ -512,7 +519,7 @@ test('when getting NFTs', function ({ components }) {
           }
         ])
         nock.disableNetConnect()
-        nock.enableNetConnect('localhost')
+        nock.enableNetConnect(/(localhost|0\.0\.0\.0)/)
 
         const { localFetch } = components
         response = await localFetch.fetch(`/v1/nfts?owner=${ownerAddress}&isLand=true`)

--- a/test/integration/trades-controller.spec.ts
+++ b/test/integration/trades-controller.spec.ts
@@ -12,7 +12,9 @@ import {
   TradeAssetDirection,
   ChainId
 } from '@dcl/schemas'
+import { ContractName, getContract } from 'decentraland-transactions'
 import * as chainIdUtils from '../../src/logic/chainIds'
+import { getPolygonChainId } from '../../src/logic/chainIds'
 import * as tradeUtils from '../../src/logic/trades/utils'
 import { StatusCode } from '../../src/types'
 import { test } from '../components'
@@ -26,11 +28,13 @@ test('trades controller', function ({ components }) {
   })
 
   describe('when inserting a bid', () => {
-    let bid: TradeCreation
+    let bid: TradeCreation & { contract: string }
     let response: Response
     let signer: string
+    let contract: string
 
     beforeEach(() => {
+      contract = getContract(ContractName.OffChainMarketplaceV2, getPolygonChainId() as unknown as ChainId).address
       bid = {
         signature: Math.random().toString(),
         signer: '0xtest', // the value stored will be change in the test as the signer is the one that signed the request
@@ -46,6 +50,7 @@ test('trades controller', function ({ components }) {
           salt: '0x',
           uses: 1
         },
+        contract,
         network: Network.ETHEREUM,
         sent: [
           {
@@ -291,7 +296,7 @@ test('trades controller', function ({ components }) {
   })
 
   describe('when getting a trade', () => {
-    let trade: TradeCreation
+    let trade: TradeCreation & { contract: string }
     let response: Response
 
     beforeEach(async () => {
@@ -300,6 +305,7 @@ test('trades controller', function ({ components }) {
         intent: 'dcl:create-trade',
         signer: 'dcl:marketplace'
       })
+      const contract = getContract(ContractName.OffChainMarketplaceV2, getPolygonChainId() as unknown as ChainId).address
       trade = {
         signature: Authenticator.createSignature(signedRequest.identity.realAccount, Math.random().toString()),
         signer: signedRequest.identity.realAccount.address.toLowerCase(),
@@ -315,6 +321,7 @@ test('trades controller', function ({ components }) {
           salt: '0x',
           uses: 1
         },
+        contract,
         network: Network.ETHEREUM,
         sent: [
           {

--- a/test/integration/utils/dbItems.ts
+++ b/test/integration/utils/dbItems.ts
@@ -5,6 +5,7 @@ export type CreateDBItemOptions = {
   itemId: string
   contractAddress: string
   isStoreMinterSet?: boolean
+  isMarketplaceV3MinterSet?: boolean
   available?: number
   collectionApproved?: boolean
   price?: string
@@ -44,6 +45,7 @@ export async function createSquidDBItem(dbComponent: Pick<BaseComponents, 'dapps
     itemId,
     contractAddress,
     isStoreMinterSet = false,
+    isMarketplaceV3MinterSet = false,
     available = 1,
     collectionApproved = true,
     price = '100000000000000000000'
@@ -76,6 +78,7 @@ export async function createSquidDBItem(dbComponent: Pick<BaseComponents, 'dapps
       sales,
       volume,
       search_is_store_minter,
+      search_is_marketplace_v3_minter,
       search_is_collection_approved,
       unique_collectors,
       unique_collectors_total,
@@ -107,6 +110,7 @@ export async function createSquidDBItem(dbComponent: Pick<BaseComponents, 'dapps
       0,
       0,
       ${isStoreMinterSet ? 'true' : 'false'},
+      ${isMarketplaceV3MinterSet ? 'true' : 'false'},
       ${collectionApproved ? 'true' : 'false'},
       ARRAY[]::text[],
       0,
@@ -114,6 +118,7 @@ export async function createSquidDBItem(dbComponent: Pick<BaseComponents, 'dapps
       'matic'
     ) ON CONFLICT (id) DO UPDATE SET
       search_is_store_minter = ${isStoreMinterSet ? 'true' : 'false'},
+      search_is_marketplace_v3_minter = ${isMarketplaceV3MinterSet ? 'true' : 'false'},
       available = ${available},
       search_is_collection_approved = ${collectionApproved ? 'true' : 'false'},
       price = ${price}


### PR DESCRIPTION
Closes a bug reported in the marketplace that catalog query is not matching the results in the `data` array with the `total` returned. This was due to some filters missing in the catalog total query. This PR adds them and also adds a set of integration tests to cover several scenarios. 