### PR TITLE
feat: validate trade signature length is 132 characters

### DIFF
--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -66,7 +66,7 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
       throw new InvalidTradeSignatureError()
     }
 
-    // vaidate signature
+    // validate signature
     if (!validateTradeSignature(trade, signer)) {
       throw new InvalidTradeSignatureError()
     }

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -61,6 +61,11 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
       throw new InvalidEstateTrade()
     }
 
+    // validate signature length (0x + 130 hex chars for a standard ECDSA signature)
+    if (trade.signature.length !== 132) {
+      throw new InvalidTradeSignatureError()
+    }
+
     // vaidate signature
     if (!validateTradeSignature(trade, signer)) {
       throw new InvalidTradeSignatureError()

--- a/test/unit/trades-component.spec.ts
+++ b/test/unit/trades-component.spec.ts
@@ -152,6 +152,16 @@ describe('when adding a new trade', () => {
     })
   })
 
+  describe('when the trade signature length is not 132 characters', () => {
+    beforeEach(() => {
+      mockTrade.signature = '0xshort'
+    })
+
+    it('should throw an InvalidTradeSignatureError', async () => {
+      await expect(tradesComponent.addTrade(mockTrade, mockSigner)).rejects.toThrow(new InvalidTradeSignatureError())
+    })
+  })
+
   describe('when the trade signature is invalid', () => {
     beforeEach(() => {
       jest.spyOn(signatureUtils, 'validateTradeSignature').mockReturnValue(false)

--- a/test/unit/trades-component.spec.ts
+++ b/test/unit/trades-component.spec.ts
@@ -155,6 +155,8 @@ describe('when adding a new trade', () => {
   describe('when the trade signature length is not 132 characters', () => {
     beforeEach(() => {
       mockTrade.signature = '0xshort'
+      jest.spyOn(utils, 'validateTradeByType').mockResolvedValue(true)
+      jest.spyOn(utils, 'isValidEstateTrade').mockResolvedValueOnce(true)
     })
 
     it('should throw an InvalidTradeSignatureError', async () => {


### PR DESCRIPTION
## Summary

Adds an explicit length check on `trade.signature` in `addTrade` before the ECDSA signature verification step.

## Why

A valid ECDSA signature is always 65 bytes, which serializes to `0x` + 130 hex characters = 132 characters. Anything else cannot be a well-formed signature. Previously, a malformed signature would fall through to `validateTradeSignature`, where the underlying ECDSA recovery would either throw a less descriptive error or silently recover an unexpected address. Rejecting it up front makes the failure mode explicit and avoids doing heavier cryptographic work on input we already know is invalid.

## How

- In `src/ports/trades/component.ts`, added a length guard immediately before the existing `validateTradeSignature` call that throws `InvalidTradeSignatureError` when `trade.signature.length !== 132`. Reusing the existing error keeps the public API surface unchanged — callers still only need to handle one signature-related error for this endpoint.
- The check is placed after structural/estate validations (so those still run first and give more specific feedback when applicable) and before the cryptographic recovery (so we short-circuit the expensive path).
- Added a unit test case in `test/unit/trades-component.spec.ts` covering a trade with a too-short signature, asserting `InvalidTradeSignatureError` is thrown.

## Test plan

- [ ] `npm test -- test/unit/trades-component.spec.ts` passes locally (note: `main` currently has unrelated TS errors in `src/adapters/bids/bids.ts` that block the suite from compiling; those need to be resolved separately)
- [ ] Manually verify that submitting a trade with a signature shorter or longer than 132 characters returns an invalid-signature error
- [ ] Manually verify that a trade with a correctly-formed 132-character signature continues to reach the ECDSA verification step