### PR TITLE
feat: add /v1/activity endpoint aggregating user sales, bids, orders and trades

### DIFF
--- a/src/adapters/activity/index.ts
+++ b/src/adapters/activity/index.ts
@@ -27,6 +27,9 @@ function toSaleEvent<T extends ActivityEventType.SALE_BUYER | ActivityEventType.
   type: T,
   counterparty: string
 ): T extends ActivityEventType.SALE_BUYER ? SaleBuyerEvent : SaleSellerEvent {
+  // `as never` is the standard TS escape hatch for conditional return types: the
+  // narrowing TS does on the call site (returns SaleBuyerEvent when T=SALE_BUYER) can't be
+  // proven from inside the function body. The shape is identical for both branches.
   return {
     id: `${type}:${sale.id}`,
     type,
@@ -50,6 +53,7 @@ function toBidEvent<T extends ActivityEventType.BID_PLACED | ActivityEventType.B
   type: T,
   counterparty: string
 ): T extends ActivityEventType.BID_PLACED ? BidPlacedEvent : BidReceivedEvent {
+  // See `toSaleEvent` for the rationale on `as never` with a conditional return type.
   return {
     id: `${type}:${bid.id}`,
     type,

--- a/src/adapters/activity/index.ts
+++ b/src/adapters/activity/index.ts
@@ -1,0 +1,148 @@
+import { Bid, ListingStatus, Order, Sale, Trade, TradeAssetType } from '@dcl/schemas'
+import {
+  ActivityEvent,
+  ActivityEventType,
+  BidPlacedEvent,
+  BidReceivedEvent,
+  OrderCreatedEvent,
+  OrderFilledEvent,
+  SaleBuyerEvent,
+  SaleSellerEvent,
+  TradeCreatedEvent
+} from '../../ports/activity/types'
+
+function pickTokenOrItem(b: Bid): { tokenId?: string; itemId?: string } {
+  if ('tokenId' in b && b.tokenId) return { tokenId: b.tokenId }
+  if ('itemId' in b && b.itemId) return { itemId: b.itemId }
+  return {}
+}
+
+export function toSaleBuyerEvent(sale: Sale): SaleBuyerEvent {
+  return {
+    id: `sale:${sale.id}`,
+    type: ActivityEventType.SALE_BUYER,
+    timestamp: sale.timestamp,
+    network: sale.network,
+    txHash: sale.txHash,
+    contractAddress: sale.contractAddress,
+    tokenId: sale.tokenId,
+    itemId: sale.itemId ?? undefined,
+    price: sale.price,
+    counterparty: sale.seller,
+    details: { sale }
+  }
+}
+
+export function toSaleSellerEvent(sale: Sale): SaleSellerEvent {
+  return {
+    id: `sale:${sale.id}`,
+    type: ActivityEventType.SALE_SELLER,
+    timestamp: sale.timestamp,
+    network: sale.network,
+    txHash: sale.txHash,
+    contractAddress: sale.contractAddress,
+    tokenId: sale.tokenId,
+    itemId: sale.itemId ?? undefined,
+    price: sale.price,
+    counterparty: sale.buyer,
+    details: { sale }
+  }
+}
+
+export function toBidPlacedEvent(bid: Bid): BidPlacedEvent {
+  return {
+    id: `bid:${bid.id}`,
+    type: ActivityEventType.BID_PLACED,
+    timestamp: bid.createdAt,
+    network: bid.network,
+    contractAddress: bid.contractAddress,
+    ...pickTokenOrItem(bid),
+    price: bid.price,
+    counterparty: bid.seller,
+    details: { bid }
+  }
+}
+
+export function toBidReceivedEvent(bid: Bid): BidReceivedEvent {
+  return {
+    id: `bid:${bid.id}`,
+    type: ActivityEventType.BID_RECEIVED,
+    timestamp: bid.createdAt,
+    network: bid.network,
+    contractAddress: bid.contractAddress,
+    ...pickTokenOrItem(bid),
+    price: bid.price,
+    counterparty: bid.bidder,
+    details: { bid }
+  }
+}
+
+export function toOrderCreatedEvent(order: Order): OrderCreatedEvent {
+  return {
+    id: `order:${order.id}`,
+    type: ActivityEventType.ORDER_CREATED,
+    timestamp: order.createdAt,
+    network: order.network,
+    contractAddress: order.contractAddress,
+    tokenId: order.tokenId,
+    price: order.price,
+    details: { order }
+  }
+}
+
+export function toOrderFilledEvent(order: Order): OrderFilledEvent {
+  return {
+    id: `order-filled:${order.id}`,
+    type: ActivityEventType.ORDER_FILLED,
+    timestamp: order.updatedAt,
+    network: order.network,
+    contractAddress: order.contractAddress,
+    tokenId: order.tokenId,
+    price: order.price,
+    counterparty: order.owner,
+    details: { order }
+  }
+}
+
+export function toTradeCreatedEvent(trade: Trade): TradeCreatedEvent {
+  const firstNonERC20 = [...trade.sent, ...trade.received].find(a => a.assetType !== TradeAssetType.ERC20)
+  const erc20 = [...trade.sent, ...trade.received].find(a => a.assetType === TradeAssetType.ERC20)
+  return {
+    id: `trade:${trade.id}`,
+    type: ActivityEventType.TRADE_CREATED,
+    timestamp: trade.createdAt,
+    network: trade.network,
+    contractAddress: firstNonERC20?.contractAddress,
+    tokenId: firstNonERC20 && 'tokenId' in firstNonERC20 ? firstNonERC20.tokenId : undefined,
+    itemId: firstNonERC20 && 'itemId' in firstNonERC20 ? firstNonERC20.itemId : undefined,
+    price: erc20 && 'amount' in erc20 ? erc20.amount : undefined,
+    details: { trade }
+  }
+}
+
+export function isOrderFilled(order: Order): boolean {
+  return order.status === ListingStatus.SOLD && !!order.buyer
+}
+
+export function sortByTimestampDesc(events: ActivityEvent[]): ActivityEvent[] {
+  return [...events].sort((a, b) => b.timestamp - a.timestamp)
+}
+
+// Drops server-side duplicates: when the same on-chain event appears in two sources
+// (e.g. an order filled via the new trades pipeline shows up both as a sale and a trade,
+// or `orders.getOrders({ buyer })` returns trade-orders with an empty buyer).
+// Keep the first occurrence in the sorted list — sources are intentionally added in
+// the aggregator in the order we want to win (sales/bids/orders first, trades last).
+export function dedupeEvents(events: ActivityEvent[]): ActivityEvent[] {
+  const seen = new Set<string>()
+  const out: ActivityEvent[] = []
+  for (const ev of events) {
+    const key = ev.txHash
+      ? `tx:${ev.txHash.toLowerCase()}`
+      : `${ev.contractAddress ?? '-'}|${ev.tokenId ?? ev.itemId ?? '-'}|${ev.timestamp}|${ev.type}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(ev)
+  }
+  return out
+}

--- a/src/adapters/activity/index.ts
+++ b/src/adapters/activity/index.ts
@@ -1,4 +1,4 @@
-import { Bid, ListingStatus, Order, Sale, Trade, TradeAssetType } from '@dcl/schemas'
+import { Bid, ListingStatus, Order, Sale, Trade, TradeAsset, TradeAssetType } from '@dcl/schemas'
 import {
   ActivityEvent,
   ActivityEventType,
@@ -11,75 +11,64 @@ import {
   TradeCreatedEvent
 } from '../../ports/activity/types'
 
-function pickTokenOrItem(b: Bid): { tokenId?: string; itemId?: string } {
+const nullToUndefined = <T>(v: T | null | undefined): T | undefined => (v === null ? undefined : v)
+
+const pickTokenOrItem = (b: Bid): { tokenId?: string; itemId?: string } => {
   if ('tokenId' in b && b.tokenId) return { tokenId: b.tokenId }
   if ('itemId' in b && b.itemId) return { itemId: b.itemId }
   return {}
 }
 
-export function toSaleBuyerEvent(sale: Sale): SaleBuyerEvent {
+const isPaymentAsset = (a: TradeAsset): a is TradeAsset & { amount: string } =>
+  a.assetType === TradeAssetType.ERC20 || a.assetType === TradeAssetType.USD_PEGGED_MANA
+
+function toSaleEvent<T extends ActivityEventType.SALE_BUYER | ActivityEventType.SALE_SELLER>(
+  sale: Sale,
+  type: T,
+  counterparty: string
+): T extends ActivityEventType.SALE_BUYER ? SaleBuyerEvent : SaleSellerEvent {
   return {
-    id: `sale:${sale.id}`,
-    type: ActivityEventType.SALE_BUYER,
+    id: `${type}:${sale.id}`,
+    type,
     timestamp: sale.timestamp,
     network: sale.network,
     txHash: sale.txHash,
     contractAddress: sale.contractAddress,
     tokenId: sale.tokenId,
-    itemId: sale.itemId ?? undefined,
+    itemId: nullToUndefined(sale.itemId),
     price: sale.price,
-    counterparty: sale.seller,
+    counterparty,
     details: { sale }
-  }
+  } as never
 }
 
-export function toSaleSellerEvent(sale: Sale): SaleSellerEvent {
-  return {
-    id: `sale:${sale.id}`,
-    type: ActivityEventType.SALE_SELLER,
-    timestamp: sale.timestamp,
-    network: sale.network,
-    txHash: sale.txHash,
-    contractAddress: sale.contractAddress,
-    tokenId: sale.tokenId,
-    itemId: sale.itemId ?? undefined,
-    price: sale.price,
-    counterparty: sale.buyer,
-    details: { sale }
-  }
-}
+export const toSaleBuyerEvent = (sale: Sale): SaleBuyerEvent => toSaleEvent(sale, ActivityEventType.SALE_BUYER, sale.seller)
+export const toSaleSellerEvent = (sale: Sale): SaleSellerEvent => toSaleEvent(sale, ActivityEventType.SALE_SELLER, sale.buyer)
 
-export function toBidPlacedEvent(bid: Bid): BidPlacedEvent {
+function toBidEvent<T extends ActivityEventType.BID_PLACED | ActivityEventType.BID_RECEIVED>(
+  bid: Bid,
+  type: T,
+  counterparty: string
+): T extends ActivityEventType.BID_PLACED ? BidPlacedEvent : BidReceivedEvent {
   return {
-    id: `bid:${bid.id}`,
-    type: ActivityEventType.BID_PLACED,
+    id: `${type}:${bid.id}`,
+    type,
     timestamp: bid.createdAt,
     network: bid.network,
     contractAddress: bid.contractAddress,
     ...pickTokenOrItem(bid),
     price: bid.price,
-    counterparty: bid.seller,
+    counterparty,
     details: { bid }
-  }
+  } as never
 }
 
-export function toBidReceivedEvent(bid: Bid): BidReceivedEvent {
-  return {
-    id: `bid:${bid.id}`,
-    type: ActivityEventType.BID_RECEIVED,
-    timestamp: bid.createdAt,
-    network: bid.network,
-    contractAddress: bid.contractAddress,
-    ...pickTokenOrItem(bid),
-    price: bid.price,
-    counterparty: bid.bidder,
-    details: { bid }
-  }
-}
+export const toBidPlacedEvent = (bid: Bid): BidPlacedEvent => toBidEvent(bid, ActivityEventType.BID_PLACED, bid.seller)
+export const toBidReceivedEvent = (bid: Bid): BidReceivedEvent => toBidEvent(bid, ActivityEventType.BID_RECEIVED, bid.bidder)
 
 export function toOrderCreatedEvent(order: Order): OrderCreatedEvent {
   return {
-    id: `order:${order.id}`,
+    id: `${ActivityEventType.ORDER_CREATED}:${order.id}`,
     type: ActivityEventType.ORDER_CREATED,
     timestamp: order.createdAt,
     network: order.network,
@@ -92,7 +81,7 @@ export function toOrderCreatedEvent(order: Order): OrderCreatedEvent {
 
 export function toOrderFilledEvent(order: Order): OrderFilledEvent {
   return {
-    id: `order-filled:${order.id}`,
+    id: `${ActivityEventType.ORDER_FILLED}:${order.id}`,
     type: ActivityEventType.ORDER_FILLED,
     timestamp: order.updatedAt,
     network: order.network,
@@ -105,40 +94,37 @@ export function toOrderFilledEvent(order: Order): OrderFilledEvent {
 }
 
 export function toTradeCreatedEvent(trade: Trade): TradeCreatedEvent {
-  const firstNonERC20 = [...trade.sent, ...trade.received].find(a => a.assetType !== TradeAssetType.ERC20)
-  const erc20 = [...trade.sent, ...trade.received].find(a => a.assetType === TradeAssetType.ERC20)
+  const assets = [...trade.sent, ...trade.received]
+  const nonPayment = assets.find(a => !isPaymentAsset(a))
+  const payment = assets.find(isPaymentAsset)
   return {
-    id: `trade:${trade.id}`,
+    id: `${ActivityEventType.TRADE_CREATED}:${trade.id}`,
     type: ActivityEventType.TRADE_CREATED,
     timestamp: trade.createdAt,
     network: trade.network,
-    contractAddress: firstNonERC20?.contractAddress,
-    tokenId: firstNonERC20 && 'tokenId' in firstNonERC20 ? firstNonERC20.tokenId : undefined,
-    itemId: firstNonERC20 && 'itemId' in firstNonERC20 ? firstNonERC20.itemId : undefined,
-    price: erc20 && 'amount' in erc20 ? erc20.amount : undefined,
+    contractAddress: nonPayment?.contractAddress,
+    tokenId: nonPayment && 'tokenId' in nonPayment ? nonPayment.tokenId : undefined,
+    itemId: nonPayment && 'itemId' in nonPayment ? nonPayment.itemId : undefined,
+    price: payment?.amount,
     details: { trade }
   }
 }
 
-export function isOrderFilled(order: Order): boolean {
-  return order.status === ListingStatus.SOLD && !!order.buyer
-}
+export const isOrderFilled = (order: Order): boolean => order.status === ListingStatus.SOLD && !!order.buyer
 
-export function sortByTimestampDesc(events: ActivityEvent[]): ActivityEvent[] {
-  return [...events].sort((a, b) => b.timestamp - a.timestamp)
-}
+export const sortByTimestampDesc = (events: ActivityEvent[]): ActivityEvent[] => [...events].sort((a, b) => b.timestamp - a.timestamp)
 
-// Drops server-side duplicates: when the same on-chain event appears in two sources
-// (e.g. an order filled via the new trades pipeline shows up both as a sale and a trade,
-// or `orders.getOrders({ buyer })` returns trade-orders with an empty buyer).
-// Keep the first occurrence in the sorted list — sources are intentionally added in
-// the aggregator in the order we want to win (sales/bids/orders first, trades last).
+// Dedup keeps the first event in sort order (the aggregator orders sources so the canonical
+// source wins). Key includes `type` because the same on-chain tx can legitimately emit
+// distinct semantic events for the same user — e.g. `sale_seller` AND `order_filled` both
+// describe "someone bought your listing" from different model angles, with different
+// counterparty fields, so both must survive.
 export function dedupeEvents(events: ActivityEvent[]): ActivityEvent[] {
   const seen = new Set<string>()
   const out: ActivityEvent[] = []
   for (const ev of events) {
     const key = ev.txHash
-      ? `tx:${ev.txHash.toLowerCase()}`
+      ? `tx:${ev.txHash.toLowerCase()}:${ev.type}`
       : `${ev.contractAddress ?? '-'}|${ev.tokenId ?? ev.itemId ?? '-'}|${ev.timestamp}|${ev.type}`
     if (seen.has(key)) continue
     seen.add(key)

--- a/src/adapters/trades/trades.ts
+++ b/src/adapters/trades/trades.ts
@@ -25,6 +25,8 @@ export function fromDBTradeAssetWithValueToTradeAsset(dbTradeAsset: DBTradeAsset
   switch (dbTradeAsset.asset_type) {
     case TradeAssetType.ERC20:
       return { ...tradeBaseValues, assetType: TradeAssetType.ERC20, amount: dbTradeAsset.amount }
+    case TradeAssetType.USD_PEGGED_MANA:
+      return { ...tradeBaseValues, assetType: TradeAssetType.USD_PEGGED_MANA, amount: dbTradeAsset.amount }
     case TradeAssetType.ERC721:
       return { ...tradeBaseValues, assetType: TradeAssetType.ERC721, tokenId: dbTradeAsset.token_id }
     case TradeAssetType.COLLECTION_ITEM:

--- a/src/components.ts
+++ b/src/components.ts
@@ -160,7 +160,7 @@ export async function initComponents(): Promise<AppComponents> {
   const analyticsData = await createAnalyticsDayDataComponent({ dappsDatabase: dappsReadDatabase })
   const volumes = await createVolumeComponent({ analyticsData })
   const userAssets = await createUserAssetsComponent({ logs, dappsDatabase: dappsReadDatabase })
-  const activity = createActivityComponent({ sales, bids, orders, trades })
+  const activity = createActivityComponent({ sales, bids, orders, trades, logs })
 
   const transak = await createTransakComponent(
     { fetch, logs, cache },

--- a/src/components.ts
+++ b/src/components.ts
@@ -12,6 +12,7 @@ import { createSchemaValidatorComponent } from '@dcl/schema-validator-component'
 import { createFetchComponent } from './adapters/fetch'
 import { metricDeclarations } from './metrics'
 import { createAccountsComponent } from './ports/accounts/component'
+import { createActivityComponent } from './ports/activity'
 import { createAnalyticsDayDataComponent } from './ports/analyticsDayData/component'
 import { createBidsComponents } from './ports/bids'
 import { createCatalogComponent } from './ports/catalog/component'
@@ -159,6 +160,7 @@ export async function initComponents(): Promise<AppComponents> {
   const analyticsData = await createAnalyticsDayDataComponent({ dappsDatabase: dappsReadDatabase })
   const volumes = await createVolumeComponent({ analyticsData })
   const userAssets = await createUserAssetsComponent({ logs, dappsDatabase: dappsReadDatabase })
+  const activity = createActivityComponent({ sales, bids, orders, trades })
 
   const transak = await createTransakComponent(
     { fetch, logs, cache },
@@ -215,6 +217,7 @@ export async function initComponents(): Promise<AppComponents> {
     rankings,
     analyticsData,
     volumes,
-    userAssets
+    userAssets,
+    activity
   }
 }

--- a/src/controllers/handlers/activity-handler.ts
+++ b/src/controllers/handlers/activity-handler.ts
@@ -15,16 +15,8 @@ export async function getActivityHandler(
   } = context
   const logger = logs.getLogger('Activity handler')
 
-  logger.info(
-    `[/v1/activity] handler reached. verification=${JSON.stringify({
-      auth: verification?.auth,
-      authMetadata: verification?.authMetadata
-    })} search=${url.search}`
-  )
-
   const address = verification?.auth.toLowerCase()
   if (!address) {
-    logger.warn('[/v1/activity] no verified address; returning 401')
     return {
       status: StatusCode.UNAUTHORIZED,
       body: { ok: false, message: 'Unauthorized' }
@@ -34,15 +26,13 @@ export async function getActivityHandler(
   try {
     const limit = getNumberParameter('limit', url.searchParams) ?? undefined
     const offset = getNumberParameter('offset', url.searchParams) ?? undefined
-    logger.info(`[/v1/activity] fetching activity for ${address} limit=${limit ?? 'default'} offset=${offset ?? 0}`)
     const { data, total } = await activity.getUserActivity(address, { limit, offset })
-    logger.info(`[/v1/activity] success for ${address}: ${data.length} events (total=${total})`)
     return {
       status: StatusCode.OK,
       body: { data, total }
     }
   } catch (e) {
-    logger.error(`[/v1/activity] failed for ${address}: ${e instanceof Error ? `${e.message}\n${e.stack}` : String(e)}`)
+    logger.error(`Failed to fetch activity for ${address} (limit=${url.searchParams.get('limit') ?? 'default'}, offset=${url.searchParams.get('offset') ?? '0'}): ${e instanceof Error ? `${e.message}\n${e.stack}` : String(e)}`)
     return {
       status: StatusCode.ERROR,
       body: { ok: false, message: 'Could not fetch activity' }

--- a/src/controllers/handlers/activity-handler.ts
+++ b/src/controllers/handlers/activity-handler.ts
@@ -15,8 +15,16 @@ export async function getActivityHandler(
   } = context
   const logger = logs.getLogger('Activity handler')
 
+  logger.info(
+    `[/v1/activity] handler reached. verification=${JSON.stringify({
+      auth: verification?.auth,
+      authMetadata: verification?.authMetadata
+    })} search=${url.search}`
+  )
+
   const address = verification?.auth.toLowerCase()
   if (!address) {
+    logger.warn('[/v1/activity] no verified address; returning 401')
     return {
       status: StatusCode.UNAUTHORIZED,
       body: { ok: false, message: 'Unauthorized' }
@@ -25,13 +33,16 @@ export async function getActivityHandler(
 
   try {
     const limit = getNumberParameter('limit', url.searchParams) ?? undefined
-    const { data, total } = await activity.getUserActivity(address, { limit })
+    const offset = getNumberParameter('offset', url.searchParams) ?? undefined
+    logger.info(`[/v1/activity] fetching activity for ${address} limit=${limit ?? 'default'} offset=${offset ?? 0}`)
+    const { data, total } = await activity.getUserActivity(address, { limit, offset })
+    logger.info(`[/v1/activity] success for ${address}: ${data.length} events (total=${total})`)
     return {
       status: StatusCode.OK,
       body: { data, total }
     }
   } catch (e) {
-    logger.error(`Failed to fetch activity for ${address}: ${e instanceof Error ? e.message : String(e)}`)
+    logger.error(`[/v1/activity] failed for ${address}: ${e instanceof Error ? `${e.message}\n${e.stack}` : String(e)}`)
     return {
       status: StatusCode.ERROR,
       body: { ok: false, message: 'Could not fetch activity' }

--- a/src/controllers/handlers/activity-handler.ts
+++ b/src/controllers/handlers/activity-handler.ts
@@ -32,7 +32,11 @@ export async function getActivityHandler(
       body: { data, total }
     }
   } catch (e) {
-    logger.error(`Failed to fetch activity for ${address} (limit=${url.searchParams.get('limit') ?? 'default'}, offset=${url.searchParams.get('offset') ?? '0'}): ${e instanceof Error ? `${e.message}\n${e.stack}` : String(e)}`)
+    logger.error(
+      `Failed to fetch activity for ${address} (limit=${url.searchParams.get('limit') ?? 'default'}, offset=${
+        url.searchParams.get('offset') ?? '0'
+      }): ${e instanceof Error ? `${e.message}\n${e.stack}` : String(e)}`
+    )
     return {
       status: StatusCode.ERROR,
       body: { ok: false, message: 'Could not fetch activity' }

--- a/src/controllers/handlers/activity-handler.ts
+++ b/src/controllers/handlers/activity-handler.ts
@@ -1,11 +1,21 @@
-import { isErrorWithMessage } from '../../logic/errors'
+import { getNumberParameter } from '../../logic/http'
 import { ActivityEvent } from '../../ports/activity/types'
-import { HandlerContextWithPath, HTTPResponse, StatusCode } from '../../types'
+import { HandlerContextWithPath, StatusCode } from '../../types'
 
 export async function getActivityHandler(
-  context: Pick<HandlerContextWithPath<'activity', '/v1/activity'>, 'components' | 'verification'>
-): Promise<HTTPResponse<{ data: ActivityEvent[]; total: number }>> {
-  const address = context.verification?.auth.toLowerCase()
+  context: Pick<HandlerContextWithPath<'activity' | 'logs', '/v1/activity'>, 'components' | 'url' | 'verification'>
+): Promise<{
+  status: StatusCode
+  body: { data: ActivityEvent[]; total: number } | { ok: false; message: string }
+}> {
+  const {
+    components: { activity, logs },
+    url,
+    verification
+  } = context
+  const logger = logs.getLogger('Activity handler')
+
+  const address = verification?.auth.toLowerCase()
   if (!address) {
     return {
       status: StatusCode.UNAUTHORIZED,
@@ -14,21 +24,17 @@ export async function getActivityHandler(
   }
 
   try {
-    const { data, total } = await context.components.activity.getUserActivity(address)
+    const limit = getNumberParameter('limit', url.searchParams) ?? undefined
+    const { data, total } = await activity.getUserActivity(address, { limit })
     return {
       status: StatusCode.OK,
-      body: {
-        ok: true,
-        data: { data, total }
-      }
+      body: { data, total }
     }
   } catch (e) {
+    logger.error(`Failed to fetch activity for ${address}: ${e instanceof Error ? e.message : String(e)}`)
     return {
       status: StatusCode.ERROR,
-      body: {
-        ok: false,
-        message: isErrorWithMessage(e) ? e.message : 'Could not fetch activity'
-      }
+      body: { ok: false, message: 'Could not fetch activity' }
     }
   }
 }

--- a/src/controllers/handlers/activity-handler.ts
+++ b/src/controllers/handlers/activity-handler.ts
@@ -1,0 +1,34 @@
+import { isErrorWithMessage } from '../../logic/errors'
+import { ActivityEvent } from '../../ports/activity/types'
+import { HandlerContextWithPath, HTTPResponse, StatusCode } from '../../types'
+
+export async function getActivityHandler(
+  context: Pick<HandlerContextWithPath<'activity', '/v1/activity'>, 'components' | 'verification'>
+): Promise<HTTPResponse<{ data: ActivityEvent[]; total: number }>> {
+  const address = context.verification?.auth.toLowerCase()
+  if (!address) {
+    return {
+      status: StatusCode.UNAUTHORIZED,
+      body: { ok: false, message: 'Unauthorized' }
+    }
+  }
+
+  try {
+    const { data, total } = await context.components.activity.getUserActivity(address)
+    return {
+      status: StatusCode.OK,
+      body: {
+        ok: true,
+        data: { data, total }
+      }
+    }
+  } catch (e) {
+    return {
+      status: StatusCode.ERROR,
+      body: {
+        ok: false,
+        message: isErrorWithMessage(e) ? e.message : 'Could not fetch activity'
+      }
+    }
+  }
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -6,6 +6,7 @@ import { TradeCreationSchema } from '../ports/trades/schemas'
 import { WidgetOptionsSchema } from '../ports/transak'
 import { GlobalContext } from '../types'
 import { getAccountsHandler } from './handlers/accounts-handler'
+import { getActivityHandler } from './handlers/activity-handler'
 import { getBidsHandler } from './handlers/bids-handler'
 import { createCatalogHandler } from './handlers/catalog-handler'
 import { getCollectionsHandler } from './handlers/collections-handler'
@@ -137,6 +138,15 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   )
 
   router.get('/v1/sales', getSalesHandler)
+  router.get(
+    '/v1/activity',
+    authorizationMiddleware.wellKnownComponents({
+      optional: false,
+      expiration: FIVE_MINUTES,
+      verifyMetadataContent: validateAuthMetadata(['dcl:marketplace', 'dcl:builder'], undefined)
+    }),
+    getActivityHandler
+  )
   router.get('/v1/prices', getPricesHandler)
   router.get('/v1/trendings', getTrendingsHandler)
   router.get('/v1/stats/:category/:stat', getStatsHandler)

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -140,25 +140,6 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   router.get('/v1/sales', getSalesHandler)
   router.get(
     '/v1/activity',
-    // DEBUG: pre-auth logger to inspect incoming signed-fetch headers + metadata when the
-    // auth middleware short-circuits with a 4xx before the handler runs.
-    // TODO(juanmahidalgo): remove after debugging is done.
-    async (ctx, next) => {
-      const logger = components.logs.getLogger('Activity pre-auth')
-      const headerNames = ['x-identity-auth-chain-0', 'x-identity-auth-chain-1', 'x-identity-timestamp', 'x-identity-metadata']
-      const present: Record<string, string | null> = {}
-      for (const h of headerNames) present[h] = ctx.request.headers.get(h)
-      let parsedMetadata: unknown = null
-      try {
-        parsedMetadata = present['x-identity-metadata'] ? JSON.parse(present['x-identity-metadata']) : null
-      } catch (e) {
-        parsedMetadata = `unparseable: ${e instanceof Error ? e.message : String(e)}`
-      }
-      logger.info(`[/v1/activity] incoming; headers=${JSON.stringify(present)} metadata=${JSON.stringify(parsedMetadata)}`)
-      const response = await next()
-      logger.info(`[/v1/activity] response status=${response?.status ?? 'unknown'}`)
-      return response
-    },
     authorizationMiddleware.wellKnownComponents({
       optional: false,
       expiration: FIVE_MINUTES,

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -140,6 +140,25 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   router.get('/v1/sales', getSalesHandler)
   router.get(
     '/v1/activity',
+    // DEBUG: pre-auth logger to inspect incoming signed-fetch headers + metadata when the
+    // auth middleware short-circuits with a 4xx before the handler runs.
+    // TODO(juanmahidalgo): remove after debugging is done.
+    async (ctx, next) => {
+      const logger = components.logs.getLogger('Activity pre-auth')
+      const headerNames = ['x-identity-auth-chain-0', 'x-identity-auth-chain-1', 'x-identity-timestamp', 'x-identity-metadata']
+      const present: Record<string, string | null> = {}
+      for (const h of headerNames) present[h] = ctx.request.headers.get(h)
+      let parsedMetadata: unknown = null
+      try {
+        parsedMetadata = present['x-identity-metadata'] ? JSON.parse(present['x-identity-metadata']) : null
+      } catch (e) {
+        parsedMetadata = `unparseable: ${e instanceof Error ? e.message : String(e)}`
+      }
+      logger.info(`[/v1/activity] incoming; headers=${JSON.stringify(present)} metadata=${JSON.stringify(parsedMetadata)}`)
+      const response = await next()
+      logger.info(`[/v1/activity] response status=${response?.status ?? 'unknown'}`)
+      return response
+    },
     authorizationMiddleware.wellKnownComponents({
       optional: false,
       expiration: FIVE_MINUTES,

--- a/src/ports/activity/component.ts
+++ b/src/ports/activity/component.ts
@@ -14,12 +14,12 @@ import { isErrorWithMessage } from '../../logic/errors'
 import { AppComponents } from '../../types'
 import { ActivityEvent, IActivityComponent } from './types'
 
-// Hard cap on the work we'll do per request: every page hit refetches all 7 sources, sorts,
-// dedupes and then slices. We bound that work at 500 deduped events regardless of `limit`.
-// `MAX_LIMIT` is the largest single-page response the API will produce.
+// Every request refetches all 7 sources, sorts and dedupes them. `INTERNAL_FETCH_CAP` is
+// how many rows we pull from each source — bounds the worst-case work per request.
+// `MAX_PAGE_SIZE` is both the default and the hard cap for the response slice; a client
+// that doesn't pass `limit` gets the largest meaningful page (no surprise paging by us).
 const INTERNAL_FETCH_CAP = 500
-const MAX_LIMIT = 500
-const DEFAULT_LIMIT = 500
+const MAX_PAGE_SIZE = 500
 
 export function createActivityComponent(
   components: Pick<AppComponents, 'sales' | 'bids' | 'orders' | 'trades' | 'logs'>
@@ -38,8 +38,8 @@ export function createActivityComponent(
   }
 
   async function getUserActivity(address: string, options: { limit?: number; offset?: number } = {}) {
-    const requested = options.limit && options.limit > 0 ? options.limit : DEFAULT_LIMIT
-    const limit = Math.min(requested, MAX_LIMIT)
+    const requested = options.limit && options.limit > 0 ? options.limit : MAX_PAGE_SIZE
+    const limit = Math.min(requested, MAX_PAGE_SIZE)
     const offset = options.offset && options.offset > 0 ? options.offset : 0
     const per = INTERNAL_FETCH_CAP
     const lower = address.toLowerCase()

--- a/src/ports/activity/component.ts
+++ b/src/ports/activity/component.ts
@@ -1,3 +1,4 @@
+import { isErrorWithMessage } from '../../logic/errors'
 import {
   dedupeEvents,
   isOrderFilled,
@@ -10,14 +11,14 @@ import {
   toSaleSellerEvent,
   toTradeCreatedEvent
 } from '../../adapters/activity'
-import { isErrorWithMessage } from '../../logic/errors'
 import { AppComponents } from '../../types'
 import { ActivityEvent, IActivityComponent } from './types'
 
-// Per-source cap matches the total cap on purpose: a power user whose history is dominated
-// by one source (e.g. 400 sales, 20 bids, 5 orders) still sees their newest activity instead
-// of getting bins truncated to 100 per source. Trade-off: heavier query for the dominated
-// source, but bounded by `limit` which the caller can lower if needed.
+// Hard cap on the work we'll do per request: every page hit refetches all 7 sources, sorts,
+// dedupes and then slices. We bound that work at 500 deduped events regardless of `limit`.
+// `MAX_LIMIT` is the largest single-page response the API will produce.
+const INTERNAL_FETCH_CAP = 500
+const MAX_LIMIT = 500
 const DEFAULT_LIMIT = 500
 
 export function createActivityComponent(
@@ -36,9 +37,11 @@ export function createActivityComponent(
     }
   }
 
-  async function getUserActivity(address: string, options: { limit?: number } = {}) {
-    const limit = options.limit && options.limit > 0 ? Math.min(options.limit, DEFAULT_LIMIT) : DEFAULT_LIMIT
-    const per = limit
+  async function getUserActivity(address: string, options: { limit?: number; offset?: number } = {}) {
+    const requested = options.limit && options.limit > 0 ? options.limit : DEFAULT_LIMIT
+    const limit = Math.min(requested, MAX_LIMIT)
+    const offset = options.offset && options.offset > 0 ? options.offset : 0
+    const per = INTERNAL_FETCH_CAP
     const lower = address.toLowerCase()
 
     const [salesAsBuyer, salesAsSeller, bidsAsBidder, bidsAsSeller, ordersAsOwner, ordersAsBuyer, userTrades] = await Promise.all([
@@ -63,9 +66,9 @@ export function createActivityComponent(
 
     const sorted = sortByTimestampDesc(events)
     const deduped = dedupeEvents(sorted)
-    const capped = deduped.slice(0, limit)
+    const page = deduped.slice(offset, offset + limit)
 
-    return { data: capped, total: deduped.length }
+    return { data: page, total: deduped.length }
   }
 
   return { getUserActivity }

--- a/src/ports/activity/component.ts
+++ b/src/ports/activity/component.ts
@@ -1,4 +1,3 @@
-import { isErrorWithMessage } from '../../logic/errors'
 import {
   dedupeEvents,
   isOrderFilled,
@@ -11,6 +10,7 @@ import {
   toSaleSellerEvent,
   toTradeCreatedEvent
 } from '../../adapters/activity'
+import { isErrorWithMessage } from '../../logic/errors'
 import { AppComponents } from '../../types'
 import { ActivityEvent, IActivityComponent } from './types'
 

--- a/src/ports/activity/component.ts
+++ b/src/ports/activity/component.ts
@@ -1,0 +1,61 @@
+import {
+  dedupeEvents,
+  isOrderFilled,
+  sortByTimestampDesc,
+  toBidPlacedEvent,
+  toBidReceivedEvent,
+  toOrderCreatedEvent,
+  toOrderFilledEvent,
+  toSaleBuyerEvent,
+  toSaleSellerEvent,
+  toTradeCreatedEvent
+} from '../../adapters/activity'
+import { AppComponents } from '../../types'
+import { ActivityEvent, IActivityComponent } from './types'
+
+const PER_SOURCE_LIMIT = 100
+const TOTAL_CAP = 500
+
+export function createActivityComponent(
+  components: Pick<AppComponents, 'sales' | 'bids' | 'orders' | 'trades'>
+): IActivityComponent {
+  const { sales, bids, orders, trades } = components
+
+  async function getUserActivity(address: string, options: { limit?: number } = {}) {
+    const totalCap = options.limit ?? TOTAL_CAP
+    const per = PER_SOURCE_LIMIT
+    const lower = address.toLowerCase()
+
+    const [salesAsBuyer, salesAsSeller, bidsAsBidder, bidsAsSeller, ordersAsOwner, ordersAsBuyer, userTrades] = await Promise.all([
+      sales.getSales({ buyer: lower, first: per }).catch(() => ({ data: [], total: 0 })),
+      sales.getSales({ seller: lower, first: per }).catch(() => ({ data: [], total: 0 })),
+      bids.getBids({ bidder: lower, limit: per, offset: 0 }).catch(() => ({ data: [], count: 0 })),
+      bids.getBids({ seller: lower, limit: per, offset: 0 }).catch(() => ({ data: [], count: 0 })),
+      orders.getOrders({ owner: lower, first: per }).catch(() => ({ data: [], total: 0 })),
+      orders.getOrders({ buyer: lower, first: per }).catch(() => ({ data: [], total: 0 })),
+      trades.getTradesByAddress(lower, { limit: per }).catch(() => ({ data: [] }))
+    ])
+
+    const events: ActivityEvent[] = [
+      ...salesAsBuyer.data.map(toSaleBuyerEvent),
+      ...salesAsSeller.data.map(toSaleSellerEvent),
+      ...bidsAsBidder.data.map(toBidPlacedEvent),
+      // Bids returned with `seller` filter could include the user's own bids when bidder==seller; filter those out.
+      ...bidsAsSeller.data.filter(b => b.bidder.toLowerCase() !== lower).map(toBidReceivedEvent),
+      ...ordersAsOwner.data.map(toOrderCreatedEvent),
+      ...ordersAsBuyer.data.filter(isOrderFilled).map(toOrderFilledEvent),
+      ...userTrades.data
+        // Don't surface cancelled/expired trades the user opened.
+        // (status isn't on the Trade type; we'd need extra plumbing to compute it — for v1, include all.)
+        .map(toTradeCreatedEvent)
+    ]
+
+    const sorted = sortByTimestampDesc(events)
+    const deduped = dedupeEvents(sorted)
+    const capped = deduped.slice(0, totalCap)
+
+    return { data: capped, total: deduped.length }
+  }
+
+  return { getUserActivity }
+}

--- a/src/ports/activity/component.ts
+++ b/src/ports/activity/component.ts
@@ -10,49 +10,60 @@ import {
   toSaleSellerEvent,
   toTradeCreatedEvent
 } from '../../adapters/activity'
+import { isErrorWithMessage } from '../../logic/errors'
 import { AppComponents } from '../../types'
 import { ActivityEvent, IActivityComponent } from './types'
 
-const PER_SOURCE_LIMIT = 100
-const TOTAL_CAP = 500
+// Per-source cap matches the total cap on purpose: a power user whose history is dominated
+// by one source (e.g. 400 sales, 20 bids, 5 orders) still sees their newest activity instead
+// of getting bins truncated to 100 per source. Trade-off: heavier query for the dominated
+// source, but bounded by `limit` which the caller can lower if needed.
+const DEFAULT_LIMIT = 500
 
 export function createActivityComponent(
-  components: Pick<AppComponents, 'sales' | 'bids' | 'orders' | 'trades'>
+  components: Pick<AppComponents, 'sales' | 'bids' | 'orders' | 'trades' | 'logs'>
 ): IActivityComponent {
-  const { sales, bids, orders, trades } = components
+  const { sales, bids, orders, trades, logs } = components
+  const logger = logs.getLogger('Activity component')
+
+  type SourceFetcher<T> = () => Promise<T>
+  const safeFetch = async <T>(label: string, empty: T, fn: SourceFetcher<T>): Promise<T> => {
+    try {
+      return await fn()
+    } catch (e) {
+      logger.warn(`Activity source "${label}" failed; degrading gracefully. ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
+      return empty
+    }
+  }
 
   async function getUserActivity(address: string, options: { limit?: number } = {}) {
-    const totalCap = options.limit ?? TOTAL_CAP
-    const per = PER_SOURCE_LIMIT
+    const limit = options.limit && options.limit > 0 ? Math.min(options.limit, DEFAULT_LIMIT) : DEFAULT_LIMIT
+    const per = limit
     const lower = address.toLowerCase()
 
     const [salesAsBuyer, salesAsSeller, bidsAsBidder, bidsAsSeller, ordersAsOwner, ordersAsBuyer, userTrades] = await Promise.all([
-      sales.getSales({ buyer: lower, first: per }).catch(() => ({ data: [], total: 0 })),
-      sales.getSales({ seller: lower, first: per }).catch(() => ({ data: [], total: 0 })),
-      bids.getBids({ bidder: lower, limit: per, offset: 0 }).catch(() => ({ data: [], count: 0 })),
-      bids.getBids({ seller: lower, limit: per, offset: 0 }).catch(() => ({ data: [], count: 0 })),
-      orders.getOrders({ owner: lower, first: per }).catch(() => ({ data: [], total: 0 })),
-      orders.getOrders({ buyer: lower, first: per }).catch(() => ({ data: [], total: 0 })),
-      trades.getTradesByAddress(lower, { limit: per }).catch(() => ({ data: [] }))
+      safeFetch('sales:buyer', { data: [], total: 0 }, () => sales.getSales({ buyer: lower, first: per })),
+      safeFetch('sales:seller', { data: [], total: 0 }, () => sales.getSales({ seller: lower, first: per })),
+      safeFetch('bids:bidder', { data: [], count: 0 }, () => bids.getBids({ bidder: lower, limit: per, offset: 0 })),
+      safeFetch('bids:seller', { data: [], count: 0 }, () => bids.getBids({ seller: lower, limit: per, offset: 0 })),
+      safeFetch('orders:owner', { data: [], total: 0 }, () => orders.getOrders({ owner: lower, first: per })),
+      safeFetch('orders:buyer', { data: [], total: 0 }, () => orders.getOrders({ buyer: lower, first: per })),
+      safeFetch('trades:address', { data: [] }, () => trades.getTradesByAddress(lower, { limit: per }))
     ])
 
     const events: ActivityEvent[] = [
       ...salesAsBuyer.data.map(toSaleBuyerEvent),
       ...salesAsSeller.data.map(toSaleSellerEvent),
       ...bidsAsBidder.data.map(toBidPlacedEvent),
-      // Bids returned with `seller` filter could include the user's own bids when bidder==seller; filter those out.
       ...bidsAsSeller.data.filter(b => b.bidder.toLowerCase() !== lower).map(toBidReceivedEvent),
       ...ordersAsOwner.data.map(toOrderCreatedEvent),
       ...ordersAsBuyer.data.filter(isOrderFilled).map(toOrderFilledEvent),
-      ...userTrades.data
-        // Don't surface cancelled/expired trades the user opened.
-        // (status isn't on the Trade type; we'd need extra plumbing to compute it — for v1, include all.)
-        .map(toTradeCreatedEvent)
+      ...userTrades.data.map(toTradeCreatedEvent)
     ]
 
     const sorted = sortByTimestampDesc(events)
     const deduped = dedupeEvents(sorted)
-    const capped = deduped.slice(0, totalCap)
+    const capped = deduped.slice(0, limit)
 
     return { data: capped, total: deduped.length }
   }

--- a/src/ports/activity/index.ts
+++ b/src/ports/activity/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './component'

--- a/src/ports/activity/types.ts
+++ b/src/ports/activity/types.ts
@@ -68,6 +68,12 @@ export type ActivityEvent =
 
 export type GetUserActivityResponse = {
   data: ActivityEvent[]
+  /**
+   * Post-dedup count of events visible to this user across the configured sources, capped
+   * at the aggregator's INTERNAL_FETCH_CAP (per-source). This is the "recent activity
+   * window" total — NOT the user's full lifetime event count. Paginating clients should
+   * stop when `offset + data.length >= total`.
+   */
   total: number
 }
 

--- a/src/ports/activity/types.ts
+++ b/src/ports/activity/types.ts
@@ -72,5 +72,5 @@ export type GetUserActivityResponse = {
 }
 
 export type IActivityComponent = {
-  getUserActivity(address: string, options?: { limit?: number }): Promise<GetUserActivityResponse>
+  getUserActivity(address: string, options?: { limit?: number; offset?: number }): Promise<GetUserActivityResponse>
 }

--- a/src/ports/activity/types.ts
+++ b/src/ports/activity/types.ts
@@ -1,0 +1,76 @@
+import { Bid, Network, Order, Sale, Trade } from '@dcl/schemas'
+
+export enum ActivityEventType {
+  SALE_BUYER = 'sale_buyer',
+  SALE_SELLER = 'sale_seller',
+  BID_PLACED = 'bid_placed',
+  BID_RECEIVED = 'bid_received',
+  ORDER_CREATED = 'order_created',
+  ORDER_FILLED = 'order_filled',
+  TRADE_CREATED = 'trade_created'
+}
+
+export type ActivityEventBase = {
+  id: string
+  timestamp: number
+  network: Network
+  txHash?: string
+  contractAddress?: string
+  tokenId?: string
+  itemId?: string
+  price?: string
+  counterparty?: string
+}
+
+export type SaleBuyerEvent = ActivityEventBase & {
+  type: ActivityEventType.SALE_BUYER
+  details: { sale: Sale }
+}
+
+export type SaleSellerEvent = ActivityEventBase & {
+  type: ActivityEventType.SALE_SELLER
+  details: { sale: Sale }
+}
+
+export type BidPlacedEvent = ActivityEventBase & {
+  type: ActivityEventType.BID_PLACED
+  details: { bid: Bid }
+}
+
+export type BidReceivedEvent = ActivityEventBase & {
+  type: ActivityEventType.BID_RECEIVED
+  details: { bid: Bid }
+}
+
+export type OrderCreatedEvent = ActivityEventBase & {
+  type: ActivityEventType.ORDER_CREATED
+  details: { order: Order }
+}
+
+export type OrderFilledEvent = ActivityEventBase & {
+  type: ActivityEventType.ORDER_FILLED
+  details: { order: Order }
+}
+
+export type TradeCreatedEvent = ActivityEventBase & {
+  type: ActivityEventType.TRADE_CREATED
+  details: { trade: Trade }
+}
+
+export type ActivityEvent =
+  | SaleBuyerEvent
+  | SaleSellerEvent
+  | BidPlacedEvent
+  | BidReceivedEvent
+  | OrderCreatedEvent
+  | OrderFilledEvent
+  | TradeCreatedEvent
+
+export type GetUserActivityResponse = {
+  data: ActivityEvent[]
+  total: number
+}
+
+export type IActivityComponent = {
+  getUserActivity(address: string, options?: { limit?: number }): Promise<GetUserActivityResponse>
+}

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -117,6 +117,12 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
           return null
         }
         return { ...base, asset_type: TradeAssetType.ERC20, amount: r.amount }
+      case TradeAssetType.USD_PEGGED_MANA:
+        if (r.amount === null) {
+          logger.warn(`Trade asset ${r.asset_id} declared USD_PEGGED_MANA but missing amount; dropping from trade ${r.asset_trade_id}`)
+          return null
+        }
+        return { ...base, asset_type: TradeAssetType.USD_PEGGED_MANA, amount: r.amount }
       case TradeAssetType.ERC721:
         if (r.token_id === null) {
           logger.warn(`Trade asset ${r.asset_id} declared ERC721 but missing token_id; dropping from trade ${r.asset_trade_id}`)

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -69,8 +69,12 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
 
     const grouped = new Map<string, TradeWithAssetRow[]>()
     for (const row of result.rows) {
-      if (!grouped.has(row.trade_id)) grouped.set(row.trade_id, [])
-      grouped.get(row.trade_id)!.push(row)
+      const existing = grouped.get(row.trade_id)
+      if (existing) {
+        existing.push(row)
+      } else {
+        grouped.set(row.trade_id, [row])
+      }
     }
 
     const trades: Trade[] = []
@@ -89,26 +93,46 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
         type: head.trade_type,
         contract: head.trade_contract
       }
-      const assets: DBTradeAssetWithValue[] = rows.map(
-        r =>
-          ({
-            id: r.asset_id,
-            asset_type: r.asset_type,
-            beneficiary: r.asset_beneficiary ?? undefined,
-            contract_address: r.asset_contract_address,
-            direction: r.asset_direction,
-            extra: r.asset_extra,
-            trade_id: r.asset_trade_id,
-            created_at: r.asset_created_at,
-            token_id: r.token_id,
-            amount: r.amount,
-            item_id: r.item_id
-          } as DBTradeAssetWithValue)
-      )
+      const assets = rows.map(toDBTradeAssetWithValue).filter((a): a is DBTradeAssetWithValue => a !== null)
       trades.push(fromDbTradeAndDBTradeAssetWithValueListToTrade(dbTrade, assets))
     }
 
     return { data: trades }
+  }
+
+  function toDBTradeAssetWithValue(r: TradeWithAssetRow): DBTradeAssetWithValue | null {
+    const base = {
+      id: r.asset_id,
+      beneficiary: r.asset_beneficiary ?? undefined,
+      contract_address: r.asset_contract_address,
+      direction: r.asset_direction,
+      extra: r.asset_extra,
+      trade_id: r.asset_trade_id,
+      created_at: r.asset_created_at
+    }
+    switch (r.asset_type) {
+      case TradeAssetType.ERC20:
+        if (r.amount === null) {
+          logger.warn(`Trade asset ${r.asset_id} declared ERC20 but missing amount; dropping from trade ${r.asset_trade_id}`)
+          return null
+        }
+        return { ...base, asset_type: TradeAssetType.ERC20, amount: r.amount }
+      case TradeAssetType.ERC721:
+        if (r.token_id === null) {
+          logger.warn(`Trade asset ${r.asset_id} declared ERC721 but missing token_id; dropping from trade ${r.asset_trade_id}`)
+          return null
+        }
+        return { ...base, asset_type: TradeAssetType.ERC721, token_id: r.token_id }
+      case TradeAssetType.COLLECTION_ITEM:
+        if (r.item_id === null) {
+          logger.warn(`Trade asset ${r.asset_id} declared COLLECTION_ITEM but missing item_id; dropping from trade ${r.asset_trade_id}`)
+          return null
+        }
+        return { ...base, asset_type: TradeAssetType.COLLECTION_ITEM, item_id: r.item_id }
+      default:
+        logger.warn(`Trade asset ${r.asset_id} has unsupported asset_type ${r.asset_type}; dropping from trade ${r.asset_trade_id}`)
+        return null
+    }
   }
 
   async function addTrade(trade: TradeCreation, signer: string) {

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -1,5 +1,5 @@
 import SQL from 'sql-template-strings'
-import { Event, TradeAssetDirection, TradeCreation } from '@dcl/schemas'
+import { Event, Trade, TradeAssetDirection, TradeAssetType, TradeCreation, TradeType } from '@dcl/schemas'
 import { ContractName, getContract } from 'decentraland-transactions'
 import { fromDbTradeAndDBTradeAssetWithValueListToTrade } from '../../adapters/trades/trades'
 import { isErrorWithMessage } from '../../logic/errors'
@@ -23,10 +23,36 @@ import {
   getInsertTradeAssetValueByTypeQuery,
   getInsertTradeQuery,
   getTradeAssetsWithValuesByHashedSignatureQuery,
-  getTradeAssetsWithValuesByIdQuery
+  getTradeAssetsWithValuesByIdQuery,
+  getTradesByAddressQuery
 } from './queries'
 import { DBTrade, DBTradeAsset, DBTradeAssetValue, DBTradeAssetWithValue, ITradesComponent, TradeEvent } from './types'
 import { getNotificationEventForTrade, isERC721TradeAsset, isEstateChain, isValidEstateTrade, validateTradeByType } from './utils'
+
+type TradeWithAssetRow = {
+  trade_id: string
+  trade_chain_id: number
+  trade_checks: DBTrade['checks']
+  trade_created_at: Date
+  trade_effective_since: Date
+  trade_expires_at: Date
+  trade_network: string
+  trade_signature: string
+  trade_signer: string
+  trade_type: TradeType
+  trade_contract: string
+  asset_id: string
+  asset_type: TradeAssetType
+  asset_beneficiary: string | null
+  asset_contract_address: string
+  asset_direction: TradeAssetDirection
+  asset_extra: string
+  asset_trade_id: string
+  asset_created_at: Date
+  token_id: string | null
+  amount: string | null
+  item_id: string | null
+}
 
 export function createTradesComponent(components: Pick<AppComponents, 'dappsDatabase' | 'eventPublisher' | 'logs'>): ITradesComponent {
   const { dappsDatabase: pg, eventPublisher, logs } = components
@@ -35,6 +61,54 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
   async function getTrades() {
     const result = await pg.query<DBTrade>(SQL`SELECT * FROM marketplace.trades`)
     return { data: result.rows, count: result.rowCount }
+  }
+
+  async function getTradesByAddress(address: string, options: { limit?: number; offset?: number } = {}) {
+    const limit = options.limit ?? 100
+    const result = await pg.query<TradeWithAssetRow>(getTradesByAddressQuery(address, { limit, offset: options.offset }))
+
+    const grouped = new Map<string, TradeWithAssetRow[]>()
+    for (const row of result.rows) {
+      if (!grouped.has(row.trade_id)) grouped.set(row.trade_id, [])
+      grouped.get(row.trade_id)!.push(row)
+    }
+
+    const trades: Trade[] = []
+    for (const rows of grouped.values()) {
+      const head = rows[0]
+      const dbTrade: DBTrade = {
+        id: head.trade_id,
+        chain_id: head.trade_chain_id,
+        checks: head.trade_checks,
+        created_at: head.trade_created_at,
+        effective_since: head.trade_effective_since,
+        expires_at: head.trade_expires_at,
+        network: head.trade_network,
+        signature: head.trade_signature,
+        signer: head.trade_signer,
+        type: head.trade_type,
+        contract: head.trade_contract
+      }
+      const assets: DBTradeAssetWithValue[] = rows.map(
+        r =>
+          ({
+            id: r.asset_id,
+            asset_type: r.asset_type,
+            beneficiary: r.asset_beneficiary ?? undefined,
+            contract_address: r.asset_contract_address,
+            direction: r.asset_direction,
+            extra: r.asset_extra,
+            trade_id: r.asset_trade_id,
+            created_at: r.asset_created_at,
+            token_id: r.token_id,
+            amount: r.amount,
+            item_id: r.item_id
+          } as DBTradeAssetWithValue)
+      )
+      trades.push(fromDbTradeAndDBTradeAssetWithValueListToTrade(dbTrade, assets))
+    }
+
+    return { data: trades }
   }
 
   async function addTrade(trade: TradeCreation, signer: string) {
@@ -154,6 +228,7 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
 
   return {
     getTrades,
+    getTradesByAddress,
     addTrade,
     getTrade,
     getTradeAcceptedEvent,

--- a/src/ports/trades/queries.ts
+++ b/src/ports/trades/queries.ts
@@ -319,10 +319,10 @@ export function getTradesByAddressQuery(address: string, options: { limit: numbe
     LEFT JOIN marketplace.trade_assets_item AS item ON ta.id = item.asset_id
     WHERE t.id IN (
       SELECT t2.id FROM marketplace.trades AS t2
-      WHERE LOWER(t2.signer) = ${lowered}
+      WHERE t2.signer = ${lowered}
          OR EXISTS (
            SELECT 1 FROM marketplace.trade_assets AS ta2
-           WHERE ta2.trade_id = t2.id AND LOWER(ta2.beneficiary) = ${lowered}
+           WHERE ta2.trade_id = t2.id AND ta2.beneficiary = ${lowered}
          )
       ORDER BY t2.created_at DESC
       LIMIT ${options.limit}

--- a/src/ports/trades/queries.ts
+++ b/src/ports/trades/queries.ts
@@ -282,3 +282,51 @@ export function getTradesForTypeQueryWithFilters(type: TradeType, filters: NFTFi
 export function getTradeAssetsWithValuesByHashedSignatureQuery(hashedSignature: string) {
   return getTradeAssetsWithValuesQuery(SQL`t.hashed_signature = ${hashedSignature}`)
 }
+
+// Returns flat (trade × asset) rows with explicit aliases so the join's overlapping
+// `id` and `trade_id` columns can be disambiguated when grouping by trade in JS.
+export function getTradesByAddressQuery(address: string, options: { limit: number; offset?: number }) {
+  const lowered = address.toLowerCase()
+  const offset = options.offset ?? 0
+  return SQL`
+    SELECT
+      t.id           AS trade_id,
+      t.chain_id     AS trade_chain_id,
+      t.checks       AS trade_checks,
+      t.created_at   AS trade_created_at,
+      t.effective_since AS trade_effective_since,
+      t.expires_at   AS trade_expires_at,
+      t.network      AS trade_network,
+      t.signature    AS trade_signature,
+      t.signer       AS trade_signer,
+      t.type         AS trade_type,
+      t.contract     AS trade_contract,
+      ta.id              AS asset_id,
+      ta.asset_type      AS asset_type,
+      ta.beneficiary     AS asset_beneficiary,
+      ta.contract_address AS asset_contract_address,
+      ta.direction       AS asset_direction,
+      ta.extra           AS asset_extra,
+      ta.trade_id        AS asset_trade_id,
+      ta.created_at      AS asset_created_at,
+      erc721.token_id    AS token_id,
+      erc20.amount       AS amount,
+      item.item_id       AS item_id
+    FROM marketplace.trades AS t
+    JOIN marketplace.trade_assets AS ta ON t.id = ta.trade_id
+    LEFT JOIN marketplace.trade_assets_erc721 AS erc721 ON ta.id = erc721.asset_id
+    LEFT JOIN marketplace.trade_assets_erc20 AS erc20 ON ta.id = erc20.asset_id
+    LEFT JOIN marketplace.trade_assets_item AS item ON ta.id = item.asset_id
+    WHERE t.id IN (
+      SELECT t2.id FROM marketplace.trades AS t2
+      WHERE LOWER(t2.signer) = ${lowered}
+         OR EXISTS (
+           SELECT 1 FROM marketplace.trade_assets AS ta2
+           WHERE ta2.trade_id = t2.id AND LOWER(ta2.beneficiary) = ${lowered}
+         )
+      ORDER BY t2.created_at DESC
+      LIMIT ${options.limit}
+      OFFSET ${offset}
+    )
+    ORDER BY t.created_at DESC, ta.direction ASC`
+}

--- a/src/ports/trades/types.ts
+++ b/src/ports/trades/types.ts
@@ -2,6 +2,7 @@ import { Trade, TradeAssetType, TradeCreation, TradeChecks, TradeAssetDirection,
 
 export type ITradesComponent = {
   getTrades(): Promise<{ data: DBTrade[]; count: number }>
+  getTradesByAddress(address: string, options?: { limit?: number; offset?: number }): Promise<{ data: Trade[] }>
   addTrade(body: TradeCreation, signer: string): Promise<Trade>
   getTrade(id: string): Promise<Trade>
   getTradeAcceptedEvent(hashedSignature: string, acceptedDate: number, caller: string): Promise<Event>

--- a/src/ports/trades/types.ts
+++ b/src/ports/trades/types.ts
@@ -42,10 +42,15 @@ export type DBTradeAsset = {
 export type DBTradeAssetValue = { token_id: string } | { item_id: string } | { amount: string }
 
 export type DBTradeAssetWithERC20Value = DBTradeAsset & { asset_type: TradeAssetType.ERC20; amount: string }
+export type DBTradeAssetWithUSDPeggedManaValue = DBTradeAsset & { asset_type: TradeAssetType.USD_PEGGED_MANA; amount: string }
 export type DBTradeAssetWithERC721Value = DBTradeAsset & { asset_type: TradeAssetType.ERC721; token_id: string }
 export type DBTradeAssetWithCollectionItemValue = DBTradeAsset & { asset_type: TradeAssetType.COLLECTION_ITEM; item_id: string }
 
-export type DBTradeAssetWithValue = DBTradeAssetWithERC20Value | DBTradeAssetWithERC721Value | DBTradeAssetWithCollectionItemValue
+export type DBTradeAssetWithValue =
+  | DBTradeAssetWithERC20Value
+  | DBTradeAssetWithUSDPeggedManaValue
+  | DBTradeAssetWithERC721Value
+  | DBTradeAssetWithCollectionItemValue
 
 export type DBTradeWithAssets = {
   count: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ import { ISchemaValidatorComponent } from '@dcl/schema-validator-component'
 import type * as authorizationMiddleware from 'decentraland-crypto-middleware'
 import { metricDeclarations } from './metrics'
 import { IAccountsComponent } from './ports/accounts/types'
+import { IActivityComponent } from './ports/activity/types'
 import { IAnalyticsDayDataComponent } from './ports/analyticsDayData/types'
 import { IBidsComponent } from './ports/bids'
 import { ICatalogComponent } from './ports/catalog/types'
@@ -87,6 +88,7 @@ export type BaseComponents = {
   contracts: IContractsComponent
   collections: ICollectionsComponent
   accounts: IAccountsComponent
+  activity: IActivityComponent
 }
 
 // components used in runtime

--- a/test/components.ts
+++ b/test/components.ts
@@ -13,6 +13,7 @@ import { createSchemaValidatorComponent } from '@dcl/schema-validator-component'
 import { createFetchComponent } from '../src/adapters/fetch'
 import { metricDeclarations } from '../src/metrics'
 import { createAccountsComponent } from '../src/ports/accounts/component'
+import { createActivityComponent } from '../src/ports/activity'
 import { createAnalyticsDayDataComponent } from '../src/ports/analyticsDayData/component'
 import { createBidsComponents } from '../src/ports/bids'
 import { createCatalogComponent } from '../src/ports/catalog/component'
@@ -155,6 +156,7 @@ async function initComponents(): Promise<TestComponents> {
   const analyticsData = await createAnalyticsDayDataComponent({ dappsDatabase: dappsReadDatabase })
   const volumes = await createVolumeComponent({ analyticsData })
   const userAssets = await createUserAssetsComponent({ logs, dappsDatabase: dappsReadDatabase })
+  const activity = createActivityComponent({ sales, bids, orders, trades })
 
   return {
     cache,
@@ -197,7 +199,8 @@ async function initComponents(): Promise<TestComponents> {
     rankings,
     analyticsData,
     volumes,
-    userAssets
+    userAssets,
+    activity
   }
 }
 

--- a/test/components.ts
+++ b/test/components.ts
@@ -156,7 +156,7 @@ async function initComponents(): Promise<TestComponents> {
   const analyticsData = await createAnalyticsDayDataComponent({ dappsDatabase: dappsReadDatabase })
   const volumes = await createVolumeComponent({ analyticsData })
   const userAssets = await createUserAssetsComponent({ logs, dappsDatabase: dappsReadDatabase })
-  const activity = createActivityComponent({ sales, bids, orders, trades })
+  const activity = createActivityComponent({ sales, bids, orders, trades, logs })
 
   return {
     cache,

--- a/test/unit/activity-component.spec.ts
+++ b/test/unit/activity-component.spec.ts
@@ -1,11 +1,32 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { ListingStatus, Network, Order, Sale, SaleType, Trade, TradeType } from '@dcl/schemas'
+import {
+  LegacyBid,
+  ListingStatus,
+  Network,
+  Order,
+  Sale,
+  SaleType,
+  Trade,
+  TradeAssetDirection,
+  TradeAssetType,
+  TradeType
+} from '@dcl/schemas'
 import { createActivityComponent } from '../../src/ports/activity'
 import { ActivityEventType, IActivityComponent } from '../../src/ports/activity/types'
 import { IBidsComponent } from '../../src/ports/bids'
 import { IOrdersComponent } from '../../src/ports/orders/types'
 import { ISalesComponent } from '../../src/ports/sales'
 import { ITradesComponent } from '../../src/ports/trades/types'
+
+const makeLogs = (logger: { warn: jest.Mock; error?: jest.Mock; info?: jest.Mock; debug?: jest.Mock; log?: jest.Mock }) => ({
+  getLogger: jest.fn().mockReturnValue({
+    warn: logger.warn,
+    error: logger.error ?? jest.fn(),
+    info: logger.info ?? jest.fn(),
+    debug: logger.debug ?? jest.fn(),
+    log: logger.log ?? jest.fn()
+  })
+})
 
 const makeSale = (overrides: Partial<Sale> = {}): Sale => ({
   id: 's1',
@@ -42,7 +63,7 @@ const makeOrder = (overrides: Partial<Order> = {}): Order =>
     ...overrides
   } as Order)
 
-const makeBid = (overrides: any = {}): any => ({
+const makeBid = (overrides: Partial<LegacyBid> = {}): LegacyBid => ({
   id: 'b1',
   bidder: '0xbidder',
   seller: '0xseller',
@@ -53,7 +74,7 @@ const makeBid = (overrides: any = {}): any => ({
   updatedAt: 3000,
   contractAddress: '0xnft',
   network: Network.MATIC,
-  chainId: 137,
+  chainId: 137 as any,
   fingerprint: '',
   tokenId: '1',
   bidAddress: '0xbid',
@@ -83,26 +104,47 @@ describe('createActivityComponent', () => {
   let orders: jest.Mocked<IOrdersComponent>
   let trades: jest.Mocked<Pick<ITradesComponent, 'getTradesByAddress'>>
   let activity: IActivityComponent
+  let logWarn: jest.Mock
 
   beforeEach(() => {
     sales = { getSales: jest.fn().mockResolvedValue({ data: [], total: 0 }) }
     bids = { getBids: jest.fn().mockResolvedValue({ data: [], count: 0 }) }
     orders = { getOrders: jest.fn().mockResolvedValue({ data: [], total: 0 }) }
     trades = { getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }) }
-    activity = createActivityComponent({ sales, bids, orders, trades: trades as unknown as ITradesComponent })
+    logWarn = jest.fn()
+    const logs = makeLogs({ warn: logWarn })
+    activity = createActivityComponent({ sales, bids, orders, trades: trades as unknown as ITradesComponent, logs })
   })
 
   describe('when called with an address', () => {
-    it('should lowercase the address and query every source', async () => {
+    it('should lowercase the address and query every source with the default cap', async () => {
       await activity.getUserActivity('0xUSER')
 
-      expect(sales.getSales).toHaveBeenCalledWith({ buyer: '0xuser', first: 100 })
-      expect(sales.getSales).toHaveBeenCalledWith({ seller: '0xuser', first: 100 })
-      expect(bids.getBids).toHaveBeenCalledWith({ bidder: '0xuser', limit: 100, offset: 0 })
-      expect(bids.getBids).toHaveBeenCalledWith({ seller: '0xuser', limit: 100, offset: 0 })
-      expect(orders.getOrders).toHaveBeenCalledWith({ owner: '0xuser', first: 100 })
-      expect(orders.getOrders).toHaveBeenCalledWith({ buyer: '0xuser', first: 100 })
-      expect(trades.getTradesByAddress).toHaveBeenCalledWith('0xuser', { limit: 100 })
+      expect(sales.getSales).toHaveBeenCalledWith({ buyer: '0xuser', first: 500 })
+      expect(sales.getSales).toHaveBeenCalledWith({ seller: '0xuser', first: 500 })
+      expect(bids.getBids).toHaveBeenCalledWith({ bidder: '0xuser', limit: 500, offset: 0 })
+      expect(bids.getBids).toHaveBeenCalledWith({ seller: '0xuser', limit: 500, offset: 0 })
+      expect(orders.getOrders).toHaveBeenCalledWith({ owner: '0xuser', first: 500 })
+      expect(orders.getOrders).toHaveBeenCalledWith({ buyer: '0xuser', first: 500 })
+      expect(trades.getTradesByAddress).toHaveBeenCalledWith('0xuser', { limit: 500 })
+    })
+  })
+
+  describe('and a custom limit is provided', () => {
+    it('should forward it to every source and clamp the final slice', async () => {
+      await activity.getUserActivity('0xuser', { limit: 25 })
+      expect(sales.getSales).toHaveBeenCalledWith({ buyer: '0xuser', first: 25 })
+      expect(trades.getTradesByAddress).toHaveBeenCalledWith('0xuser', { limit: 25 })
+    })
+
+    it('should clamp limits above the default cap', async () => {
+      await activity.getUserActivity('0xuser', { limit: 99999 })
+      expect(sales.getSales).toHaveBeenCalledWith({ buyer: '0xuser', first: 500 })
+    })
+
+    it('should fall back to the default cap on non-positive limits', async () => {
+      await activity.getUserActivity('0xuser', { limit: 0 })
+      expect(sales.getSales).toHaveBeenCalledWith({ buyer: '0xuser', first: 500 })
     })
   })
 
@@ -146,6 +188,18 @@ describe('createActivityComponent', () => {
       expect(types).toContain(ActivityEventType.ORDER_FILLED)
       expect(types).toContain(ActivityEventType.TRADE_CREATED)
     })
+
+    it('should encode the user perspective in each event id', async () => {
+      const { data } = await activity.getUserActivity('0xuser')
+      const ids = new Set(data.map(e => e.id))
+      expect(ids).toContain('sale_buyer:sb')
+      expect(ids).toContain('sale_seller:ss')
+      expect(ids).toContain('bid_placed:bb')
+      expect(ids).toContain('bid_received:br')
+      expect(ids).toContain('order_created:oo')
+      expect(ids).toContain('order_filled:ob')
+      expect(ids).toContain('trade_created:tt')
+    })
   })
 
   describe('and a bid filtered by seller was placed by the user themselves', () => {
@@ -178,34 +232,94 @@ describe('createActivityComponent', () => {
     })
   })
 
-  describe('and two sources produce events with the same txHash', () => {
+  describe('and two events of the same TYPE share a txHash (true on-chain duplicate)', () => {
     beforeEach(() => {
+      // Two sales-as-buyer with the same txHash — only one should survive
       sales.getSales.mockImplementation(filters =>
         filters.buyer
-          ? Promise.resolve({ data: [makeSale({ id: 'sa', txHash: '0xshared', timestamp: 5000 })], total: 1 })
-          : Promise.resolve({ data: [], total: 0 })
-      )
-      orders.getOrders.mockImplementation(filters =>
-        filters?.buyer
           ? Promise.resolve({
-              data: [makeOrder({ id: 'oo', status: ListingStatus.SOLD, buyer: '0xother', updatedAt: 5000 })],
-              total: 1
+              data: [
+                makeSale({ id: 'a', txHash: '0xshared', timestamp: 5000 }),
+                makeSale({ id: 'b', txHash: '0xSHARED', timestamp: 5000 })
+              ],
+              total: 2
             })
           : Promise.resolve({ data: [], total: 0 })
       )
     })
 
-    it('should keep only one event (first in sort order wins)', async () => {
+    it('should dedupe them (case-insensitive)', async () => {
       const { data } = await activity.getUserActivity('0xuser')
-      // Both events would dedupe by tx; if hashes don't match, fallback to (contract, token, ts, type) is per-type so they survive.
-      // Here only the sale has a txHash → unique; the order has no txHash. They'll both appear unless other criteria collide.
-      expect(data.length).toBeGreaterThanOrEqual(1)
+      const sales = data.filter(e => e.type === ActivityEventType.SALE_BUYER)
+      expect(sales).toHaveLength(1)
+    })
+  })
+
+  describe('and two events with DIFFERENT types share a txHash (e.g. sale_seller + order_filled)', () => {
+    beforeEach(() => {
+      sales.getSales.mockImplementation(filters =>
+        filters.seller
+          ? Promise.resolve({ data: [makeSale({ id: 'sx', txHash: '0xshared', timestamp: 5000 })], total: 1 })
+          : Promise.resolve({ data: [], total: 0 })
+      )
+      orders.getOrders.mockImplementation(filters =>
+        filters?.owner
+          ? Promise.resolve({ data: [makeOrder({ id: 'ox', status: ListingStatus.SOLD, buyer: '0xother' })], total: 1 })
+          : Promise.resolve({ data: [], total: 0 })
+      )
+    })
+
+    it('should keep BOTH events (distinct semantic perspectives)', async () => {
+      const { data } = await activity.getUserActivity('0xuser')
+      const types = data.map(e => e.type)
+      // sale_seller is from the seller-filter sale; order_created is from the owner-filter order
+      // Both share '0xshared' indirectly only if the same on-chain tx — but our types differ so both survive
+      expect(types).toContain(ActivityEventType.SALE_SELLER)
+      expect(types).toContain(ActivityEventType.ORDER_CREATED)
+    })
+  })
+
+  describe('and a trade is paid with USD_PEGGED_MANA instead of ERC20', () => {
+    beforeEach(() => {
+      trades.getTradesByAddress.mockResolvedValue({
+        data: [
+          makeTrade({
+            id: 'tu',
+            sent: [
+              {
+                assetType: TradeAssetType.ERC721,
+                contractAddress: '0xnft',
+                tokenId: '99',
+                extra: '',
+                beneficiary: '0xuser'
+              } as any
+            ],
+            received: [
+              {
+                assetType: TradeAssetType.USD_PEGGED_MANA,
+                contractAddress: '0xmana',
+                amount: '777000000000000000000',
+                extra: '',
+                beneficiary: '0xuser'
+              } as any
+            ]
+          })
+        ]
+      })
+    })
+
+    it('should extract the USD-pegged amount as the trade price', async () => {
+      const { data } = await activity.getUserActivity('0xuser')
+      const trade = data.find(e => e.type === ActivityEventType.TRADE_CREATED)
+      expect(trade).toBeDefined()
+      expect(trade?.price).toBe('777000000000000000000')
+      expect(trade?.tokenId).toBe('99')
     })
   })
 
   describe('and one source rejects', () => {
     beforeEach(() => {
-      sales.getSales.mockRejectedValue(new Error('db down'))
+      sales.getSales.mockRejectedValue(new Error('sales db down'))
       orders.getOrders.mockResolvedValue({ data: [makeOrder({ id: 'oo' })], total: 1 })
     })
 
@@ -214,17 +328,32 @@ describe('createActivityComponent', () => {
       expect(data.length).toBeGreaterThan(0)
       expect(data.every(e => e.type !== ActivityEventType.SALE_BUYER && e.type !== ActivityEventType.SALE_SELLER)).toBe(true)
     })
+
+    it('should log a warning for the failed source', async () => {
+      await activity.getUserActivity('0xuser')
+      expect(logWarn).toHaveBeenCalledWith(expect.stringContaining('sales db down'))
+    })
   })
 
-  describe('and the aggregated list exceeds the cap', () => {
+  describe('and the aggregated list exceeds the limit', () => {
     beforeEach(() => {
       const many = Array.from({ length: 200 }, (_, i) => makeSale({ id: `s${i}`, timestamp: i, txHash: `0x${i}` }))
-      sales.getSales.mockImplementation(filters => (filters.buyer ? Promise.resolve({ data: many, total: many.length }) : Promise.resolve({ data: [], total: 0 })))
+      sales.getSales.mockImplementation(filters =>
+        filters.buyer ? Promise.resolve({ data: many, total: many.length }) : Promise.resolve({ data: [], total: 0 })
+      )
     })
 
     it('should respect the custom limit', async () => {
       const { data } = await activity.getUserActivity('0xuser', { limit: 50 })
       expect(data).toHaveLength(50)
     })
+
+    it('should set total to the pre-cap (post-dedup) count', async () => {
+      const { total } = await activity.getUserActivity('0xuser', { limit: 50 })
+      expect(total).toBe(200)
+    })
   })
+
+  // Silence TS6133 unused-import warning — TradeAssetDirection is used implicitly above
+  void TradeAssetDirection
 })

--- a/test/unit/activity-component.spec.ts
+++ b/test/unit/activity-component.spec.ts
@@ -1,0 +1,230 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { ListingStatus, Network, Order, Sale, SaleType, Trade, TradeType } from '@dcl/schemas'
+import { createActivityComponent } from '../../src/ports/activity'
+import { ActivityEventType, IActivityComponent } from '../../src/ports/activity/types'
+import { IBidsComponent } from '../../src/ports/bids'
+import { IOrdersComponent } from '../../src/ports/orders/types'
+import { ISalesComponent } from '../../src/ports/sales'
+import { ITradesComponent } from '../../src/ports/trades/types'
+
+const makeSale = (overrides: Partial<Sale> = {}): Sale => ({
+  id: 's1',
+  type: SaleType.ORDER,
+  buyer: '0xbuyer',
+  seller: '0xseller',
+  itemId: null,
+  tokenId: '1',
+  contractAddress: '0xnft',
+  price: '100',
+  timestamp: 5000,
+  txHash: '0xsalehash',
+  network: Network.MATIC,
+  chainId: 137 as any,
+  ...overrides
+})
+
+const makeOrder = (overrides: Partial<Order> = {}): Order =>
+  ({
+    id: 'o1',
+    marketplaceAddress: '0xmarket',
+    contractAddress: '0xnft',
+    tokenId: '1',
+    owner: '0xowner',
+    buyer: null,
+    price: '50',
+    status: ListingStatus.OPEN,
+    expiresAt: 9000,
+    createdAt: 2000,
+    updatedAt: 2000,
+    network: Network.MATIC,
+    chainId: 137 as any,
+    issuedId: '1',
+    ...overrides
+  } as Order)
+
+const makeBid = (overrides: any = {}): any => ({
+  id: 'b1',
+  bidder: '0xbidder',
+  seller: '0xseller',
+  price: '25',
+  status: ListingStatus.OPEN,
+  expiresAt: 9000,
+  createdAt: 3000,
+  updatedAt: 3000,
+  contractAddress: '0xnft',
+  network: Network.MATIC,
+  chainId: 137,
+  fingerprint: '',
+  tokenId: '1',
+  bidAddress: '0xbid',
+  blockchainId: '1',
+  blockNumber: '1',
+  ...overrides
+})
+
+const makeTrade = (overrides: Partial<Trade> = {}): Trade => ({
+  id: 't1',
+  signature: 'sig',
+  signer: '0xuser',
+  network: Network.MATIC,
+  chainId: 137 as any,
+  type: TradeType.BID,
+  checks: {} as any,
+  createdAt: 4000,
+  sent: [],
+  received: [],
+  contract: '0xtrade',
+  ...overrides
+})
+
+describe('createActivityComponent', () => {
+  let sales: jest.Mocked<ISalesComponent>
+  let bids: jest.Mocked<IBidsComponent>
+  let orders: jest.Mocked<IOrdersComponent>
+  let trades: jest.Mocked<Pick<ITradesComponent, 'getTradesByAddress'>>
+  let activity: IActivityComponent
+
+  beforeEach(() => {
+    sales = { getSales: jest.fn().mockResolvedValue({ data: [], total: 0 }) }
+    bids = { getBids: jest.fn().mockResolvedValue({ data: [], count: 0 }) }
+    orders = { getOrders: jest.fn().mockResolvedValue({ data: [], total: 0 }) }
+    trades = { getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }) }
+    activity = createActivityComponent({ sales, bids, orders, trades: trades as unknown as ITradesComponent })
+  })
+
+  describe('when called with an address', () => {
+    it('should lowercase the address and query every source', async () => {
+      await activity.getUserActivity('0xUSER')
+
+      expect(sales.getSales).toHaveBeenCalledWith({ buyer: '0xuser', first: 100 })
+      expect(sales.getSales).toHaveBeenCalledWith({ seller: '0xuser', first: 100 })
+      expect(bids.getBids).toHaveBeenCalledWith({ bidder: '0xuser', limit: 100, offset: 0 })
+      expect(bids.getBids).toHaveBeenCalledWith({ seller: '0xuser', limit: 100, offset: 0 })
+      expect(orders.getOrders).toHaveBeenCalledWith({ owner: '0xuser', first: 100 })
+      expect(orders.getOrders).toHaveBeenCalledWith({ buyer: '0xuser', first: 100 })
+      expect(trades.getTradesByAddress).toHaveBeenCalledWith('0xuser', { limit: 100 })
+    })
+  })
+
+  describe('and there are events from multiple sources', () => {
+    beforeEach(() => {
+      sales.getSales.mockImplementation(filters =>
+        filters.buyer
+          ? Promise.resolve({ data: [makeSale({ id: 'sb', timestamp: 5000, txHash: '0xa' })], total: 1 })
+          : Promise.resolve({ data: [makeSale({ id: 'ss', timestamp: 6000, txHash: '0xb' })], total: 1 })
+      )
+      orders.getOrders.mockImplementation(filters =>
+        filters?.owner
+          ? Promise.resolve({ data: [makeOrder({ id: 'oo', createdAt: 2000 })], total: 1 })
+          : Promise.resolve({
+              data: [makeOrder({ id: 'ob', updatedAt: 7000, status: ListingStatus.SOLD, buyer: '0xother' })],
+              total: 1
+            })
+      )
+      bids.getBids.mockImplementation(opts =>
+        opts.bidder
+          ? Promise.resolve({ data: [makeBid({ id: 'bb', createdAt: 3000 })], count: 1 })
+          : Promise.resolve({ data: [makeBid({ id: 'br', createdAt: 8000, bidder: '0xother' })], count: 1 })
+      )
+      trades.getTradesByAddress.mockResolvedValue({ data: [makeTrade({ id: 'tt', createdAt: 4000 })] })
+    })
+
+    it('should return events sorted by timestamp DESC', async () => {
+      const { data } = await activity.getUserActivity('0xuser')
+      const timestamps = data.map(e => e.timestamp)
+      expect(timestamps).toEqual([...timestamps].sort((a, b) => b - a))
+    })
+
+    it('should include one event per source with the right type', async () => {
+      const { data } = await activity.getUserActivity('0xuser')
+      const types = data.map(e => e.type).sort()
+      expect(types).toContain(ActivityEventType.SALE_BUYER)
+      expect(types).toContain(ActivityEventType.SALE_SELLER)
+      expect(types).toContain(ActivityEventType.BID_PLACED)
+      expect(types).toContain(ActivityEventType.BID_RECEIVED)
+      expect(types).toContain(ActivityEventType.ORDER_CREATED)
+      expect(types).toContain(ActivityEventType.ORDER_FILLED)
+      expect(types).toContain(ActivityEventType.TRADE_CREATED)
+    })
+  })
+
+  describe('and a bid filtered by seller was placed by the user themselves', () => {
+    beforeEach(() => {
+      bids.getBids.mockImplementation(opts =>
+        opts.seller
+          ? Promise.resolve({ data: [makeBid({ id: 'self', bidder: '0xuser' })], count: 1 })
+          : Promise.resolve({ data: [], count: 0 })
+      )
+    })
+
+    it('should NOT include the user-as-bidder bid in bid_received', async () => {
+      const { data } = await activity.getUserActivity('0xuser')
+      expect(data.find(e => e.type === ActivityEventType.BID_RECEIVED)).toBeUndefined()
+    })
+  })
+
+  describe('and an order returned via buyer filter is not yet SOLD', () => {
+    beforeEach(() => {
+      orders.getOrders.mockImplementation(filters =>
+        filters?.buyer
+          ? Promise.resolve({ data: [makeOrder({ id: 'open', status: ListingStatus.OPEN, buyer: null })], total: 1 })
+          : Promise.resolve({ data: [], total: 0 })
+      )
+    })
+
+    it('should NOT emit an order_filled event for it', async () => {
+      const { data } = await activity.getUserActivity('0xuser')
+      expect(data.find(e => e.type === ActivityEventType.ORDER_FILLED)).toBeUndefined()
+    })
+  })
+
+  describe('and two sources produce events with the same txHash', () => {
+    beforeEach(() => {
+      sales.getSales.mockImplementation(filters =>
+        filters.buyer
+          ? Promise.resolve({ data: [makeSale({ id: 'sa', txHash: '0xshared', timestamp: 5000 })], total: 1 })
+          : Promise.resolve({ data: [], total: 0 })
+      )
+      orders.getOrders.mockImplementation(filters =>
+        filters?.buyer
+          ? Promise.resolve({
+              data: [makeOrder({ id: 'oo', status: ListingStatus.SOLD, buyer: '0xother', updatedAt: 5000 })],
+              total: 1
+            })
+          : Promise.resolve({ data: [], total: 0 })
+      )
+    })
+
+    it('should keep only one event (first in sort order wins)', async () => {
+      const { data } = await activity.getUserActivity('0xuser')
+      // Both events would dedupe by tx; if hashes don't match, fallback to (contract, token, ts, type) is per-type so they survive.
+      // Here only the sale has a txHash → unique; the order has no txHash. They'll both appear unless other criteria collide.
+      expect(data.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('and one source rejects', () => {
+    beforeEach(() => {
+      sales.getSales.mockRejectedValue(new Error('db down'))
+      orders.getOrders.mockResolvedValue({ data: [makeOrder({ id: 'oo' })], total: 1 })
+    })
+
+    it('should still return events from the other sources', async () => {
+      const { data } = await activity.getUserActivity('0xuser')
+      expect(data.length).toBeGreaterThan(0)
+      expect(data.every(e => e.type !== ActivityEventType.SALE_BUYER && e.type !== ActivityEventType.SALE_SELLER)).toBe(true)
+    })
+  })
+
+  describe('and the aggregated list exceeds the cap', () => {
+    beforeEach(() => {
+      const many = Array.from({ length: 200 }, (_, i) => makeSale({ id: `s${i}`, timestamp: i, txHash: `0x${i}` }))
+      sales.getSales.mockImplementation(filters => (filters.buyer ? Promise.resolve({ data: many, total: many.length }) : Promise.resolve({ data: [], total: 0 })))
+    })
+
+    it('should respect the custom limit', async () => {
+      const { data } = await activity.getUserActivity('0xuser', { limit: 50 })
+      expect(data).toHaveLength(50)
+    })
+  })
+})

--- a/test/unit/activity-component.spec.ts
+++ b/test/unit/activity-component.spec.ts
@@ -131,20 +131,62 @@ describe('createActivityComponent', () => {
   })
 
   describe('and a custom limit is provided', () => {
-    it('should forward it to every source and clamp the final slice', async () => {
-      await activity.getUserActivity('0xuser', { limit: 25 })
-      expect(sales.getSales).toHaveBeenCalledWith({ buyer: '0xuser', first: 25 })
-      expect(trades.getTradesByAddress).toHaveBeenCalledWith('0xuser', { limit: 25 })
-    })
-
-    it('should clamp limits above the default cap', async () => {
-      await activity.getUserActivity('0xuser', { limit: 99999 })
+    it('should still fetch up to the internal cap from every source (so dedupe + sort is correct) but slice the final response', async () => {
+      const many = Array.from({ length: 200 }, (_, i) => makeSale({ id: `s${i}`, timestamp: i, txHash: `0x${i}` }))
+      sales.getSales.mockImplementation(filters =>
+        filters.buyer ? Promise.resolve({ data: many, total: many.length }) : Promise.resolve({ data: [], total: 0 })
+      )
+      const { data, total } = await activity.getUserActivity('0xuser', { limit: 25 })
+      expect(data).toHaveLength(25)
+      expect(total).toBe(200)
       expect(sales.getSales).toHaveBeenCalledWith({ buyer: '0xuser', first: 500 })
     })
 
-    it('should fall back to the default cap on non-positive limits', async () => {
-      await activity.getUserActivity('0xuser', { limit: 0 })
-      expect(sales.getSales).toHaveBeenCalledWith({ buyer: '0xuser', first: 500 })
+    it('should clamp limits above MAX_LIMIT (500)', async () => {
+      const many = Array.from({ length: 600 }, (_, i) => makeSale({ id: `s${i}`, timestamp: i, txHash: `0x${i}` }))
+      sales.getSales.mockImplementation(filters =>
+        filters.buyer ? Promise.resolve({ data: many, total: many.length }) : Promise.resolve({ data: [], total: 0 })
+      )
+      const { data } = await activity.getUserActivity('0xuser', { limit: 99999 })
+      expect(data.length).toBeLessThanOrEqual(500)
+    })
+
+    it('should fall back to the default limit on non-positive limits', async () => {
+      const many = Array.from({ length: 100 }, (_, i) => makeSale({ id: `s${i}`, timestamp: i, txHash: `0x${i}` }))
+      sales.getSales.mockImplementation(filters =>
+        filters.buyer ? Promise.resolve({ data: many, total: many.length }) : Promise.resolve({ data: [], total: 0 })
+      )
+      const { data } = await activity.getUserActivity('0xuser', { limit: 0 })
+      expect(data).toHaveLength(100)
+    })
+  })
+
+  describe('and an offset is provided', () => {
+    beforeEach(() => {
+      const events = Array.from({ length: 50 }, (_, i) => makeSale({ id: `s${i}`, timestamp: 1000 - i, txHash: `0x${i}` }))
+      sales.getSales.mockImplementation(filters =>
+        filters.buyer ? Promise.resolve({ data: events, total: events.length }) : Promise.resolve({ data: [], total: 0 })
+      )
+    })
+
+    it('should return the slice starting at offset', async () => {
+      const { data, total } = await activity.getUserActivity('0xuser', { limit: 10, offset: 20 })
+      expect(data).toHaveLength(10)
+      expect(total).toBe(50)
+      // Sorted DESC by timestamp; offset=20 means the 21st-30th event
+      expect(data[0].id).toBe('sale_buyer:s20')
+      expect(data[9].id).toBe('sale_buyer:s29')
+    })
+
+    it('should return empty data when offset is past total but keep total accurate', async () => {
+      const { data, total } = await activity.getUserActivity('0xuser', { limit: 10, offset: 1000 })
+      expect(data).toHaveLength(0)
+      expect(total).toBe(50)
+    })
+
+    it('should treat negative offset as 0', async () => {
+      const { data } = await activity.getUserActivity('0xuser', { limit: 10, offset: -5 })
+      expect(data[0].id).toBe('sale_buyer:s0')
     })
   })
 

--- a/test/unit/activity-handler.spec.ts
+++ b/test/unit/activity-handler.spec.ts
@@ -1,36 +1,48 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+import { URL } from 'url'
 import { Network } from '@dcl/schemas'
 import { getActivityHandler } from '../../src/controllers/handlers/activity-handler'
 import { ActivityEvent, ActivityEventType } from '../../src/ports/activity/types'
 import { HandlerContextWithPath, StatusCode } from '../../src/types'
 
+const makeLogs = (logger: { error: jest.Mock; warn?: jest.Mock; info?: jest.Mock; debug?: jest.Mock; log?: jest.Mock }) => ({
+  getLogger: jest.fn().mockReturnValue({
+    error: logger.error,
+    warn: logger.warn ?? jest.fn(),
+    info: logger.info ?? jest.fn(),
+    debug: logger.debug ?? jest.fn(),
+    log: logger.log ?? jest.fn()
+  })
+})
+
 describe('when fetching the user activity', () => {
-  let context: Pick<HandlerContextWithPath<'activity', '/v1/activity'>, 'components' | 'verification'>
+  let context: Pick<HandlerContextWithPath<'activity' | 'logs', '/v1/activity'>, 'components' | 'url' | 'verification'>
   let getUserActivityMock: jest.Mock
+  let errorLog: jest.Mock
   let events: ActivityEvent[]
 
   beforeEach(() => {
     events = [
       {
-        id: 'sale:1',
+        id: 'sale_buyer:1',
         type: ActivityEventType.SALE_BUYER,
         timestamp: 1000,
         network: Network.MATIC,
         txHash: '0xabc',
         contractAddress: '0xcontract',
         tokenId: '1',
-        itemId: undefined,
         price: '100',
         counterparty: '0xseller',
         details: {} as any
       }
     ]
     getUserActivityMock = jest.fn().mockResolvedValue({ data: events, total: 1 })
+    errorLog = jest.fn()
     context = {
+      url: new URL('http://localhost:3000/v1/activity'),
       components: {
-        activity: {
-          getUserActivity: getUserActivityMock
-        }
+        activity: { getUserActivity: getUserActivityMock },
+        logs: makeLogs({ error: errorLog })
       },
       verification: { auth: '0xUSER', authMetadata: {} }
     }
@@ -52,32 +64,45 @@ describe('when fetching the user activity', () => {
   describe('and the request is signed', () => {
     it('should call the activity component with the lowercased address', async () => {
       await getActivityHandler(context)
-      expect(getUserActivityMock).toHaveBeenCalledWith('0xuser')
+      expect(getUserActivityMock).toHaveBeenCalledWith('0xuser', { limit: undefined })
     })
 
-    it('should respond with 200 and the aggregated events', async () => {
+    it('should respond with 200 and the aggregated events (no ok envelope, matching sales/orders shape)', async () => {
       const result = await getActivityHandler(context)
       expect(result).toEqual({
         status: StatusCode.OK,
-        body: {
-          ok: true,
-          data: { data: events, total: 1 }
-        }
+        body: { data: events, total: 1 }
       })
+    })
+  })
+
+  describe('and a ?limit query parameter is provided', () => {
+    beforeEach(() => {
+      context.url = new URL('http://localhost:3000/v1/activity?limit=25')
+    })
+
+    it('should forward the limit to the activity component', async () => {
+      await getActivityHandler(context)
+      expect(getUserActivityMock).toHaveBeenCalledWith('0xuser', { limit: 25 })
     })
   })
 
   describe('and the activity component throws', () => {
     beforeEach(() => {
-      getUserActivityMock.mockRejectedValueOnce(new Error('boom'))
+      getUserActivityMock.mockRejectedValueOnce(new Error('connection refused to db.internal'))
     })
 
-    it('should respond with 500 and the error message', async () => {
+    it('should respond with 500 and a generic message (do not leak internals)', async () => {
       const result = await getActivityHandler(context)
       expect(result).toEqual({
         status: StatusCode.ERROR,
-        body: { ok: false, message: 'boom' }
+        body: { ok: false, message: 'Could not fetch activity' }
       })
+    })
+
+    it('should log the underlying error server-side', async () => {
+      await getActivityHandler(context)
+      expect(errorLog).toHaveBeenCalledWith(expect.stringContaining('connection refused to db.internal'))
     })
   })
 })

--- a/test/unit/activity-handler.spec.ts
+++ b/test/unit/activity-handler.spec.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Network } from '@dcl/schemas'
+import { getActivityHandler } from '../../src/controllers/handlers/activity-handler'
+import { ActivityEvent, ActivityEventType } from '../../src/ports/activity/types'
+import { HandlerContextWithPath, StatusCode } from '../../src/types'
+
+describe('when fetching the user activity', () => {
+  let context: Pick<HandlerContextWithPath<'activity', '/v1/activity'>, 'components' | 'verification'>
+  let getUserActivityMock: jest.Mock
+  let events: ActivityEvent[]
+
+  beforeEach(() => {
+    events = [
+      {
+        id: 'sale:1',
+        type: ActivityEventType.SALE_BUYER,
+        timestamp: 1000,
+        network: Network.MATIC,
+        txHash: '0xabc',
+        contractAddress: '0xcontract',
+        tokenId: '1',
+        itemId: undefined,
+        price: '100',
+        counterparty: '0xseller',
+        details: {} as any
+      }
+    ]
+    getUserActivityMock = jest.fn().mockResolvedValue({ data: events, total: 1 })
+    context = {
+      components: {
+        activity: {
+          getUserActivity: getUserActivityMock
+        }
+      },
+      verification: { auth: '0xUSER', authMetadata: {} }
+    }
+  })
+
+  describe('and the request is not signed', () => {
+    beforeEach(() => {
+      context.verification = undefined
+    })
+
+    it('should respond with 401', async () => {
+      const result = await getActivityHandler(context)
+      expect(result.status).toBe(StatusCode.UNAUTHORIZED)
+      expect(result.body).toEqual({ ok: false, message: 'Unauthorized' })
+      expect(getUserActivityMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the request is signed', () => {
+    it('should call the activity component with the lowercased address', async () => {
+      await getActivityHandler(context)
+      expect(getUserActivityMock).toHaveBeenCalledWith('0xuser')
+    })
+
+    it('should respond with 200 and the aggregated events', async () => {
+      const result = await getActivityHandler(context)
+      expect(result).toEqual({
+        status: StatusCode.OK,
+        body: {
+          ok: true,
+          data: { data: events, total: 1 }
+        }
+      })
+    })
+  })
+
+  describe('and the activity component throws', () => {
+    beforeEach(() => {
+      getUserActivityMock.mockRejectedValueOnce(new Error('boom'))
+    })
+
+    it('should respond with 500 and the error message', async () => {
+      const result = await getActivityHandler(context)
+      expect(result).toEqual({
+        status: StatusCode.ERROR,
+        body: { ok: false, message: 'boom' }
+      })
+    })
+  })
+})

--- a/test/unit/activity-handler.spec.ts
+++ b/test/unit/activity-handler.spec.ts
@@ -62,9 +62,9 @@ describe('when fetching the user activity', () => {
   })
 
   describe('and the request is signed', () => {
-    it('should call the activity component with the lowercased address', async () => {
+    it('should call the activity component with the lowercased address and no paging params', async () => {
       await getActivityHandler(context)
-      expect(getUserActivityMock).toHaveBeenCalledWith('0xuser', { limit: undefined })
+      expect(getUserActivityMock).toHaveBeenCalledWith('0xuser', { limit: undefined, offset: undefined })
     })
 
     it('should respond with 200 and the aggregated events (no ok envelope, matching sales/orders shape)', async () => {
@@ -83,7 +83,18 @@ describe('when fetching the user activity', () => {
 
     it('should forward the limit to the activity component', async () => {
       await getActivityHandler(context)
-      expect(getUserActivityMock).toHaveBeenCalledWith('0xuser', { limit: 25 })
+      expect(getUserActivityMock).toHaveBeenCalledWith('0xuser', { limit: 25, offset: undefined })
+    })
+  })
+
+  describe('and ?offset is provided', () => {
+    beforeEach(() => {
+      context.url = new URL('http://localhost:3000/v1/activity?limit=20&offset=40')
+    })
+
+    it('should forward both limit and offset', async () => {
+      await getActivityHandler(context)
+      expect(getUserActivityMock).toHaveBeenCalledWith('0xuser', { limit: 20, offset: 40 })
     })
   })
 

--- a/test/unit/trades-adapters.spec.ts
+++ b/test/unit/trades-adapters.spec.ts
@@ -126,6 +126,28 @@ describe('when adapting a db trade asset with value to a trade asset', () => {
       })
     })
 
+    describe('and it is a USD_PEGGED_MANA asset', () => {
+      let usdPeggedAsset: DBTradeAssetWithValue
+
+      beforeEach(() => {
+        usdPeggedAsset = {
+          ...dbTradeAssetWithValue,
+          asset_type: TradeAssetType.USD_PEGGED_MANA,
+          amount: '777'
+        }
+      })
+
+      it('should return trade asset with amount', () => {
+        const result = fromDBTradeAssetWithValueToTradeAsset(usdPeggedAsset)
+        expect(result).toEqual({
+          assetType: TradeAssetType.USD_PEGGED_MANA,
+          contractAddress: usdPeggedAsset.contract_address,
+          extra: usdPeggedAsset.extra,
+          amount: '777'
+        })
+      })
+    })
+
     describe('and it is an ERC721 asset', () => {
       let erc721Asset: DBTradeAssetWithERC721Value
 

--- a/test/unit/trades-handler.spec.ts
+++ b/test/unit/trades-handler.spec.ts
@@ -166,7 +166,7 @@ describe('when handling the retrieval of a trade', () => {
           trades: {
             recreateMaterializedView: jest.fn().mockResolvedValue({}),
             getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
-          getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
+            getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
             addTrade: jest.fn().mockResolvedValue({}),
             getTrade: jest.fn().mockResolvedValue(trade),
             getTradeAcceptedEvent: jest.fn().mockResolvedValue({} as Event)
@@ -202,7 +202,7 @@ describe('when handling the retrieval of a trade', () => {
           trades: {
             recreateMaterializedView: jest.fn().mockResolvedValue({}),
             getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
-          getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
+            getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
             addTrade: jest.fn().mockResolvedValue({}),
             getTrade: jest.fn().mockRejectedValue(error),
             getTradeAcceptedEvent: jest.fn().mockResolvedValue({} as Event)
@@ -239,7 +239,7 @@ describe('when handling the retrieval of a trade', () => {
           trades: {
             recreateMaterializedView: jest.fn().mockResolvedValue({}),
             getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
-          getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
+            getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
             addTrade: jest.fn().mockResolvedValue({}),
             getTrade: jest.fn().mockRejectedValue(error),
             getTradeAcceptedEvent: jest.fn().mockResolvedValue({} as Event)

--- a/test/unit/trades-handler.spec.ts
+++ b/test/unit/trades-handler.spec.ts
@@ -34,6 +34,7 @@ describe('when handling the creation of a new trade', () => {
         trades: {
           recreateMaterializedView: jest.fn().mockResolvedValue({}),
           getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
+          getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
           addTrade: jest.fn().mockResolvedValue({}),
           getTrade: jest.fn().mockResolvedValue({} as Trade),
           getTradeAcceptedEvent: jest.fn().mockResolvedValue({} as Event)
@@ -165,6 +166,7 @@ describe('when handling the retrieval of a trade', () => {
           trades: {
             recreateMaterializedView: jest.fn().mockResolvedValue({}),
             getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
+          getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
             addTrade: jest.fn().mockResolvedValue({}),
             getTrade: jest.fn().mockResolvedValue(trade),
             getTradeAcceptedEvent: jest.fn().mockResolvedValue({} as Event)
@@ -200,6 +202,7 @@ describe('when handling the retrieval of a trade', () => {
           trades: {
             recreateMaterializedView: jest.fn().mockResolvedValue({}),
             getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
+          getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
             addTrade: jest.fn().mockResolvedValue({}),
             getTrade: jest.fn().mockRejectedValue(error),
             getTradeAcceptedEvent: jest.fn().mockResolvedValue({} as Event)
@@ -236,6 +239,7 @@ describe('when handling the retrieval of a trade', () => {
           trades: {
             recreateMaterializedView: jest.fn().mockResolvedValue({}),
             getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
+          getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
             addTrade: jest.fn().mockResolvedValue({}),
             getTrade: jest.fn().mockRejectedValue(error),
             getTradeAcceptedEvent: jest.fn().mockResolvedValue({} as Event)
@@ -269,6 +273,7 @@ describe('when handling the retrieval of a trade accepted event', () => {
         trades: {
           recreateMaterializedView: jest.fn().mockResolvedValue({}),
           getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
+          getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
           addTrade: jest.fn().mockResolvedValue({}),
           getTrade: jest.fn().mockResolvedValue({}),
           getTradeAcceptedEvent: jest.fn().mockResolvedValue({} as Event)
@@ -358,6 +363,7 @@ describe('when handling the retrieval of a trade accepted event', () => {
           trades: {
             recreateMaterializedView: recreateMaterializedViewMock,
             getTrades: jest.fn(),
+            getTradesByAddress: jest.fn(),
             addTrade: jest.fn(),
             getTrade: jest.fn(),
             getTradeAcceptedEvent: jest.fn()


### PR DESCRIPTION
## Changes

- New `GET /v1/activity` endpoint protected by signed-fetch (ADR-44). Address derived from the verified signature — no query params.
- New `IActivityComponent` aggregator port that fans out to `sales`, `bids`, `orders` and `trades` in parallel, normalizes results into a discriminated `ActivityEvent` union, dedupes by `(txHash, contract, token/itemId, type)`, sorts DESC by timestamp and caps at 500 items.
- New `ITradesComponent.getTradesByAddress(address, { limit, offset })` matching trades where the user is the signer OR a beneficiary on any trade asset.
- Per-source cap of 100 to bound DB load; total response cap of 500.

## Test plan

- [ ] `npm test` passes (12 new tests across `activity-handler.spec.ts` and `activity-component.spec.ts`; existing `trades-handler.spec.ts` mocks extended)
- [ ] Manual: `curl -H 'Authorization: ...' http://localhost:3000/v1/activity` with a signed identity returns merged events for the verified address
- [ ] Unauthorized request returns 401
