### PR TITLE
fix: cap user-supplied query limits on public marketplace endpoints

### DIFF
--- a/src/controllers/handlers/catalog-handler.ts
+++ b/src/controllers/handlers/catalog-handler.ts
@@ -6,6 +6,7 @@ import { AppComponents, AuthenticatedContext } from '../../types'
 import { getItemsParams } from './utils'
 
 const DEFAULT_PAGE_SIZE = 20
+const MAX_PAGE_SIZE = 1000
 
 export function createCatalogHandler(
   components: Pick<AppComponents, 'catalog'>
@@ -23,7 +24,7 @@ export function createCatalogHandler(
     const sortBy = params.getValue<CatalogSortBy>('sortBy', CatalogSortBy) || CatalogSortBy.CHEAPEST
     const sortDirection = params.getValue<CatalogSortDirection>('sortDirection', CatalogSortDirection) || CatalogSortDirection.ASC
 
-    const limit = params.getNumber('first', DEFAULT_PAGE_SIZE)
+    const limit = Math.min(params.getNumber('first', DEFAULT_PAGE_SIZE) ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE)
     const offset = params.getNumber('skip', 0)
     // @TODO: add favorites logic
     const pickedBy: string | undefined = context.verification?.auth.toLowerCase()

--- a/src/ports/orders/queries.ts
+++ b/src/ports/orders/queries.ts
@@ -24,15 +24,17 @@ function getOrdersSortByStatement(filters: OrderFilters): SQLStatement {
   }
 }
 
+const MAX_LIMIT = 1000
+
 function getOrdersLimitAndOffsetStatement(filters: OrderFilters) {
-  const limit = filters?.first ? filters.first : 1000
+  const limit = filters?.first ? Math.min(filters.first, MAX_LIMIT) : MAX_LIMIT
   const offset = filters?.skip ? filters.skip : 0
 
   return SQL` LIMIT ${limit} OFFSET ${offset} `
 }
 
 function getInnerOrdersLimitAndOffsetStatement(filters: OrderFilters) {
-  const finalLimit = filters?.first ? filters.first : 1000
+  const finalLimit = filters?.first ? Math.min(filters.first, MAX_LIMIT) : MAX_LIMIT
   const finalOffset = filters?.skip ? filters.skip : 0
 
   // For inner queries, we need to fetch enough records to account for the final offset

--- a/src/ports/owners/queries.ts
+++ b/src/ports/owners/queries.ts
@@ -4,6 +4,7 @@ import { OwnersFilters, OwnersSortBy } from './types'
 
 export const OWNERS_QUERY_DEFAULT_OFFSET = 0
 export const OWNERS_QUERY_DEFAULT_LIMIT = 20
+export const OWNERS_QUERY_MAX_LIMIT = 1000
 
 export const getOwnersQuery = (
   filters: OwnersFilters & {
@@ -56,7 +57,7 @@ export const getOwnersQuery = (
     }
     query.append(skip !== undefined ? SQL` OFFSET ${skip}` : SQL` OFFSET ${OWNERS_QUERY_DEFAULT_OFFSET}`)
 
-    query.append(first !== undefined ? SQL` LIMIT ${first}` : SQL` LIMIT ${OWNERS_QUERY_DEFAULT_LIMIT}`)
+    query.append(first !== undefined ? SQL` LIMIT ${Math.min(first, OWNERS_QUERY_MAX_LIMIT)}` : SQL` LIMIT ${OWNERS_QUERY_DEFAULT_LIMIT}`)
   }
 
   return query

--- a/src/ports/sales/queries.ts
+++ b/src/ports/sales/queries.ts
@@ -5,9 +5,10 @@ import { getDBNetworks } from '../../utils'
 import { getWhereStatementFromFilters } from '../utils'
 
 const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 1000
 
 function getSalesLimitAndOffsetStatement(filters: SaleFilters) {
-  const limit = filters?.first ? filters.first : DEFAULT_LIMIT
+  const limit = filters?.first ? Math.min(filters.first, MAX_LIMIT) : DEFAULT_LIMIT
   const offset = filters?.skip ? filters.skip : 0
 
   return SQL` LIMIT ${limit} OFFSET ${offset} `


### PR DESCRIPTION
## What

Several public (unauthenticated) endpoints let the caller-supplied `first` flow straight into the SQL `LIMIT` with no upper bound:

- `/v1/sales` — `ports/sales/queries.ts`
- `/v1/orders` — `ports/orders/queries.ts` (both the outer and inner limit/offset builders)
- `/v1/owners` — `ports/owners/queries.ts`
- `/v1/catalog` and `/v2/catalog` — `controllers/handlers/catalog-handler.ts`

A request like `?first=999999999` makes Postgres materialize and the service buffer a huge result set, with no auth and no app-level rate limiting — a cheap DoS vector. The `contracts`, `accounts` and `collections` query builders already cap with `Math.min(first, 1000)`; these endpoints were simply missing the same guard.

## Change

Apply the existing cap pattern (`Math.min(first, MAX)` with `MAX = 1000`) to the four uncapped paths, matching the already-capped builders. Default behavior for normal requests is unchanged.

## Verification

- `tsc -p tsconfig.json --noEmit` clean; eslint clean on the changed files.
- No unit tests assert the uncapped behavior; query/integration tests run under CI.