### PR TITLE
refactor: clean up NFTs count extraction and simplify orders count query

### DIFF
--- a/src/ports/nfts/component.ts
+++ b/src/ports/nfts/component.ts
@@ -77,7 +77,8 @@ export function createNFTsComponent(components: Pick<AppComponents, 'dappsDataba
 
       return {
         data: fromNFTsAndOrdersToNFTsResult(nfts.rows, orders.rows, listings || rentalListings),
-        total: total ? Number(total.rows[0]?.total) ?? 0 : nfts.rowCount > 0 ? Number(nfts.rows[0].count) : 0
+        // ENS uses a separate count query; other categories use COUNT(*) OVER() in the data query
+        total: total ? Number(total.rows[0]?.total ?? 0) : nfts.rowCount > 0 ? Number(nfts.rows[0].count) : 0
       }
     } catch (error) {
       if ((error as Error).message === 'Query read timeout') {

--- a/src/ports/nfts/queries.ts
+++ b/src/ports/nfts/queries.ts
@@ -4,6 +4,7 @@ import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getDBNetworks } from '../../utils'
 import { getTradesCTE, MAX_ORDER_TIMESTAMP } from '../catalog/queries'
 import { ItemType } from '../items'
+import { getLimitAndOffsetStatement } from '../pagination'
 import { getWhereStatementFromFilters } from '../utils'
 import { getENSs } from './ensQueries'
 import { getAllLANDsQuery, getLandsOnSaleQuery } from './landQueries'
@@ -200,10 +201,7 @@ function getParcelEstateDataCTE(filters: GetNFTsFilters): SQLStatement {
 }
 
 export function getNFTLimitAndOffsetStatement(nftFilters?: GetNFTsFilters) {
-  const limit = nftFilters?.first ? nftFilters.first : 100
-  const offset = nftFilters?.skip ? nftFilters.skip : 0
-
-  return SQL` LIMIT ${limit} OFFSET ${offset} `
+  return getLimitAndOffsetStatement(nftFilters ?? {}, { defaultLimit: 100 })
 }
 
 export function getNFTsSortByStatement(sortBy?: NFTSortBy) {

--- a/src/ports/orders/component.ts
+++ b/src/ports/orders/component.ts
@@ -1,6 +1,7 @@
 import { OrderFilters } from '@dcl/schemas'
 import { fromDBOrderToOrder } from '../../adapters/orders'
 import { AppComponents } from '../../types'
+import { extractCount } from '../pagination'
 import { getOrdersCountQuery, getOrdersQuery } from './queries'
 import { IOrdersComponent, DBOrder } from './types'
 
@@ -10,9 +11,9 @@ export function createOrdersComponent(components: Pick<AppComponents, 'dappsData
   async function getOrders(filters: OrderFilters) {
     const [orders, count] = await Promise.all([
       pg.query<DBOrder>(getOrdersQuery(filters)),
-      pg.query<{ count: number }>(getOrdersCountQuery(filters))
+      pg.query<{ count: string }>(getOrdersCountQuery(filters))
     ])
-    return { data: orders.rows.map(fromDBOrderToOrder), total: count.rows[0].count }
+    return { data: orders.rows.map(fromDBOrderToOrder), total: extractCount(count) }
   }
 
   return {

--- a/src/ports/orders/queries.ts
+++ b/src/ports/orders/queries.ts
@@ -3,6 +3,7 @@ import { OrderFilters, OrderSortBy } from '@dcl/schemas'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getDBNetworks } from '../../utils'
 import { getTradesCTE } from '../catalog/queries'
+import { getLimitAndOffsetStatement } from '../pagination'
 import { getWhereStatementFromFilters } from '../utils'
 
 function getOrdersSortByStatement(filters: OrderFilters): SQLStatement {
@@ -25,10 +26,7 @@ function getOrdersSortByStatement(filters: OrderFilters): SQLStatement {
 }
 
 function getOrdersLimitAndOffsetStatement(filters: OrderFilters) {
-  const limit = filters?.first ? filters.first : 1000
-  const offset = filters?.skip ? filters.skip : 0
-
-  return SQL` LIMIT ${limit} OFFSET ${offset} `
+  return getLimitAndOffsetStatement(filters)
 }
 
 function getInnerOrdersLimitAndOffsetStatement(filters: OrderFilters) {
@@ -145,14 +143,14 @@ export function getOrderAndTradeQueries(filters: OrderFilters & { nftIds?: strin
   }
   const commonQueryParts = getOrdersSortByStatement(filters).append(getInnerOrdersLimitAndOffsetStatement(filters))
 
-  const orderTradesQuery = SQL`SELECT *, COUNT(*) OVER() as count `
+  const orderTradesQuery = SQL`SELECT * `
     .append(SQL`FROM (`)
     .append(getTradesOrdersQuery(filters))
     .append(SQL`) as order_trades`)
     .append(getWhereStatementFromFilters(tradesFilters))
     .append(commonQueryParts)
 
-  const legacyOrdersQuery = SQL`SELECT *, COUNT(*) OVER() as count `
+  const legacyOrdersQuery = SQL`SELECT * `
     .append(SQL`FROM (`)
     .append(getLegacyOrdersQuery())
     .append(getWhereStatementFromFilters(ordersFilters))
@@ -197,55 +195,30 @@ export function getOrdersQuery(filters: OrderFilters & { nftIds?: string[] }, pr
 export function getOrdersCountQuery(filters: OrderFilters & { nftIds?: string[] }): SQLStatement {
   const { orders: ordersFilters, trades: tradesFilters } = getOrdersAndTradesFilters(filters)
 
+  if (filters.tokenId) {
+    ordersFilters.push(SQL` nft.token_id = ${filters.tokenId} `)
+    tradesFilters.push(SQL` token_id = ${filters.tokenId} `)
+  }
+
   return getTradesCTE({ first: filters.first, skip: filters.skip }).append(
     SQL`
-    ,aggregated_counts AS (
-      SELECT 
-        SUM(COALESCE(trades_count, 0)) AS total_trades,
-        SUM(COALESCE(orders_count, 0)) AS total_orders
-      FROM (
-        -- Trades Count
-        SELECT COUNT(*) AS trades_count, 
-               NULL::bigint AS orders_count
-        FROM (
-          SELECT *, 
-                 COUNT(*) OVER() AS trades_count
-          FROM (
-            `
+    SELECT (
+      SELECT COUNT(*) FROM (
+        `
       .append(getTradesOrdersQuery(filters))
+      .append(SQL`) as trades_filtered`)
+      .append(getWhereStatementFromFilters(tradesFilters))
       .append(
         SQL`
-          ) AS trades_filtered
-          `
-          .append(getWhereStatementFromFilters(tradesFilters))
+    ) + (
+      SELECT COUNT(*) FROM `
+          .append(MARKETPLACE_SQUID_SCHEMA)
           .append(
-            SQL`
-        ) AS trades_final
-        
-        UNION ALL
-        
-        -- Orders Count
-        SELECT NULL::bigint AS trades_count, 
-               COUNT(*) AS orders_count
-        FROM (
-          SELECT id
-          FROM `
-              .append(MARKETPLACE_SQUID_SCHEMA)
-              .append(
-                SQL`."order" as ord
-          `.append(getWhereStatementFromFilters(ordersFilters)).append(SQL`
-        ) AS orders_filtered
-      ) AS counts_combined
-    )
-    SELECT *,
-           (SELECT total_trades + total_orders FROM aggregated_counts) AS count
-    FROM (
-      SELECT *
-      FROM   aggregated_counts
-    ) AS combined_counts
-  `)
-              )
+            SQL`."order" as ord
+      `
+              .append(getWhereStatementFromFilters(ordersFilters))
           )
       )
+      .append(SQL`) as count`)
   )
 }

--- a/src/ports/orders/queries.ts
+++ b/src/ports/orders/queries.ts
@@ -215,8 +215,7 @@ export function getOrdersCountQuery(filters: OrderFilters & { nftIds?: string[] 
           .append(MARKETPLACE_SQUID_SCHEMA)
           .append(
             SQL`."order" as ord
-      `
-              .append(getWhereStatementFromFilters(ordersFilters))
+      `.append(getWhereStatementFromFilters(ordersFilters))
           )
       )
       .append(SQL`) as count`)

--- a/src/ports/orders/types.ts
+++ b/src/ports/orders/types.ts
@@ -7,7 +7,6 @@ export type IOrdersComponent = {
 
 export type DBOrder = {
   id: string
-  count: number
   marketplace_address: string
   category: NFTCategory
   nft_address: string

--- a/test/unit/nfts-adapters.spec.ts
+++ b/test/unit/nfts-adapters.spec.ts
@@ -394,7 +394,6 @@ describe('fromNFTsAndOrdersToNFTsResult', () => {
     const orders: DBOrder[] = [
       {
         id: '1',
-        count: 1,
         marketplace_address: '0xabc123',
         category: NFTCategory.WEARABLE,
         nft_address: '0x123abc',
@@ -414,7 +413,6 @@ describe('fromNFTsAndOrdersToNFTsResult', () => {
       },
       {
         id: '2',
-        count: 1,
         marketplace_address: '0xdef456',
         category: NFTCategory.PARCEL,
         nft_address: '0x456def',

--- a/test/unit/orders-adapters.spec.ts
+++ b/test/unit/orders-adapters.spec.ts
@@ -21,7 +21,6 @@ describe('fromDBOrderToOrder', () => {
       network: SquidNetwork.ETHEREUM,
       issued_id: 'abc123',
       trade_id: 'def456',
-      count: 1,
       category: NFTCategory.ENS,
       item_id: 'ghi789',
       nft_id: 'jkl012'

--- a/test/unit/orders-queries.spec.ts
+++ b/test/unit/orders-queries.spec.ts
@@ -1,0 +1,74 @@
+import { ChainId, ListingStatus, Network } from '@dcl/schemas'
+import { getOrdersCountQuery, getOrdersQuery } from '../../src/ports/orders/queries'
+
+jest.mock('../../src/logic/chainIds', () => ({
+  getEthereumChainId: () => ChainId.ETHEREUM_SEPOLIA,
+  getPolygonChainId: () => ChainId.MATIC_AMOY
+}))
+
+describe('getOrdersQuery', () => {
+  describe('when no filters are provided', () => {
+    it('should not include COUNT(*) OVER() in inner queries', () => {
+      const query = getOrdersQuery({})
+      expect(query.text).not.toContain('COUNT(*) OVER()')
+    })
+
+    it('should include pagination', () => {
+      const query = getOrdersQuery({})
+      expect(query.text).toContain('LIMIT')
+      expect(query.text).toContain('OFFSET')
+    })
+  })
+})
+
+describe('getOrdersCountQuery', () => {
+  describe('when no filters are provided', () => {
+    it('should sum counts from both trades and legacy orders', () => {
+      const query = getOrdersCountQuery({})
+      expect(query.text).toContain('SELECT (')
+      expect(query.text).toContain('SELECT COUNT(*) FROM (')
+      expect(query.text).toContain(') + (')
+      expect(query.text).toContain('as count')
+    })
+
+    it('should not include pagination', () => {
+      const query = getOrdersCountQuery({})
+      const afterCount = query.text.split('as count')[0]
+      expect(afterCount).not.toMatch(/LIMIT \$\d/)
+    })
+
+    it('should not include ORDER BY', () => {
+      const query = getOrdersCountQuery({})
+      expect(query.text).not.toContain('ORDER BY')
+    })
+  })
+
+  describe('when the network filter is provided', () => {
+    it('should apply the network filter', () => {
+      const query = getOrdersCountQuery({ network: Network.MATIC })
+      expect(query.text).toContain('network = ANY')
+    })
+  })
+
+  describe('when the owner filter is provided', () => {
+    it('should apply the owner filter', () => {
+      const query = getOrdersCountQuery({ owner: '0x123' })
+      expect(query.text).toContain('LOWER(owner) = LOWER')
+    })
+  })
+
+  describe('when the status filter is provided', () => {
+    it('should apply the status filter', () => {
+      const query = getOrdersCountQuery({ status: ListingStatus.OPEN })
+      expect(query.text).toContain('status =')
+    })
+  })
+
+  describe('when the tokenId filter is provided', () => {
+    it('should apply the tokenId filter to both trades and orders', () => {
+      const query = getOrdersCountQuery({ tokenId: '123' })
+      expect(query.text).toContain('nft.token_id =')
+      expect(query.text).toContain('token_id =')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Two high-risk domains cleaned up in a single PR since they don't overlap.

### NFTs

- Replaced the local `getNFTLimitAndOffsetStatement` body with a delegate to the shared `getLimitAndOffsetStatement` utility (keeping the function signature since it's imported by `ensQueries.ts` and `landQueries.ts`)
- Fixed operator precedence bug in count extraction: `Number(total.rows[0]?.total) ?? 0` — `Number()` never returns `null`/`undefined`, so the `??` fallback was dead code. Changed to `Number(total.rows[0]?.total ?? 0)`
- NFTs intentionally keep `COUNT(*) OVER()` for non-ENS categories since creating separate count queries for LAND/estate/recently-listed would be a large effort with high regression risk

### Orders

The `getOrdersCountQuery` was a 55-line deeply nested monster: a CTE wrapping `COUNT(*) OVER()` inside inner queries, then `UNION ALL`, then `aggregated_counts` CTE summing the results, then a final SELECT from the aggregated CTE. Replaced with a straightforward:

```sql
SELECT (SELECT COUNT(*) FROM (trades_subquery) t) +
       (SELECT COUNT(*) FROM legacy_orders_subquery) AS count
```

Additional fixes:
- Added the missing `tokenId` filter to the count query — it was being applied in `getOrderAndTradeQueries` (data query) but not in `getOrdersCountQuery`, causing count mismatches when filtering by tokenId
- Removed `COUNT(*) OVER() as count` from the inner queries in `getOrderAndTradeQueries` since count is now handled by the separate query
- Removed `count` from `DBOrder` type
- Component uses `extractCount` for consistent count parsing

## Test plan

- [x] `npx tsc --noEmit` passes cleanly
- [x] nfts-handler, nfts-adapters, orders-adapters tests all pass (12 tests)

Depends on #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)