### PR TITLE
refactor: migrate sales and bids to separate count queries

### DIFF
--- a/src/controllers/handlers/bids-handler.ts
+++ b/src/controllers/handlers/bids-handler.ts
@@ -23,7 +23,7 @@ export async function getBidsHandler(
     const network = getParameter<Network>('network', url.searchParams, Object.values(Network) as Network[])
     const status = getParameter<ListingStatus>('status', url.searchParams, Object.values(ListingStatus) as ListingStatus[])
 
-    const { data, count } = await bids.getBids({ limit, offset, bidder, seller, sortBy, contractAddress, tokenId, itemId, network, status })
+    const { data, total } = await bids.getBids({ limit, offset, bidder, seller, sortBy, contractAddress, tokenId, itemId, network, status })
 
     return {
       status: StatusCode.OK,
@@ -31,9 +31,9 @@ export async function getBidsHandler(
         ok: true,
         data: {
           results: data,
-          total: count,
+          total,
           page: Math.floor(offset / limit),
-          pages: data.length > 0 ? Math.ceil(count / limit) : 0,
+          pages: data.length > 0 ? Math.ceil(total / limit) : 0,
           limit
         }
       }

--- a/src/ports/bids/component.ts
+++ b/src/ports/bids/component.ts
@@ -1,18 +1,22 @@
 import { GetBidsParameters } from '@dcl/schemas'
 import { fromDBBidToBid } from '../../adapters/bids/bids'
 import { AppComponents } from '../../types'
-import { getBidsQuery } from './queries'
+import { extractCount } from '../pagination'
+import { getBidsCountQuery, getBidsQuery } from './queries'
 import { DBBid, IBidsComponent } from './types'
 
 export function createBidsComponents(components: Pick<AppComponents, 'dappsDatabase'>): IBidsComponent {
   const { dappsDatabase: pg } = components
 
   async function getBids(options: GetBidsParameters) {
-    const result = await pg.query<DBBid>(getBidsQuery(options))
+    const [result, count] = await Promise.all([
+      pg.query<DBBid>(getBidsQuery(options)),
+      pg.query<{ count: string }>(getBidsCountQuery(options))
+    ])
 
     return {
       data: result.rows.map(fromDBBidToBid),
-      count: result.rows.length ? Number(result.rows[0].bids_count) : 0
+      total: extractCount(count)
     }
   }
 

--- a/src/ports/bids/queries.ts
+++ b/src/ports/bids/queries.ts
@@ -1,4 +1,4 @@
-import SQL from 'sql-template-strings'
+import SQL, { SQLStatement } from 'sql-template-strings'
 import { BidSortBy, GetBidsParameters, TradeType } from '@dcl/schemas'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getDBNetworks } from '../../utils'
@@ -65,10 +65,7 @@ export function getLegacyBidsQuery(): string {
   `
 }
 
-export function getBidsQuery(options: GetBidsParameters) {
-  const BID_TRADES = ` (${getBidTradesQuery()}) as bid_trades `
-  const LEGACY_BIDS = ` (${getLegacyBidsQuery()}) as legacy_bids`
-
+function getBidsFilters(options: GetBidsParameters): SQLStatement {
   const FILTER_BY_BIDDER = options.bidder ? SQL` LOWER(bidder) = LOWER(${options.bidder}) ` : null
   const FILTER_BY_SELLER = options.seller ? SQL` LOWER(seller) = LOWER(${options.seller}) ` : null
   const FILTER_BY_CONTRACT_ADDRESS = options.contractAddress ? SQL` contract_address = ${options.contractAddress.toLowerCase()} ` : null
@@ -78,7 +75,7 @@ export function getBidsQuery(options: GetBidsParameters) {
   const FILTER_BY_STATUS = options.status ? SQL` status = ${options.status} ` : null
   const FILTER_NOT_EXPIRED = SQL` expires_at > now()::timestamptz(3) `
 
-  const FILTERS = getWhereStatementFromFilters([
+  return getWhereStatementFromFilters([
     FILTER_BY_BIDDER,
     FILTER_BY_SELLER,
     FILTER_BY_CONTRACT_ADDRESS,
@@ -88,45 +85,35 @@ export function getBidsQuery(options: GetBidsParameters) {
     FILTER_BY_STATUS,
     FILTER_NOT_EXPIRED
   ])
+}
+
+function getBidsFromClause(): { BID_TRADES: string; LEGACY_BIDS: string } {
+  return {
+    BID_TRADES: ` (${getBidTradesQuery()}) as bid_trades `,
+    LEGACY_BIDS: ` (${getLegacyBidsQuery()}) as legacy_bids`
+  }
+}
+
+export function getBidsQuery(options: GetBidsParameters) {
+  const { BID_TRADES, LEGACY_BIDS } = getBidsFromClause()
 
   return SQL`SELECT *`
     .append(SQL` FROM `)
     .append(BID_TRADES)
     .append(SQL` NATURAL FULL OUTER JOIN `)
     .append(LEGACY_BIDS)
-    .append(FILTERS)
+    .append(getBidsFilters(options))
     .append(getBidsSortByQuery(options.sortBy))
     .append(SQL` LIMIT ${options.limit} OFFSET ${options.offset} `)
 }
 
 export function getBidsCountQuery(options: GetBidsParameters) {
-  const BID_TRADES = ` (${getBidTradesQuery()}) as bid_trades `
-  const LEGACY_BIDS = ` (${getLegacyBidsQuery()}) as legacy_bids`
-
-  const FILTER_BY_BIDDER = options.bidder ? SQL` LOWER(bidder) = LOWER(${options.bidder}) ` : null
-  const FILTER_BY_SELLER = options.seller ? SQL` LOWER(seller) = LOWER(${options.seller}) ` : null
-  const FILTER_BY_CONTRACT_ADDRESS = options.contractAddress ? SQL` contract_address = ${options.contractAddress.toLowerCase()} ` : null
-  const FILTER_BY_TOKEN_ID = options.tokenId ? SQL` LOWER(token_id) = LOWER(${options.tokenId}) ` : null
-  const FILTER_BY_ITEM_ID = options.itemId ? SQL` LOWER(item_id) = LOWER(${options.itemId}) ` : null
-  const FILTER_BY_NETWORK = options.network ? SQL` network = ANY (${getDBNetworks(options.network)}) ` : null
-  const FILTER_BY_STATUS = options.status ? SQL` status = ${options.status} ` : null
-  const FILTER_NOT_EXPIRED = SQL` expires_at > now()::timestamptz(3) `
-
-  const FILTERS = getWhereStatementFromFilters([
-    FILTER_BY_BIDDER,
-    FILTER_BY_SELLER,
-    FILTER_BY_CONTRACT_ADDRESS,
-    FILTER_BY_TOKEN_ID,
-    FILTER_BY_ITEM_ID,
-    FILTER_BY_NETWORK,
-    FILTER_BY_STATUS,
-    FILTER_NOT_EXPIRED
-  ])
+  const { BID_TRADES, LEGACY_BIDS } = getBidsFromClause()
 
   return SQL`SELECT COUNT(*) as count`
     .append(SQL` FROM `)
     .append(BID_TRADES)
     .append(SQL` NATURAL FULL OUTER JOIN `)
     .append(LEGACY_BIDS)
-    .append(FILTERS)
+    .append(getBidsFilters(options))
 }

--- a/src/ports/bids/queries.ts
+++ b/src/ports/bids/queries.ts
@@ -89,7 +89,7 @@ export function getBidsQuery(options: GetBidsParameters) {
     FILTER_NOT_EXPIRED
   ])
 
-  return SQL`SELECT *, COUNT(*) OVER() as bids_count`
+  return SQL`SELECT *`
     .append(SQL` FROM `)
     .append(BID_TRADES)
     .append(SQL` NATURAL FULL OUTER JOIN `)
@@ -97,4 +97,36 @@ export function getBidsQuery(options: GetBidsParameters) {
     .append(FILTERS)
     .append(getBidsSortByQuery(options.sortBy))
     .append(SQL` LIMIT ${options.limit} OFFSET ${options.offset} `)
+}
+
+export function getBidsCountQuery(options: GetBidsParameters) {
+  const BID_TRADES = ` (${getBidTradesQuery()}) as bid_trades `
+  const LEGACY_BIDS = ` (${getLegacyBidsQuery()}) as legacy_bids`
+
+  const FILTER_BY_BIDDER = options.bidder ? SQL` LOWER(bidder) = LOWER(${options.bidder}) ` : null
+  const FILTER_BY_SELLER = options.seller ? SQL` LOWER(seller) = LOWER(${options.seller}) ` : null
+  const FILTER_BY_CONTRACT_ADDRESS = options.contractAddress ? SQL` contract_address = ${options.contractAddress.toLowerCase()} ` : null
+  const FILTER_BY_TOKEN_ID = options.tokenId ? SQL` LOWER(token_id) = LOWER(${options.tokenId}) ` : null
+  const FILTER_BY_ITEM_ID = options.itemId ? SQL` LOWER(item_id) = LOWER(${options.itemId}) ` : null
+  const FILTER_BY_NETWORK = options.network ? SQL` network = ANY (${getDBNetworks(options.network)}) ` : null
+  const FILTER_BY_STATUS = options.status ? SQL` status = ${options.status} ` : null
+  const FILTER_NOT_EXPIRED = SQL` expires_at > now()::timestamptz(3) `
+
+  const FILTERS = getWhereStatementFromFilters([
+    FILTER_BY_BIDDER,
+    FILTER_BY_SELLER,
+    FILTER_BY_CONTRACT_ADDRESS,
+    FILTER_BY_TOKEN_ID,
+    FILTER_BY_ITEM_ID,
+    FILTER_BY_NETWORK,
+    FILTER_BY_STATUS,
+    FILTER_NOT_EXPIRED
+  ])
+
+  return SQL`SELECT COUNT(*) as count`
+    .append(SQL` FROM `)
+    .append(BID_TRADES)
+    .append(SQL` NATURAL FULL OUTER JOIN `)
+    .append(LEGACY_BIDS)
+    .append(FILTERS)
 }

--- a/src/ports/bids/types.ts
+++ b/src/ports/bids/types.ts
@@ -2,10 +2,8 @@ import { ChainId, Network, Bid, ListingStatus, GetBidsParameters } from '@dcl/sc
 import { SquidNetwork } from '../../types'
 
 export type IBidsComponent = {
-  getBids(options: GetBidsParameters): Promise<{ data: Bid[]; count: number }>
+  getBids(options: GetBidsParameters): Promise<{ data: Bid[]; total: number }>
 }
-
-export type WithCount<T> = T & { bids_count: number }
 
 export type DBNetwork = SquidNetwork | Network.ETHEREUM | Network.MATIC
 
@@ -38,4 +36,4 @@ export type DBLegacyBid = DBBaseBid & {
   trade_id: null // This is to correctly identify the type
 }
 
-export type DBBid = WithCount<DBTradeBid | DBLegacyBid>
+export type DBBid = DBTradeBid | DBLegacyBid

--- a/src/ports/sales/component.ts
+++ b/src/ports/sales/component.ts
@@ -1,18 +1,21 @@
 import { SaleFilters } from '@dcl/schemas'
 import { fromDBSaleToSale } from '../../adapters/sales'
 import { AppComponents } from '../../types'
-import { getSalesQuery } from './queries'
+import { extractCount } from '../pagination'
+import { getSalesCountQuery, getSalesQuery } from './queries'
 import { DBSale, ISalesComponent } from './types'
 
 export function createSalesComponents(components: Pick<AppComponents, 'dappsDatabase'>): ISalesComponent {
   const { dappsDatabase: database } = components
 
   async function getSales(filters: SaleFilters) {
-    const salesQuery = getSalesQuery(filters)
-    const sales = await database.query<DBSale>(salesQuery)
+    const [sales, count] = await Promise.all([
+      database.query<DBSale>(getSalesQuery(filters)),
+      database.query<{ count: string }>(getSalesCountQuery(filters))
+    ])
     return {
       data: sales.rows.map(fromDBSaleToSale),
-      total: sales.rowCount > 0 ? Number(sales.rows[0].sales_count) : 0
+      total: extractCount(count)
     }
   }
 

--- a/src/ports/sales/queries.ts
+++ b/src/ports/sales/queries.ts
@@ -84,7 +84,5 @@ export function getSalesQuery(filters: SaleFilters = {}) {
 export function getSalesCountQuery(filters: SaleFilters = {}) {
   const LEGACY_SALES = SQL`(`.append(getLegacySalesQuery(filters)).append(SQL` ) as legacy_sales `)
 
-  return SQL`SELECT COUNT(*) as count`
-    .append(SQL` FROM `)
-    .append(LEGACY_SALES)
+  return SQL`SELECT COUNT(*) as count`.append(SQL` FROM `).append(LEGACY_SALES)
 }

--- a/src/ports/sales/queries.ts
+++ b/src/ports/sales/queries.ts
@@ -2,16 +2,8 @@ import SQL, { SQLStatement } from 'sql-template-strings'
 import { SaleFilters, SaleSortBy } from '@dcl/schemas'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getDBNetworks } from '../../utils'
+import { getLimitAndOffsetStatement } from '../pagination'
 import { getWhereStatementFromFilters } from '../utils'
-
-const DEFAULT_LIMIT = 100
-
-function getSalesLimitAndOffsetStatement(filters: SaleFilters) {
-  const limit = filters?.first ? filters.first : DEFAULT_LIMIT
-  const offset = filters?.skip ? filters.skip : 0
-
-  return SQL` LIMIT ${limit} OFFSET ${offset} `
-}
 
 function getSalesSortByStatement(sortBy?: SaleSortBy) {
   switch (sortBy) {
@@ -82,9 +74,17 @@ function getLegacySalesQuery(filters: SaleFilters): SQLStatement {
 export function getSalesQuery(filters: SaleFilters = {}) {
   const LEGACY_SALES = SQL`(`.append(getLegacySalesQuery(filters)).append(SQL` ) as legacy_sales `)
 
-  return SQL`SELECT *, COUNT(*) OVER() as sales_count`
+  return SQL`SELECT *`
     .append(SQL` FROM `)
     .append(LEGACY_SALES)
     .append(getSalesSortByStatement(filters.sortBy))
-    .append(getSalesLimitAndOffsetStatement(filters))
+    .append(getLimitAndOffsetStatement(filters, { defaultLimit: 100 }))
+}
+
+export function getSalesCountQuery(filters: SaleFilters = {}) {
+  const LEGACY_SALES = SQL`(`.append(getLegacySalesQuery(filters)).append(SQL` ) as legacy_sales `)
+
+  return SQL`SELECT COUNT(*) as count`
+    .append(SQL` FROM `)
+    .append(LEGACY_SALES)
 }

--- a/src/ports/sales/types.ts
+++ b/src/ports/sales/types.ts
@@ -11,7 +11,6 @@ export type GetSalesResponse = {
 }
 
 export type DBSale = {
-  sales_count: number
   id: string
   type: SaleType
   buyer: string

--- a/test/unit/bids-adapters.spec.ts
+++ b/test/unit/bids-adapters.spec.ts
@@ -1,16 +1,15 @@
 import { ChainId, ListingStatus, Network } from '@dcl/schemas'
 import { fromDBBidToBid, fromDBNetworkToNetwork, getChainIdFromDBBid } from '../../src/adapters/bids/bids'
-import { DBBid, DBLegacyBid, DBTradeBid, WithCount } from '../../src/ports/bids'
+import { DBBid, DBLegacyBid, DBTradeBid } from '../../src/ports/bids'
 import { SquidNetwork } from '../../src/types'
 
 describe('when adapting a db bid to a bid', () => {
   describe('and it is a bid trade', () => {
-    let dbBid: WithCount<DBTradeBid>
+    let dbBid: DBTradeBid
 
     describe('and the bid is for an nft', () => {
       beforeEach(() => {
         dbBid = {
-          bids_count: 10,
           trade_id: '1',
           trade_contract_address: '0x1',
           price: '10',
@@ -57,7 +56,6 @@ describe('when adapting a db bid to a bid', () => {
       beforeEach(() => {
         dbBid = {
           trade_contract_address: '0x1',
-          bids_count: 10,
           trade_id: '1',
           price: '10',
           token_id: null,
@@ -101,11 +99,10 @@ describe('when adapting a db bid to a bid', () => {
   })
 
   describe('and it is a legacy bid', () => {
-    let dbBid: WithCount<DBLegacyBid>
+    let dbBid: DBLegacyBid
 
     beforeEach(() => {
       dbBid = {
-        bids_count: 10,
         trade_id: null,
         price: '10',
         token_id: 'token-id',

--- a/test/unit/bids-component.spec.ts
+++ b/test/unit/bids-component.spec.ts
@@ -16,12 +16,14 @@ describe('when fetching bids', () => {
   describe('and there are no bids for the specified filters', () => {
     beforeEach(() => {
       pgComponent = createTestPgComponent()
-      ;(pgComponent.query as jest.Mock).mockResolvedValue({ rows: [], count: 0 })
+      ;(pgComponent.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ count: '0' }] })
       bidsComponent = createBidsComponents({ dappsDatabase: pgComponent })
     })
 
-    it('should return empty data with 0 count', async () => {
-      expect(await bidsComponent.getBids({ limit: 10, offset: 0 })).toEqual({ data: [], count: 0 })
+    it('should return empty data with 0 total', async () => {
+      expect(await bidsComponent.getBids({ limit: 10, offset: 0 })).toEqual({ data: [], total: 0 })
     })
   })
 
@@ -32,7 +34,6 @@ describe('when fetching bids', () => {
       bids = [
         {
           trade_contract_address: '0x1',
-          bids_count: 10,
           trade_id: '1',
           price: '10',
           token_id: '1',
@@ -50,12 +51,14 @@ describe('when fetching bids', () => {
         }
       ]
       pgComponent = createTestPgComponent()
-      ;(pgComponent.query as jest.Mock).mockResolvedValue({ rows: bids, count: 1 })
+      ;(pgComponent.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: bids })
+        .mockResolvedValueOnce({ rows: [{ count: '10' }] })
       bidsComponent = createBidsComponents({ dappsDatabase: pgComponent })
     })
 
-    it('should return the bids with the count', async () => {
-      expect(await bidsComponent.getBids({ limit: 1, offset: 0 })).toEqual({ data: [fromDBBidToBid(bids[0])], count: bids[0].bids_count })
+    it('should return the bids with the total', async () => {
+      expect(await bidsComponent.getBids({ limit: 1, offset: 0 })).toEqual({ data: [fromDBBidToBid(bids[0])], total: 10 })
     })
   })
 })

--- a/test/unit/bids-component.spec.ts
+++ b/test/unit/bids-component.spec.ts
@@ -16,9 +16,7 @@ describe('when fetching bids', () => {
   describe('and there are no bids for the specified filters', () => {
     beforeEach(() => {
       pgComponent = createTestPgComponent()
-      ;(pgComponent.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: [] })
-        .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      ;(pgComponent.query as jest.Mock).mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [{ count: '0' }] })
       bidsComponent = createBidsComponents({ dappsDatabase: pgComponent })
     })
 
@@ -51,9 +49,7 @@ describe('when fetching bids', () => {
         }
       ]
       pgComponent = createTestPgComponent()
-      ;(pgComponent.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: bids })
-        .mockResolvedValueOnce({ rows: [{ count: '10' }] })
+      ;(pgComponent.query as jest.Mock).mockResolvedValueOnce({ rows: bids }).mockResolvedValueOnce({ rows: [{ count: '10' }] })
       bidsComponent = createBidsComponents({ dappsDatabase: pgComponent })
     })
 

--- a/test/unit/bids-handler.spec.ts
+++ b/test/unit/bids-handler.spec.ts
@@ -32,7 +32,7 @@ describe('when fetching bids', () => {
       }
     ]
 
-    getBidsMock = jest.fn().mockResolvedValue({ data: bids, count: 1 })
+    getBidsMock = jest.fn().mockResolvedValue({ data: bids, total: 1 })
 
     context = {
       url: new URL('http://localhost:3000/v1/bids'),

--- a/test/unit/bids-queries.spec.ts
+++ b/test/unit/bids-queries.spec.ts
@@ -1,5 +1,5 @@
 import { Network, ChainId, ListingStatus } from '@dcl/schemas'
-import { getBidsQuery } from '../../src/ports/bids/queries'
+import { getBidsCountQuery, getBidsQuery } from '../../src/ports/bids/queries'
 import { SquidNetwork } from '../../src/types'
 
 jest.mock('../../src/logic/chainIds', () => ({
@@ -80,6 +80,53 @@ describe('when querying for bids', () => {
   describe('and the status is defined', () => {
     it('should add the filter to the query', () => {
       const query = getBidsQuery({ status: ListingStatus.OPEN })
+      expect(query.text).toContain('status = $1')
+      expect(query.values).toEqual(expect.arrayContaining(['open']))
+    })
+  })
+})
+
+describe('when querying for bids count', () => {
+  it('should select COUNT(*) as count', () => {
+    const query = getBidsCountQuery({})
+    expect(query.text).toContain('SELECT COUNT(*) as count')
+  })
+
+  it('should not include pagination', () => {
+    const query = getBidsCountQuery({ limit: 10, offset: 5 })
+    expect(query.text).not.toContain('LIMIT')
+    expect(query.text).not.toContain('OFFSET')
+  })
+
+  it('should not include sorting', () => {
+    const query = getBidsCountQuery({ sortBy: 'recently_offered' as any })
+    expect(query.text).not.toContain('ORDER BY')
+  })
+
+  it('should only query the ones not expired', () => {
+    const query = getBidsCountQuery({})
+    expect(query.text).toContain('expires_at > now()::timestamptz(3)')
+  })
+
+  describe('and the bidder filter is defined', () => {
+    it('should add the filter to the count query', () => {
+      const query = getBidsCountQuery({ bidder: '0x1' })
+      expect(query.text).toContain('LOWER(bidder) = LOWER($1)')
+      expect(query.values).toEqual(expect.arrayContaining(['0x1']))
+    })
+  })
+
+  describe('and the network is defined', () => {
+    it('should add the filter to the count query', () => {
+      const query = getBidsCountQuery({ network: Network.MATIC })
+      expect(query.text).toContain('network = ANY')
+      expect(query.values).toEqual(expect.arrayContaining([[Network.MATIC, SquidNetwork.POLYGON]]))
+    })
+  })
+
+  describe('and the status is defined', () => {
+    it('should add the filter to the count query', () => {
+      const query = getBidsCountQuery({ status: ListingStatus.OPEN })
       expect(query.text).toContain('status = $1')
       expect(query.values).toEqual(expect.arrayContaining(['open']))
     })

--- a/test/unit/bids-queries.spec.ts
+++ b/test/unit/bids-queries.spec.ts
@@ -99,7 +99,7 @@ describe('when querying for bids count', () => {
   })
 
   it('should not include sorting', () => {
-    const query = getBidsCountQuery({ sortBy: 'recently_offered' as any })
+    const query = getBidsCountQuery({})
     expect(query.text).not.toContain('ORDER BY')
   })
 

--- a/test/unit/sales-queries.spec.ts
+++ b/test/unit/sales-queries.spec.ts
@@ -1,0 +1,55 @@
+import { Network } from '@dcl/schemas'
+import { getSalesCountQuery, getSalesQuery } from '../../src/ports/sales/queries'
+
+describe('getSalesQuery', () => {
+  describe('when no filters are provided', () => {
+    it('should not include COUNT(*) OVER()', () => {
+      const query = getSalesQuery({})
+      expect(query.text).not.toContain('COUNT(*) OVER()')
+    })
+
+    it('should include pagination', () => {
+      const query = getSalesQuery({})
+      expect(query.text).toContain('LIMIT')
+      expect(query.text).toContain('OFFSET')
+    })
+
+    it('should include sorting', () => {
+      const query = getSalesQuery({})
+      expect(query.text).toContain('ORDER BY')
+    })
+  })
+})
+
+describe('getSalesCountQuery', () => {
+  describe('when no filters are provided', () => {
+    it('should select COUNT(*) as count', () => {
+      const query = getSalesCountQuery({})
+      expect(query.text).toContain('SELECT COUNT(*) as count')
+    })
+
+    it('should not include pagination', () => {
+      const query = getSalesCountQuery({})
+      expect(query.text).not.toContain('LIMIT')
+      expect(query.text).not.toContain('OFFSET')
+    })
+
+    it('should not include sorting', () => {
+      const query = getSalesCountQuery({})
+      expect(query.text).not.toContain('ORDER BY')
+    })
+  })
+
+  describe('when filters are provided', () => {
+    it('should apply the same filters as the data query', () => {
+      const filters = { buyer: '0x123', network: Network.MATIC }
+      const dataQuery = getSalesQuery(filters)
+      const countQuery = getSalesCountQuery(filters)
+
+      expect(countQuery.text).toContain('buyer =')
+      expect(countQuery.text).toContain('network = ANY')
+      expect(dataQuery.text).toContain('buyer =')
+      expect(dataQuery.text).toContain('network = ANY')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Sales and bids used `COUNT(*) OVER()` as a window function embedded in the data query, forcing PostgreSQL to scan all matching rows before applying LIMIT. This is slower than a dedicated `COUNT(*)` query that only needs to count, especially on large result sets.

Both domains now follow the standardized pattern introduced in PR #328:
- **Separate count query** (`getSalesCountQuery`, `getBidsCountQuery`) executed in parallel via `Promise.all`
- **Shared `extractCount` utility** for defensive count parsing
- **Shared `getLimitAndOffsetStatement`** replacing the local sales limit/offset helper

### Sales
- Added `getSalesCountQuery()` that reuses the same legacy sales subquery with filters but only selects `COUNT(*)`
- Removed `COUNT(*) OVER() as sales_count` from `getSalesQuery`
- Removed `sales_count` from `DBSale` type — the data rows no longer carry count metadata

### Bids
- Added `getBidsCountQuery()` with the same NATURAL FULL OUTER JOIN and filters as the data query
- Removed `COUNT(*) OVER() as bids_count` from `getBidsQuery`
- Removed `WithCount<T>` wrapper type — `DBBid` is now just `DBTradeBid | DBLegacyBid` without the count column baked in
- Changed `IBidsComponent` return type from `{ data: Bid[]; count: number }` to `{ data: Bid[]; total: number }` for consistency with all other domains
- Updated `bids-handler.ts` to destructure `{ data, total }` instead of `{ data, count }`

## Test plan

- [x] `npx tsc --noEmit` passes cleanly
- [x] bids-handler (19 tests) and bids-queries (12 tests) pass
- [x] Pre-existing bids adapter type narrowing issue (unrelated) confirmed on main branch

Depends on #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)