### PR TITLE
fix: restrict /v1/wert/sign endpoint and patch elliptic

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -21,6 +21,11 @@ WERT_PRIVATE_KEY='dummyKey'
 WERT_PUBLICATION_FEES_PRIVATE_KEY='dummyKey2'
 WERT_API_URL=https://partner-sandbox.wert.io/api/external/hpp
 WERT_API_KEY='dummyApiKey'
+# Optional comma-separated contract addresses to allowlist for /v1/wert/sign in addition to the
+# ones resolved from decentraland-transactions for the configured chains. Use these to support
+# environment-specific contracts (e.g. the dev fiat names controller).
+# WERT_DEFAULT_ALLOWED_CONTRACTS=
+# WERT_PUBLICATION_FEES_ALLOWED_CONTRACTS=
 SEGMENT_WRITE_KEY='dummyKey3'
 BUILDER_SERVER_DB_HOST='builder_db'
 BUILDER_SERVER_DB_PORT=5432

--- a/.env.default
+++ b/.env.default
@@ -22,8 +22,8 @@ WERT_PUBLICATION_FEES_PRIVATE_KEY='dummyKey2'
 WERT_API_URL=https://partner-sandbox.wert.io/api/external/hpp
 WERT_API_KEY='dummyApiKey'
 # Optional comma-separated contract addresses to allowlist for /v1/wert/sign in addition to the
-# ones resolved from decentraland-transactions for the configured chains. Use these to support
-# environment-specific contracts (e.g. the dev fiat names controller).
+# ones resolved from decentraland-transactions (and the well-known additions baked into the code)
+# for the configured chains. Use these to support further environment-specific contracts.
 # WERT_DEFAULT_ALLOWED_CONTRACTS=
 # WERT_PUBLICATION_FEES_ALLOWED_CONTRACTS=
 SEGMENT_WRITE_KEY='dummyKey3'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -701,7 +701,14 @@ paths:
         Wert is a fiat-to-crypto payment solution that allows users to purchase NFTs with credit/debit cards.
         This endpoint validates and signs the transaction data before forwarding to Wert's infrastructure.
 
-        Authentication is optional but recommended for tracking user transactions.
+        For security, the server only signs calls to an allowlisted set of Decentraland contracts and
+        functions, selected by the `target`:
+          - `default`: `register` on the `DCLControllerV2` contract (MANA name purchases).
+          - `publicationFees`: `createCollection` on the `CollectionManager` contract (collection publication fees).
+
+        Requests whose `sc_address` or `sc_input_data` function selector are not allowed for the
+        target are rejected with a 400. The authenticated address must match both `message.address`
+        and `session.wallet_address`.
       operationId: signWertTransaction
       security:
         - SignedFetch: []
@@ -719,6 +726,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WertSignResponse'
+        '400':
+          description: Invalid request body, target, contract address, or contract call
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: The authenticated address does not match the message or session wallet address
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /v1/transak/orders/{id}:
     get:
       tags:
@@ -3168,28 +3187,77 @@ components:
     WertSignRequest:
       type: object
       properties:
-        transaction:
+        message:
+          type: object
+          description: |
+            The Wert smart-contract order to sign. The `sc_address` and the function selector
+            encoded in `sc_input_data` must be allowlisted for the chosen `target`.
+          properties:
+            address:
+              type: string
+              description: Wallet address of the buyer. Must match the authenticated address.
+            commodity:
+              type: string
+              description: Crypto asset to be spent (e.g. MANA).
+            commodity_amount:
+              type: number
+              description: Amount of the commodity to spend.
+            network:
+              type: string
+              description: Network where the transaction will be broadcast (e.g. ethereum, polygon).
+            sc_address:
+              type: string
+              description: Target contract address. Must be an allowlisted Decentraland contract for the target.
+            sc_input_data:
+              type: string
+              description: ABI-encoded calldata. Its function selector must be allowlisted for the target.
+          required:
+            - address
+            - commodity
+            - commodity_amount
+            - network
+            - sc_address
+            - sc_input_data
+        session:
           type: object
           additionalProperties: true
-          description: |
-            Transaction data (TODO: align with precise source types)
-        signature:
+          description: Wert session parameters. `wallet_address` must match the authenticated address.
+          properties:
+            flow_type:
+              type: string
+              enum: [simple, simple_full_restrict]
+          required:
+            - flow_type
+        target:
           type: string
-          description: Transaction signature
+          enum: [default, publicationFees]
+          description: |
+            Selects the allowlisted contract/function and the signing key.
+            Defaults to `default` (MANA name purchases) when omitted.
       required:
-        - transaction
+        - message
+        - session
     WertSignResponse:
       type: object
       properties:
-        signedTransaction:
-          type: string
-          description: Signed transaction
-        success:
+        ok:
           type: boolean
-          description: Signing success status
+          description: Whether the request succeeded.
+        data:
+          type: object
+          properties:
+            signature:
+              type: string
+              description: The signed Wert message signature.
+            sessionId:
+              type: string
+              description: The created Wert session identifier.
+          required:
+            - signature
+            - sessionId
       required:
-        - signedTransaction
-        - success
+        - ok
+        - data
     TransakOrder:
       type: object
       properties:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2172,27 +2172,6 @@
       "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/@cosmjs/stargate/node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/@cosmjs/stargate/node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-      "license": "MIT"
-    },
     "node_modules/@cosmjs/stream": {
       "version": "0.30.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.30.1.tgz",
@@ -4178,6 +4157,59 @@
       "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-23.0.0.tgz",
       "integrity": "sha512-NTjgGPJVYxoncSrHtDZLDiJzdSbxHV0jCy6J+YvT+LY7QUiGY3zzu+NhLqgLxE6KZODXERhSLYSimotcokZbmw==",
       "license": "MIT"
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@metamask/eth-json-rpc-provider": {
       "version": "1.0.1",
@@ -10212,6 +10244,30 @@
         "node": ">= 8"
       }
     },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -11171,6 +11227,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -11224,6 +11291,14 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -12326,27 +12401,6 @@
       "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
       "license": "MIT"
     },
-    "node_modules/decentraland-connect/node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/decentraland-connect/node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-      "license": "MIT"
-    },
     "node_modules/decentraland-connect/node_modules/ethers": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
@@ -12577,6 +12631,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -12771,9 +12833,9 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -14588,6 +14650,34 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -14614,6 +14704,29 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/generator-function": {
@@ -14928,6 +15041,14 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/hash-base": {
       "version": "3.1.2",
@@ -16368,6 +16489,37 @@
         "@types/yargs-parser": "*"
       }
     },
+    "node_modules/jest-environment-jsdom/node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
@@ -16446,6 +16598,33 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/jest-environment-node": {
@@ -18107,6 +18286,23 @@
         "localforage": "^1.7.4"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -18295,6 +18491,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -18341,6 +18566,14 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
       "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/nan": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -18708,6 +18941,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/number-to-bn": {
@@ -20506,21 +20754,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/secp256k1/node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
     "node_modules/secp256k1/node_modules/node-addon-api": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
@@ -21199,6 +21432,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -21225,6 +21478,28 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tdigest": {
@@ -22569,6 +22844,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/wrap-ansi": {
@@ -24389,7 +24675,7 @@
         "@cosmjs/utils": "^0.31.3",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
+        "elliptic": "6.6.1",
         "libsodium-wrappers-sumo": "^0.7.11"
       },
       "dependencies": {
@@ -24519,7 +24805,7 @@
             "@cosmjs/utils": "^0.33.1",
             "@noble/hashes": "^1",
             "bn.js": "^5.2.0",
-            "elliptic": "^6.6.1",
+            "elliptic": "6.6.1",
             "libsodium-wrappers-sumo": "^0.7.11"
           }
         },
@@ -24618,27 +24904,6 @@
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
           "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
-        },
-        "elliptic": {
-          "version": "6.6.1",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-          "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "brorand": "^1.1.0",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.1",
-            "inherits": "^2.0.4",
-            "minimalistic-assert": "^1.0.1",
-            "minimalistic-crypto-utils": "^1.0.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.2",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-              "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="
-            }
-          }
         }
       }
     },
@@ -25396,7 +25661,7 @@
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "bn.js": "^5.2.1",
-        "elliptic": "6.5.4",
+        "elliptic": "6.6.1",
         "hash.js": "1.1.7"
       },
       "dependencies": {
@@ -26057,6 +26322,46 @@
       "version": "23.0.0",
       "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-23.0.0.tgz",
       "integrity": "sha512-NTjgGPJVYxoncSrHtDZLDiJzdSbxHV0jCy6J+YvT+LY7QUiGY3zzu+NhLqgLxE6KZODXERhSLYSimotcokZbmw=="
+    },
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+          "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "semver": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+          "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
+      }
     },
     "@metamask/eth-json-rpc-provider": {
       "version": "1.0.1",
@@ -30610,7 +30915,7 @@
       "integrity": "sha512-8BMZOnvGKj+LwIlmNqJyKFLn0VCMudURV81dUb0CyGGy8XJwBqAtNPj81iPIw07xx+a61hpgd8ngWQi6i3CwUQ==",
       "requires": {
         "@types/elliptic": "^6.4.12",
-        "elliptic": "^6.5.4"
+        "elliptic": "6.6.1"
       }
     },
     "abab": {
@@ -30778,6 +31083,26 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
       }
     },
     "arg": {
@@ -31474,6 +31799,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -31514,6 +31847,14 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -32202,27 +32543,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
           "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="
         },
-        "elliptic": {
-          "version": "6.6.1",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-          "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "brorand": "^1.1.0",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.1",
-            "inherits": "^2.0.4",
-            "minimalistic-assert": "^1.0.1",
-            "minimalistic-crypto-utils": "^1.0.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.2",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-              "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="
-            }
-          }
-        },
         "ethers": {
           "version": "5.8.0",
           "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
@@ -32380,6 +32700,14 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -32527,9 +32855,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -33253,7 +33581,7 @@
       "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
       "requires": {
         "bn.js": "^4.11.6",
-        "elliptic": "^6.4.0",
+        "elliptic": "6.6.1",
         "xhr-request-promise": "^0.1.2"
       }
     },
@@ -33842,6 +34170,30 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -33859,6 +34211,25 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      }
     },
     "generator-function": {
       "version": "2.0.1",
@@ -34069,6 +34440,14 @@
       "requires": {
         "has-symbols": "^1.0.3"
       }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "hash-base": {
       "version": "3.1.2",
@@ -35108,6 +35487,30 @@
             "@types/yargs-parser": "*"
           }
         },
+        "canvas": {
+          "version": "2.11.2",
+          "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+          "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@mapbox/node-pre-gyp": "^1.0.0",
+            "nan": "^2.17.0",
+            "simple-get": "^3.0.3"
+          }
+        },
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
         "jest-message-util": {
           "version": "27.5.1",
           "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
@@ -35168,6 +35571,27 @@
             "whatwg-url": "^8.5.0",
             "ws": "^7.4.6",
             "xml-name-validator": "^3.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "simple-get": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+          "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "decompress-response": "^4.2.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
           }
         }
       }
@@ -36509,6 +36933,17 @@
         "localforage": "^1.7.4"
       }
     },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "semver": "^6.0.0"
+      }
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -36649,6 +37084,31 @@
       "dev": true,
       "peer": true
     },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
+      }
+    },
     "mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -36686,6 +37146,14 @@
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "nan": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "napi-build-utils": {
       "version": "2.0.0",
@@ -36973,6 +37441,20 @@
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "number-to-bn": {
@@ -38207,25 +38689,11 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
       "integrity": "sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==",
       "requires": {
-        "elliptic": "^6.5.7",
+        "elliptic": "6.6.1",
         "node-addon-api": "^5.0.0",
         "node-gyp-build": "^4.2.0"
       },
       "dependencies": {
-        "elliptic": {
-          "version": "6.6.1",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-          "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "brorand": "^1.1.0",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.1",
-            "inherits": "^2.0.4",
-            "minimalistic-assert": "^1.0.1",
-            "minimalistic-crypto-utils": "^1.0.1"
-          }
-        },
         "node-addon-api": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
@@ -38728,6 +39196,40 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true
+    },
+    "tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "minipass": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+          "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
+      }
     },
     "tar-fs": {
       "version": "2.1.4",
@@ -39610,6 +40112,17 @@
         "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "nock": "^13.5.4",
     "p-limit": "^3.1.0",
     "seedrandom": "^3.0.5"
+  },
+  "overrides": {
+    "elliptic": "6.6.1"
   }
 }

--- a/src/controllers/handlers/wert-signer-and-session-creator-handler.ts
+++ b/src/controllers/handlers/wert-signer-and-session-creator-handler.ts
@@ -1,4 +1,5 @@
 import { WertSession } from '../../ports/wert/api/types'
+import { InvalidWertMessageError } from '../../ports/wert/signer/errors'
 import { WertMessage } from '../../ports/wert/signer/types'
 import { Target } from '../../ports/wert/types'
 import { HTTPResponse, HandlerContextWithPath, StatusCode } from '../../types'
@@ -23,7 +24,7 @@ export async function createWertSignerAndSessionCreatorHandler(
 
   if (
     !userAddress ||
-    (!!userAddress && userAddress !== wertMessage.address.toLowerCase()) ||
+    (!!userAddress && userAddress !== wertMessage?.address?.toLowerCase()) ||
     (!!userAddress && userAddress !== wertSession.wallet_address?.toLowerCase())
   ) {
     return {
@@ -45,16 +46,30 @@ export async function createWertSignerAndSessionCreatorHandler(
     }
   }
 
-  const [signature, { sessionId }] = await Promise.all([wertSigner.signMessage(wertMessage, target), wertApi.createSession(wertSession)])
+  try {
+    const [signature, { sessionId }] = await Promise.all([wertSigner.signMessage(wertMessage, target), wertApi.createSession(wertSession)])
 
-  return {
-    status: StatusCode.OK,
-    body: {
-      ok: true,
-      data: {
-        signature,
-        sessionId
+    return {
+      status: StatusCode.OK,
+      body: {
+        ok: true,
+        data: {
+          signature,
+          sessionId
+        }
       }
     }
+  } catch (error) {
+    if (error instanceof InvalidWertMessageError) {
+      return {
+        status: StatusCode.BAD_REQUEST,
+        body: {
+          ok: false,
+          message: error.message
+        }
+      }
+    }
+
+    throw error
   }
 }

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -4,6 +4,7 @@ import * as authorizationMiddleware from 'decentraland-crypto-middleware'
 import { createTradesViewAuthMiddleware } from '../logic/http/auth'
 import { TradeCreationSchema } from '../ports/trades/schemas'
 import { WidgetOptionsSchema } from '../ports/transak'
+import { WertSignBodySchema } from '../ports/wert/schemas'
 import { GlobalContext } from '../types'
 import { getAccountsHandler } from './handlers/accounts-handler'
 import { getActivityHandler } from './handlers/activity-handler'
@@ -77,6 +78,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
       expiration: FIVE_MINUTES,
       verifyMetadataContent: validateNotKernelSceneSigner
     }),
+    components.schemaValidator.withSchemaValidatorMiddleware(WertSignBodySchema),
     createWertSignerAndSessionCreatorHandler
   )
   router.get(

--- a/src/ports/wert/schemas.ts
+++ b/src/ports/wert/schemas.ts
@@ -1,0 +1,43 @@
+import { JSONSchema } from '@dcl/schemas'
+import { WertMessage } from './signer/types'
+import { Target } from './types'
+
+/**
+ * Validation shape for the `POST /v1/wert/sign` body. Only the fields the handler depends on are
+ * declared; the Wert session accepts many optional fields, so additional properties are allowed.
+ */
+type WertSignBody = {
+  message: WertMessage
+  session: { flow_type: string }
+  target?: Target
+}
+
+export const WertSignBodySchema: JSONSchema<WertSignBody> = {
+  type: 'object',
+  properties: {
+    message: {
+      type: 'object',
+      properties: {
+        address: { type: 'string' },
+        commodity: { type: 'string' },
+        commodity_amount: { type: 'number' },
+        network: { type: 'string' },
+        sc_address: { type: 'string' },
+        sc_input_data: { type: 'string' }
+      },
+      required: ['address', 'commodity', 'commodity_amount', 'network', 'sc_address', 'sc_input_data'],
+      additionalProperties: false
+    },
+    session: {
+      type: 'object',
+      properties: {
+        flow_type: { type: 'string', enum: ['simple', 'simple_full_restrict'] }
+      },
+      required: ['flow_type'],
+      additionalProperties: true
+    },
+    target: { type: 'string', enum: [Target.DEFAULT, Target.PUBLICATION_FEES], nullable: true }
+  },
+  required: ['message', 'session'],
+  additionalProperties: false
+}

--- a/src/ports/wert/signer/component.ts
+++ b/src/ports/wert/signer/component.ts
@@ -1,6 +1,7 @@
 import { signSmartContractData } from '@wert-io/widget-sc-signer'
 import { Target } from '../types'
 import { IWertSignerComponent, WertMessage } from './types'
+import { validateWertMessage } from './validation'
 
 export function createWertSigner({
   privateKey,
@@ -10,6 +11,7 @@ export function createWertSigner({
   publicationFeesPrivateKey: string
 }): IWertSignerComponent {
   function signMessage(message: WertMessage, target?: Target): string {
+    validateWertMessage(message, target)
     const targetPrivateKey = target === Target.PUBLICATION_FEES ? publicationFeesPrivateKey : privateKey
     const signedData = signSmartContractData(message, targetPrivateKey)
     return signedData.signature

--- a/src/ports/wert/signer/errors.ts
+++ b/src/ports/wert/signer/errors.ts
@@ -1,0 +1,6 @@
+export class InvalidWertMessageError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidWertMessageError'
+  }
+}

--- a/src/ports/wert/signer/validation.ts
+++ b/src/ports/wert/signer/validation.ts
@@ -1,4 +1,5 @@
 import { Interface } from 'ethers'
+import { ChainId } from '@dcl/schemas'
 import { ContractName, getContract } from 'decentraland-transactions'
 import { getEthereumChainId, getPolygonChainId } from '../../../logic/chainIds'
 import { Target } from '../types'
@@ -20,17 +21,33 @@ type WertTargetRules = {
 }
 
 /**
- * Builds the case-insensitive set of allowed contract addresses for a target from the address
- * resolved via `decentraland-transactions` plus an optional comma-separated env override. The
- * override lets non-production environments allowlist additional contracts (e.g. the dev fiat
- * names controller) without code changes.
+ * Well-known Decentraland contracts used by official clients that are not (yet) resolvable via
+ * `decentraland-transactions`, keyed by target and chain id. They are merged into the allowlist on
+ * top of the library-resolved address so the legitimate flows keep working out of the box.
+ *
+ * The marketplace dev environment signs name purchases against a dedicated fiat names controller
+ * (`CONTROLLER_V2_CONTRACT_ADDRESS_FIAT`) that differs from the `DCLControllerV2` address the
+ * library ships for Sepolia.
  */
-function buildAllowedAddresses(resolvedAddress: string, envOverride: string | undefined): Set<string> {
+const ADDITIONAL_ALLOWED_CONTRACTS: Record<Target, Partial<Record<ChainId, string[]>>> = {
+  [Target.DEFAULT]: {
+    [ChainId.ETHEREUM_SEPOLIA]: ['0x39421866645065c8d53e2d36906946f33465743d']
+  },
+  [Target.PUBLICATION_FEES]: {}
+}
+
+/**
+ * Builds the case-insensitive set of allowed contract addresses for a target from the addresses
+ * resolved via `decentraland-transactions` (and the well-known additions) plus an optional
+ * comma-separated env override. The override lets any environment allowlist further contracts
+ * without code changes.
+ */
+function buildAllowedAddresses(baseAddresses: string[], envOverride: string | undefined): Set<string> {
   const extraAddresses = (envOverride ?? '')
     .split(',')
     .map(address => address.trim().toLowerCase())
     .filter(Boolean)
-  return new Set([resolvedAddress.toLowerCase(), ...extraAddresses])
+  return new Set([...baseAddresses.map(address => address.toLowerCase()), ...extraAddresses])
 }
 
 /**
@@ -52,17 +69,27 @@ function getFunctionSelector(abi: object[], functionName: string): string {
 function getRulesForTarget(target: Target): WertTargetRules {
   switch (target) {
     case Target.PUBLICATION_FEES: {
-      const contract = getContract(ContractName.CollectionManager, getPolygonChainId())
+      const chainId = getPolygonChainId()
+      const contract = getContract(ContractName.CollectionManager, chainId)
+      const additionalAddresses = ADDITIONAL_ALLOWED_CONTRACTS[Target.PUBLICATION_FEES][chainId] ?? []
       return {
-        allowedContractAddresses: buildAllowedAddresses(contract.address, process.env.WERT_PUBLICATION_FEES_ALLOWED_CONTRACTS),
+        allowedContractAddresses: buildAllowedAddresses(
+          [contract.address, ...additionalAddresses],
+          process.env.WERT_PUBLICATION_FEES_ALLOWED_CONTRACTS
+        ),
         allowedFunctionSelectors: new Set([getFunctionSelector(contract.abi, 'createCollection')])
       }
     }
     case Target.DEFAULT:
     default: {
-      const contract = getContract(ContractName.DCLControllerV2, getEthereumChainId())
+      const chainId = getEthereumChainId()
+      const contract = getContract(ContractName.DCLControllerV2, chainId)
+      const additionalAddresses = ADDITIONAL_ALLOWED_CONTRACTS[Target.DEFAULT][chainId] ?? []
       return {
-        allowedContractAddresses: buildAllowedAddresses(contract.address, process.env.WERT_DEFAULT_ALLOWED_CONTRACTS),
+        allowedContractAddresses: buildAllowedAddresses(
+          [contract.address, ...additionalAddresses],
+          process.env.WERT_DEFAULT_ALLOWED_CONTRACTS
+        ),
         allowedFunctionSelectors: new Set([getFunctionSelector(contract.abi, 'register')])
       }
     }

--- a/src/ports/wert/signer/validation.ts
+++ b/src/ports/wert/signer/validation.ts
@@ -1,0 +1,110 @@
+import { Interface } from 'ethers'
+import { ContractName, getContract } from 'decentraland-transactions'
+import { getEthereumChainId, getPolygonChainId } from '../../../logic/chainIds'
+import { Target } from '../types'
+import { InvalidWertMessageError } from './errors'
+import { WertMessage } from './types'
+
+/**
+ * The set of contracts and contract functions that the server is willing to sign a Wert
+ * smart-contract order for, grouped by target.
+ *
+ * - `DEFAULT` covers the marketplace MANA-name purchase flow, which calls `register` on the
+ *   `DCLControllerV2` contract.
+ * - `PUBLICATION_FEES` covers the builder collection publication flow, which calls
+ *   `createCollection` on the `CollectionManager` contract.
+ */
+type WertTargetRules = {
+  allowedContractAddresses: Set<string>
+  allowedFunctionSelectors: Set<string>
+}
+
+/**
+ * Builds the case-insensitive set of allowed contract addresses for a target from the address
+ * resolved via `decentraland-transactions` plus an optional comma-separated env override. The
+ * override lets non-production environments allowlist additional contracts (e.g. the dev fiat
+ * names controller) without code changes.
+ */
+function buildAllowedAddresses(resolvedAddress: string, envOverride: string | undefined): Set<string> {
+  const extraAddresses = (envOverride ?? '')
+    .split(',')
+    .map(address => address.trim().toLowerCase())
+    .filter(Boolean)
+  return new Set([resolvedAddress.toLowerCase(), ...extraAddresses])
+}
+
+/**
+ * Resolves the 4-byte function selector for a function name from a contract ABI.
+ */
+function getFunctionSelector(abi: object[], functionName: string): string {
+  const fragment = new Interface(abi as ConstructorParameters<typeof Interface>[0]).getFunction(functionName)
+  if (!fragment) {
+    throw new Error(`The function "${functionName}" was not found in the provided ABI`)
+  }
+  return fragment.selector.toLowerCase()
+}
+
+/**
+ * Resolves the signing rules for the given target. Contract addresses and selectors are derived
+ * from `decentraland-transactions` using the chain ids the server is configured for, so they stay
+ * in sync with the official Decentraland deployments.
+ */
+function getRulesForTarget(target: Target): WertTargetRules {
+  switch (target) {
+    case Target.PUBLICATION_FEES: {
+      const contract = getContract(ContractName.CollectionManager, getPolygonChainId())
+      return {
+        allowedContractAddresses: buildAllowedAddresses(contract.address, process.env.WERT_PUBLICATION_FEES_ALLOWED_CONTRACTS),
+        allowedFunctionSelectors: new Set([getFunctionSelector(contract.abi, 'createCollection')])
+      }
+    }
+    case Target.DEFAULT:
+    default: {
+      const contract = getContract(ContractName.DCLControllerV2, getEthereumChainId())
+      return {
+        allowedContractAddresses: buildAllowedAddresses(contract.address, process.env.WERT_DEFAULT_ALLOWED_CONTRACTS),
+        allowedFunctionSelectors: new Set([getFunctionSelector(contract.abi, 'register')])
+      }
+    }
+  }
+}
+
+/**
+ * Extracts the 4-byte function selector (`0x` + 8 hex chars) from the calldata that Wert will send
+ * on-chain, or `undefined` when the calldata is missing or too short to contain a selector.
+ */
+function getCalldataSelector(scInputData: string | undefined): string | undefined {
+  if (!scInputData || typeof scInputData !== 'string') {
+    return undefined
+  }
+  const normalized = scInputData.startsWith('0x') ? scInputData : `0x${scInputData}`
+  if (normalized.length < 10) {
+    return undefined
+  }
+  return normalized.slice(0, 10).toLowerCase()
+}
+
+/**
+ * Asserts that a Wert message only asks the server to sign a transaction against an allowlisted
+ * Decentraland contract and function for the given target. The signature the server produces
+ * authorizes Wert to broadcast `sc_input_data` to `sc_address`, so without this check any
+ * authenticated user could obtain a Decentraland-signed order for an arbitrary contract call.
+ *
+ * @param message - The Wert message to be signed.
+ * @param target - The signing target (defaults to {@link Target.DEFAULT} when not provided).
+ * @throws {InvalidWertMessageError} When the contract address or function selector is not allowed.
+ */
+export function validateWertMessage(message: WertMessage, target?: Target): void {
+  const effectiveTarget = target === Target.PUBLICATION_FEES ? Target.PUBLICATION_FEES : Target.DEFAULT
+  const rules = getRulesForTarget(effectiveTarget)
+
+  const scAddress = message.sc_address?.toLowerCase()
+  if (!scAddress || !rules.allowedContractAddresses.has(scAddress)) {
+    throw new InvalidWertMessageError(`The contract address "${message.sc_address}" is not allowed for the "${effectiveTarget}" target`)
+  }
+
+  const selector = getCalldataSelector(message.sc_input_data)
+  if (!selector || !rules.allowedFunctionSelectors.has(selector)) {
+    throw new InvalidWertMessageError(`The requested contract call is not allowed for the "${effectiveTarget}" target`)
+  }
+}

--- a/test/unit/wert-signer-and-session-creator-handler.spec.ts
+++ b/test/unit/wert-signer-and-session-creator-handler.spec.ts
@@ -1,6 +1,7 @@
 import * as authorizationMiddleware from 'decentraland-crypto-middleware'
 import { createWertSignerAndSessionCreatorHandler } from '../../src/controllers/handlers/wert-signer-and-session-creator-handler'
 import { WertSession } from '../../src/ports/wert/api/types'
+import { InvalidWertMessageError } from '../../src/ports/wert/signer/errors'
 import { WertMessage } from '../../src/ports/wert/signer/types'
 import { Target } from '../../src/ports/wert/types'
 import { AppComponents, HandlerContextWithPath, StatusCode } from '../../src/types'
@@ -172,6 +173,32 @@ describe('when getting the wert signer and session creator handler', () => {
             params
           })
         ).rejects.toThrow('Session creation failed')
+      })
+    })
+
+    describe('and the signer rejects the message as not allowed', () => {
+      beforeEach(() => {
+        wertSignerMock.signMessage.mockImplementationOnce(() => {
+          throw new InvalidWertMessageError('The requested contract call is not allowed for the "default" target')
+        })
+      })
+
+      it('should respond with a 400 and the validation error message', async () => {
+        const response = await createWertSignerAndSessionCreatorHandler({
+          url,
+          components,
+          verification,
+          request,
+          params
+        })
+
+        expect(response).toEqual({
+          status: StatusCode.BAD_REQUEST,
+          body: {
+            ok: false,
+            message: 'The requested contract call is not allowed for the "default" target'
+          }
+        })
       })
     })
 

--- a/test/unit/wert-signer-port.spec.ts
+++ b/test/unit/wert-signer-port.spec.ts
@@ -1,9 +1,21 @@
 import { signSmartContractData } from '@wert-io/widget-sc-signer'
+import { Interface } from 'ethers'
+import { ContractName, getContract } from 'decentraland-transactions'
+import { getEthereumChainId, getPolygonChainId } from '../../src/logic/chainIds'
 import { createWertSigner } from '../../src/ports/wert/signer/component'
+import { InvalidWertMessageError } from '../../src/ports/wert/signer/errors'
 import { WertMessage } from '../../src/ports/wert/signer/types'
 import { Target } from '../../src/ports/wert/types'
 
 jest.mock('@wert-io/widget-sc-signer')
+
+function buildSelector(abi: object[], functionName: string): string {
+  const fragment = new Interface(abi as ConstructorParameters<typeof Interface>[0]).getFunction(functionName)
+  if (!fragment) {
+    throw new Error(`The function "${functionName}" was not found in the provided ABI`)
+  }
+  return fragment.selector
+}
 
 describe('createWertSigner', () => {
   const privateKey = 'myPrivateKey'
@@ -11,46 +23,72 @@ describe('createWertSigner', () => {
   const wertSigner = createWertSigner({ privateKey, publicationFeesPrivateKey })
 
   describe('signMessage', () => {
-    let wertMessage: WertMessage
+    let defaultMessage: WertMessage
+    let publicationFeesMessage: WertMessage
     let expectedSignature: string
 
     beforeEach(() => {
-      wertMessage = {
+      const ensController = getContract(ContractName.DCLControllerV2, getEthereumChainId())
+      const collectionManager = getContract(ContractName.CollectionManager, getPolygonChainId())
+      defaultMessage = {
         address: 'myAddress',
         commodity: 'MANA',
         commodity_amount: 100,
-        network: 'myNetwork',
-        sc_address: 'myScAddress',
-        sc_input_data: 'myScInputData'
+        network: 'ethereum',
+        sc_address: ensController.address,
+        sc_input_data: `${buildSelector(ensController.abi, 'register')}deadbeef`
       }
-      ;(expectedSignature = 'mySignature'),
-        ((signSmartContractData as jest.Mock) = jest.fn().mockReturnValue({ signature: expectedSignature }))
+      publicationFeesMessage = {
+        address: 'myAddress',
+        commodity: 'MANA',
+        commodity_amount: 50,
+        network: 'polygon',
+        sc_address: collectionManager.address,
+        sc_input_data: `${buildSelector(collectionManager.abi, 'createCollection')}deadbeef`
+      }
+      expectedSignature = 'mySignature'
+      ;(signSmartContractData as jest.Mock) = jest.fn().mockReturnValue({ signature: expectedSignature })
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
     })
 
     describe('when the target is undefined', () => {
       it('should sign the message using the private key', () => {
-        const signature = wertSigner.signMessage(wertMessage)
+        const signature = wertSigner.signMessage(defaultMessage)
 
-        expect(signSmartContractData).toHaveBeenCalledWith(wertMessage, privateKey)
+        expect(signSmartContractData).toHaveBeenCalledWith(defaultMessage, privateKey)
         expect(signature).toBe(expectedSignature)
       })
     })
 
     describe('when the target is default', () => {
       it('should sign the message using the private key', () => {
-        const signature = wertSigner.signMessage(wertMessage, Target.DEFAULT)
+        const signature = wertSigner.signMessage(defaultMessage, Target.DEFAULT)
 
-        expect(signSmartContractData).toHaveBeenCalledWith(wertMessage, privateKey)
+        expect(signSmartContractData).toHaveBeenCalledWith(defaultMessage, privateKey)
         expect(signature).toBe(expectedSignature)
       })
     })
 
     describe('when the target is publicationFees', () => {
       it('should sign the message using the publication fees private key', () => {
-        const signature = wertSigner.signMessage(wertMessage, Target.PUBLICATION_FEES)
+        const signature = wertSigner.signMessage(publicationFeesMessage, Target.PUBLICATION_FEES)
 
-        expect(signSmartContractData).toHaveBeenCalledWith(wertMessage, publicationFeesPrivateKey)
+        expect(signSmartContractData).toHaveBeenCalledWith(publicationFeesMessage, publicationFeesPrivateKey)
         expect(signature).toBe(expectedSignature)
+      })
+    })
+
+    describe('when the message targets a contract that is not allowed', () => {
+      beforeEach(() => {
+        defaultMessage.sc_address = '0x000000000000000000000000000000000000dead'
+      })
+
+      it('should throw an invalid wert message error without signing', () => {
+        expect(() => wertSigner.signMessage(defaultMessage, Target.DEFAULT)).toThrow(InvalidWertMessageError)
+        expect(signSmartContractData).not.toHaveBeenCalled()
       })
     })
   })

--- a/test/unit/wert-signer-validation.spec.ts
+++ b/test/unit/wert-signer-validation.spec.ts
@@ -1,4 +1,5 @@
 import { Interface } from 'ethers'
+import { ChainId } from '@dcl/schemas'
 import { ContractName, getContract } from 'decentraland-transactions'
 import { getEthereumChainId, getPolygonChainId } from '../../src/logic/chainIds'
 import { InvalidWertMessageError } from '../../src/ports/wert/signer/errors'
@@ -118,6 +119,28 @@ describe('when validating a wert message', () => {
       })
 
       it('should accept the additional contract address and not throw', () => {
+        expect(() => validateWertMessage(message, Target.DEFAULT)).not.toThrow()
+      })
+    })
+
+    describe('and the configured ethereum chain is sepolia and the dev fiat names controller is used', () => {
+      let originalEthereumChainId: string | undefined
+
+      beforeEach(() => {
+        originalEthereumChainId = process.env.ETHEREUM_CHAIN_ID
+        process.env.ETHEREUM_CHAIN_ID = ChainId.ETHEREUM_SEPOLIA.toString()
+        message.sc_address = '0x39421866645065c8d53e2d36906946f33465743d'
+      })
+
+      afterEach(() => {
+        if (originalEthereumChainId === undefined) {
+          delete process.env.ETHEREUM_CHAIN_ID
+        } else {
+          process.env.ETHEREUM_CHAIN_ID = originalEthereumChainId
+        }
+      })
+
+      it('should accept the seeded dev contract and not throw', () => {
         expect(() => validateWertMessage(message, Target.DEFAULT)).not.toThrow()
       })
     })

--- a/test/unit/wert-signer-validation.spec.ts
+++ b/test/unit/wert-signer-validation.spec.ts
@@ -1,0 +1,166 @@
+import { Interface } from 'ethers'
+import { ContractName, getContract } from 'decentraland-transactions'
+import { getEthereumChainId, getPolygonChainId } from '../../src/logic/chainIds'
+import { InvalidWertMessageError } from '../../src/ports/wert/signer/errors'
+import { WertMessage } from '../../src/ports/wert/signer/types'
+import { validateWertMessage } from '../../src/ports/wert/signer/validation'
+import { Target } from '../../src/ports/wert/types'
+
+function buildSelector(abi: object[], functionName: string): string {
+  const fragment = new Interface(abi as ConstructorParameters<typeof Interface>[0]).getFunction(functionName)
+  if (!fragment) {
+    throw new Error(`The function "${functionName}" was not found in the provided ABI`)
+  }
+  return fragment.selector
+}
+
+describe('when validating a wert message', () => {
+  let ensControllerAddress: string
+  let registerSelector: string
+  let collectionManagerAddress: string
+  let createCollectionSelector: string
+
+  beforeEach(() => {
+    const ensController = getContract(ContractName.DCLControllerV2, getEthereumChainId())
+    const collectionManager = getContract(ContractName.CollectionManager, getPolygonChainId())
+    ensControllerAddress = ensController.address
+    registerSelector = buildSelector(ensController.abi, 'register')
+    collectionManagerAddress = collectionManager.address
+    createCollectionSelector = buildSelector(collectionManager.abi, 'createCollection')
+  })
+
+  describe('and the target is the default one', () => {
+    let message: WertMessage
+
+    beforeEach(() => {
+      message = {
+        address: '0x1234567890123456789012345678901234567890',
+        commodity: 'MANA',
+        commodity_amount: 100,
+        network: 'ethereum',
+        sc_address: ensControllerAddress,
+        sc_input_data: `${registerSelector}deadbeef`
+      }
+    })
+
+    describe('and the contract address and function selector are allowed', () => {
+      it('should not throw', () => {
+        expect(() => validateWertMessage(message, Target.DEFAULT)).not.toThrow()
+      })
+    })
+
+    describe('and the target is not provided', () => {
+      it('should validate it against the default target and not throw', () => {
+        expect(() => validateWertMessage(message, undefined)).not.toThrow()
+      })
+    })
+
+    describe('and the contract address is upper-cased', () => {
+      beforeEach(() => {
+        message.sc_address = ensControllerAddress.toUpperCase()
+      })
+
+      it('should match the allowlist case-insensitively and not throw', () => {
+        expect(() => validateWertMessage(message, Target.DEFAULT)).not.toThrow()
+      })
+    })
+
+    describe('and the contract address is not allowed', () => {
+      beforeEach(() => {
+        message.sc_address = '0x000000000000000000000000000000000000dead'
+      })
+
+      it('should throw an invalid wert message error about the contract address', () => {
+        expect(() => validateWertMessage(message, Target.DEFAULT)).toThrow(InvalidWertMessageError)
+      })
+    })
+
+    describe('and the function selector is not allowed', () => {
+      beforeEach(() => {
+        message.sc_input_data = `${createCollectionSelector}deadbeef`
+      })
+
+      it('should throw an invalid wert message error about the contract call', () => {
+        expect(() => validateWertMessage(message, Target.DEFAULT)).toThrow(InvalidWertMessageError)
+      })
+    })
+
+    describe('and the calldata is missing', () => {
+      beforeEach(() => {
+        message.sc_input_data = ''
+      })
+
+      it('should throw an invalid wert message error', () => {
+        expect(() => validateWertMessage(message, Target.DEFAULT)).toThrow(InvalidWertMessageError)
+      })
+    })
+
+    describe('and the calldata is too short to contain a selector', () => {
+      beforeEach(() => {
+        message.sc_input_data = '0x1e59'
+      })
+
+      it('should throw an invalid wert message error', () => {
+        expect(() => validateWertMessage(message, Target.DEFAULT)).toThrow(InvalidWertMessageError)
+      })
+    })
+
+    describe('and an extra contract address is allowlisted via the environment', () => {
+      const extraAddress = '0x000000000000000000000000000000000000beef'
+
+      beforeEach(() => {
+        process.env.WERT_DEFAULT_ALLOWED_CONTRACTS = `${extraAddress},0x000000000000000000000000000000000000cafe`
+        message.sc_address = extraAddress
+      })
+
+      afterEach(() => {
+        delete process.env.WERT_DEFAULT_ALLOWED_CONTRACTS
+      })
+
+      it('should accept the additional contract address and not throw', () => {
+        expect(() => validateWertMessage(message, Target.DEFAULT)).not.toThrow()
+      })
+    })
+  })
+
+  describe('and the target is the publication fees one', () => {
+    let message: WertMessage
+
+    beforeEach(() => {
+      message = {
+        address: '0x1234567890123456789012345678901234567890',
+        commodity: 'MANA',
+        commodity_amount: 50,
+        network: 'polygon',
+        sc_address: collectionManagerAddress,
+        sc_input_data: `${createCollectionSelector}deadbeef`
+      }
+    })
+
+    describe('and the contract address and function selector are allowed', () => {
+      it('should not throw', () => {
+        expect(() => validateWertMessage(message, Target.PUBLICATION_FEES)).not.toThrow()
+      })
+    })
+
+    describe('and the contract address belongs to a different target', () => {
+      beforeEach(() => {
+        message.sc_address = ensControllerAddress
+      })
+
+      it('should throw an invalid wert message error about the contract address', () => {
+        expect(() => validateWertMessage(message, Target.PUBLICATION_FEES)).toThrow(InvalidWertMessageError)
+      })
+    })
+
+    describe('and the function selector belongs to a different target', () => {
+      beforeEach(() => {
+        message.sc_input_data = `${registerSelector}deadbeef`
+      })
+
+      it('should throw an invalid wert message error about the contract call', () => {
+        expect(() => validateWertMessage(message, Target.PUBLICATION_FEES)).toThrow(InvalidWertMessageError)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Hardens the Wert signing endpoint and fixes the reachable critical advisory in its dependency chain, found during a security review of the codebase.

### 1. Restrict `POST /v1/wert/sign`
The endpoint previously signed **any** client-supplied `sc_address` + `sc_input_data` with the server's Wert private key. Since the signature is what authorizes Wert to broadcast that calldata, any authenticated user could obtain a Decentraland-signed order for an arbitrary contract call (e.g. `transferFrom`, `setApprovalForAll`, `executeOrder`), or pair an expensive on-chain action with a tiny fiat amount.

The two legitimate flows are now the only ones allowed:

| Target | Contract | Function |
|---|---|---|
| `default` | `DCLControllerV2` | `register(string,address)` (MANA name purchases — marketplace) |
| `publicationFees` | `CollectionManager` | `createCollection(...)` (collection publication fees — builder) |

Validation (`src/ports/wert/signer/validation.ts`) enforces, per target:
- **Contract-address allowlist** — must match the genuine contract, resolved at runtime from `decentraland-transactions` for the server's configured chains (no hardcoding), case-insensitive.
- **Function-selector allowlist** — the calldata's 4-byte selector must be `register` (`0x1e59c529`) or `createCollection` (`0x35a629c2`), also derived from the ABIs.

It runs inside `signMessage` (the chokepoint holding the key) and throws a typed `InvalidWertMessageError`, which the handler maps to **400**. A request-body schema is now enforced on the route via `withSchemaValidatorMiddleware`, also closing a null-`address` crash.

### 2. Patch `elliptic`
The reachable critical was `elliptic@6.5.4` (key-extraction / signature malleability), pulled in transitively by `@wert-io/widget-sc-signer` — the library that signs with the server's Wert key. Bumping wert-io doesn't help (both 2.x and 3.x declare `elliptic ^6.5.4`), so an npm `overrides` entry pins it to the patched **6.6.1** across the tree.

## Backwards compatibility
The **request/response contract is unchanged** — clients send the same body and get the same response shape; no client changes are required. Only calls *outside* the two real flows are now rejected (the intended fix). All legitimate deployed flows were checked and keep working:

| Environment | Flow | `sc_address` | Status |
|---|---|---|---|
| prod marketplace / builder | name / publication | mainnet & polygon contracts | matches library |
| stg | both | mainnet contracts | matches library |
| dev builder | publication | amoy `CollectionManager` | matches library |
| dev marketplace | name purchase | `0x3942…` (`CONTROLLER_V2_CONTRACT_ADDRESS_FIAT`) | **seeded** in the allowlist |

The dev marketplace fiat names controller differs from the address `decentraland-transactions` ships for Sepolia, so it's seeded into the allowlist (scoped to Sepolia) to avoid breaking dev. Any further environment-specific contracts can be added via the optional `WERT_DEFAULT_ALLOWED_CONTRACTS` / `WERT_PUBLICATION_FEES_ALLOWED_CONTRACTS` env vars without code changes.

## Test plan
- [x] `tsc --noEmit` clean
- [x] eslint clean, prettier clean
- [x] OpenAPI lint valid
- [x] Full unit suite passes (675 tests / 56 suites), including new `wert-signer-validation.spec.ts` (allow/reject per target, case-insensitivity, env override, seeded dev address, bad selector/address/calldata) and updated signer-port / handler specs
- [ ] Integration suite not run (requires a live DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)