### PR TITLE
feat: validate Estate trade fingerprint against getFingerprintV2

### DIFF
--- a/src/logic/trades/utils.ts
+++ b/src/logic/trades/utils.ts
@@ -151,10 +151,10 @@ export async function isEstateFingerprintValid(
   chainId: ChainId,
   fingerprint: string
 ): Promise<boolean> {
-  const abi = ['function getFingerprint(uint256 tokenId) view returns (bytes32)']
+  const abi = ['function getFingerprintV2(uint256 tokenId) view returns (bytes32)']
   const provider = new JsonRpcProvider(getRPCUrlByChainId(chainId))
   const contract = new Contract(contractAddress, abi, provider)
-  const estateFingerprint = await contract.getFingerprint(tokenId)
+  const estateFingerprint = await contract.getFingerprintV2(tokenId)
   return estateFingerprint.toLowerCase() === fingerprint.toLowerCase()
 }
 

--- a/test/unit/trades-logic.spec.ts
+++ b/test/unit/trades-logic.spec.ts
@@ -184,7 +184,7 @@ describe('when validating the estate signature', () => {
     beforeEach(() => {
       ;(Contract as jest.Mock).mockImplementationOnce(() => {
         return {
-          getFingerprint: () => Promise.resolve(fingerprint)
+          getFingerprintV2: () => Promise.resolve(fingerprint)
         }
       })
     })
@@ -198,7 +198,7 @@ describe('when validating the estate signature', () => {
     beforeEach(() => {
       ;(Contract as jest.Mock).mockImplementationOnce(() => {
         return {
-          getFingerprint: () => Promise.resolve('0x')
+          getFingerprintV2: () => Promise.resolve('0x')
         }
       })
     })


### PR DESCRIPTION
## Summary
  
  When validating an incoming Estate trade, query `EstateRegistry.getFingerprintV2(tokenId)` instead of the legacy
  `getFingerprint`. New trades must sign with the v2 fingerprint to be accepted by the upgraded on-chain `verifyFingerprint`.
  
  ## Test plan

  - [ ] Unit tests in `test/unit/trades-logic.spec.ts` pass
  - [ ] Creating a new Estate trade via the webapp succeeds end-to-end
  - [ ] Existing v1-signed trades remain in the DB untouched (the validation only runs on creation)