### PR TITLE
perf: speed up offchain trade creation path

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -144,7 +144,7 @@ export async function initComponents(): Promise<AppComponents> {
 
   // catalog
   const catalog = await createCatalogComponent({ dappsDatabase: dappsReadDatabase, dappsWriteDatabase, picks }, SEGMENT_WRITE_KEY)
-  const trades = await createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs })
+  const trades = await createTradesComponent({ dappsDatabase: dappsWriteDatabase, dappsReadDatabase, eventPublisher, logs })
   const bids = await createBidsComponents({ dappsDatabase: dappsReadDatabase })
   const nfts = await createNFTsComponent({ dappsDatabase: dappsReadDatabase, config, rentals })
   const orders = await createOrdersComponent({ dappsDatabase: dappsReadDatabase })

--- a/src/controllers/handlers/trades-handler.ts
+++ b/src/controllers/handlers/trades-handler.ts
@@ -14,7 +14,9 @@ import {
   TradeNotFoundBySignatureError,
   TradeNotFoundError,
   DuplicateNFTOrderError,
+  DuplicateItemOrderError,
   InvalidEstateTrade,
+  InvalidOwnerError,
   EstateContractNotFoundForChainId
 } from '../../ports/trades/errors'
 import { HTTPResponse, HandlerContextWithPath, StatusCode } from '../../types'
@@ -81,6 +83,7 @@ export async function addTradeHandler(
       e instanceof InvalidTradeSignerError ||
       e instanceof InvalidECDSASignatureError ||
       e instanceof InvalidEstateTrade ||
+      e instanceof InvalidOwnerError ||
       e instanceof EstateContractNotFoundForChainId
     ) {
       return {
@@ -92,7 +95,7 @@ export async function addTradeHandler(
       }
     }
 
-    if (e instanceof DuplicatedBidError || e instanceof DuplicateNFTOrderError) {
+    if (e instanceof DuplicatedBidError || e instanceof DuplicateNFTOrderError || e instanceof DuplicateItemOrderError) {
       return {
         status: StatusCode.CONFLICT,
         body: {

--- a/src/logic/trades/utils.ts
+++ b/src/logic/trades/utils.ts
@@ -27,6 +27,37 @@ function getRPCUrlByChainId(chainId: ChainId): string {
   return `https://rpc.decentraland.org/${rpcPath}`
 }
 
+// Reuse one provider per chain instead of constructing a new JsonRpcProvider (and re-running
+// network detection) on every ownership / fingerprint check on the trade-creation hot path.
+const providersByChainId: Partial<Record<ChainId, JsonRpcProvider>> = {}
+
+function getProvider(chainId: ChainId): JsonRpcProvider {
+  let provider = providersByChainId[chainId]
+  if (!provider) {
+    provider = new JsonRpcProvider(getRPCUrlByChainId(chainId))
+    providersByChainId[chainId] = provider
+  }
+  return provider
+}
+
+// Bound on-chain reads so a slow/unresponsive public RPC can't stall trade creation up to the
+// DB statement timeout (40s). Callers treat a timeout as a validation failure.
+export const ON_CHAIN_READ_TIMEOUT_MS = 5000
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs)
+  })
+  try {
+    return await Promise.race([promise, timeout])
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
+}
+
 export function getValueFromTradeAsset(asset: TradeAsset) {
   switch (asset.assetType) {
     case TradeAssetType.COLLECTION_ITEM:
@@ -140,9 +171,12 @@ export function isERC721TradeAsset(asset: TradeAsset): asset is ERC721TradeAsset
 
 async function getContractOwner(contractAddress: string, tokenId: string, chainId: ChainId): Promise<string> {
   const abi = ['function ownerOf(uint256 tokenId) view returns (address)']
-  const provider = new JsonRpcProvider(getRPCUrlByChainId(chainId))
-  const contract = new Contract(contractAddress, abi, provider)
-  return await contract.ownerOf(tokenId)
+  const contract = new Contract(contractAddress, abi, getProvider(chainId))
+  return await withTimeout(
+    contract.ownerOf(tokenId),
+    ON_CHAIN_READ_TIMEOUT_MS,
+    `Timed out reading ownerOf for ${contractAddress}:${tokenId}`
+  )
 }
 
 export async function isEstateFingerprintValid(
@@ -152,9 +186,12 @@ export async function isEstateFingerprintValid(
   fingerprint: string
 ): Promise<boolean> {
   const abi = ['function getFingerprintV2(uint256 tokenId) view returns (bytes32)']
-  const provider = new JsonRpcProvider(getRPCUrlByChainId(chainId))
-  const contract = new Contract(contractAddress, abi, provider)
-  const estateFingerprint = await contract.getFingerprintV2(tokenId)
+  const contract = new Contract(contractAddress, abi, getProvider(chainId))
+  const estateFingerprint = await withTimeout(
+    contract.getFingerprintV2(tokenId),
+    ON_CHAIN_READ_TIMEOUT_MS,
+    `Timed out reading getFingerprintV2 for ${contractAddress}:${tokenId}`
+  )
   return estateFingerprint.toLowerCase() === fingerprint.toLowerCase()
 }
 

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -6,6 +6,7 @@ import { isErrorWithMessage } from '../../logic/errors'
 import { recreateTradesMaterializedView } from '../../logic/trades/materialized-view'
 import { validateAssetOwnership, validateTradeSignature } from '../../logic/trades/utils'
 import { AppComponents } from '../../types'
+import { IPgComponent } from '../db/types'
 import {
   InvalidTradeSignatureError,
   TradeAlreadyExpiredError,
@@ -54,8 +55,13 @@ type TradeWithAssetRow = {
   item_id: string | null
 }
 
-export function createTradesComponent(components: Pick<AppComponents, 'dappsDatabase' | 'eventPublisher' | 'logs'>): ITradesComponent {
-  const { dappsDatabase: pg, eventPublisher, logs } = components
+export function createTradesComponent(
+  components: Pick<AppComponents, 'dappsDatabase' | 'eventPublisher' | 'logs'> & { dappsReadDatabase?: IPgComponent }
+): ITradesComponent {
+  const { dappsDatabase: pg, dappsReadDatabase, eventPublisher, logs } = components
+  // Route read-only validation + notification queries to the read replica when one is wired, keeping
+  // the write primary for the insert transaction. Falls back to the write DB if no replica is given.
+  const readPg = dappsReadDatabase ?? pg
   const logger = logs.getLogger('Trades component')
 
   async function getTrades() {
@@ -156,28 +162,46 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
       throw new InvalidTradeSignerError()
     }
 
-    // validate trade type
-    if (!(await validateTradeByType(trade, pg))) {
-      throw new InvalidTradeStructureError(trade.type)
-    }
-    // Validate if estate trade is correct
-    if (isEstateChain(trade.chainId) && !(await isValidEstateTrade(trade))) {
-      throw new InvalidEstateTrade()
-    }
-
     // validate signature length (0x + 130 hex chars for a standard ECDSA signature)
     if (trade.signature.length !== 132) {
       throw new InvalidTradeSignatureError()
     }
 
-    // validate signature
+    // Validate the signature BEFORE any I/O: it is cheap (CPU only) and short-circuiting here avoids
+    // running DB queries / on-chain RPC calls on behalf of forged or unsigned requests.
     if (!validateTradeSignature(trade, signer)) {
       throw new InvalidTradeSignatureError()
     }
 
-    // validate right ownership
-    if (isERC721TradeAsset(trade.sent[0]) && !(await validateAssetOwnership(trade.sent[0], signer, trade.chainId))) {
-      throw new InvalidOwnerError()
+    // The remaining validations are independent and I/O-bound (DB query + on-chain RPC calls). Run
+    // them concurrently instead of serially so the validation latency is the max of the checks
+    // rather than their sum. We then surface the first failure in a FIXED precedence
+    // (structure → estate → ownership) so the error returned to the client is deterministic and does
+    // not depend on which check happens to settle first.
+    const validations = await Promise.allSettled([
+      (async () => {
+        // validate trade type / structure (read-only duplicate check → read replica)
+        if (!(await validateTradeByType(trade, readPg))) {
+          throw new InvalidTradeStructureError(trade.type)
+        }
+      })(),
+      (async () => {
+        // validate the estate fingerprint (estate chains only)
+        if (isEstateChain(trade.chainId) && !(await isValidEstateTrade(trade))) {
+          throw new InvalidEstateTrade()
+        }
+      })(),
+      (async () => {
+        // validate ownership of the sent asset (ERC721 sent assets only)
+        if (isERC721TradeAsset(trade.sent[0]) && !(await validateAssetOwnership(trade.sent[0], signer, trade.chainId))) {
+          throw new InvalidOwnerError()
+        }
+      })()
+    ])
+
+    const failedValidation = validations.find((result): result is PromiseRejectedResult => result.status === 'rejected')
+    if (failedValidation) {
+      throw failedValidation.reason
     }
 
     const tradeContract = getContract(ContractName.OffChainMarketplaceV2, trade.chainId)
@@ -207,18 +231,28 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
       }
     )
 
-    // trigger notification for trade creation
+    // Fire-and-forget the creation notification. It is best-effort (failures are swallowed) and must
+    // not add the asset lookups + SNS publish round-trip to the user-perceived latency: the trade is
+    // already durably persisted, so return it immediately.
+    void notifyTradeCreated(insertedTrade, signer)
+
+    return insertedTrade
+  }
+
+  async function notifyTradeCreated(insertedTrade: Trade, signer: string) {
     try {
-      const event = await getNotificationEventForTrade(insertedTrade, pg, TradeEvent.CREATED, signer)
+      // read-only asset lookups for the notification → read replica
+      const event = await getNotificationEventForTrade(insertedTrade, readPg, TradeEvent.CREATED, signer)
       if (event) {
         const messageId = await eventPublisher.publishMessage(event)
         logger.info(`Notification has been send for trade ${insertedTrade.id} with message id ${messageId}`)
       }
     } catch (e) {
-      logger.error(`Could not trigger trade creation event for trade type ${trade.type}`, isErrorWithMessage(e) ? e.message : (e as any))
+      logger.error(
+        `Could not trigger trade creation event for trade type ${insertedTrade.type}`,
+        isErrorWithMessage(e) ? e.message : (e as any)
+      )
     }
-
-    return insertedTrade
   }
 
   async function getTrade(id: string) {

--- a/test/unit/trades-component.spec.ts
+++ b/test/unit/trades-component.spec.ts
@@ -25,6 +25,7 @@ import {
   DBTradeAssetValue,
   DBTradeAssetWithValue,
   ITradesComponent,
+  TradeEvent,
   createTradesComponent
 } from '../../src/ports/trades'
 import {
@@ -143,6 +144,9 @@ describe('when adding a new trade', () => {
 
   describe('when the trade structure is not valid for a given type', () => {
     beforeEach(() => {
+      // the signature is now validated before the I/O-bound checks, so it must pass for the
+      // structure validation to be reached
+      jest.spyOn(signatureUtils, 'validateTradeSignature').mockReturnValue(true)
       jest.spyOn(utils, 'validateTradeByType').mockResolvedValue(false)
       jest.spyOn(utils, 'isValidEstateTrade').mockResolvedValueOnce(true)
     })
@@ -279,6 +283,9 @@ describe('when adding a new trade', () => {
       jest.spyOn(utils, 'getNotificationEventForTrade').mockResolvedValue(event)
 
       response = await tradesComponent.addTrade(mockTrade, mockSigner)
+      // the creation notification is now fire-and-forget; let the pending microtasks settle so the
+      // publish assertion below can observe it
+      await new Promise(resolve => setImmediate(resolve))
     })
 
     it('should add the trade to the database', async () => {
@@ -313,6 +320,90 @@ describe('when adding a new trade', () => {
 
     it('should send event notification', () => {
       expect(publishMessageMock).toHaveBeenCalledWith(event)
+    })
+  })
+
+  describe('and a read replica is configured', () => {
+    let mockWritePg: IPgComponent
+    let mockReadPg: IPgComponent
+    let writeWithTransaction: jest.Mock
+    let readWithTransaction: jest.Mock
+    let insertedTrade: Trade
+
+    beforeEach(async () => {
+      jest.spyOn(signatureUtils, 'validateTradeSignature').mockReturnValue(true)
+      jest.spyOn(utils, 'validateTradeByType').mockResolvedValue(true)
+      jest.spyOn(utils, 'isValidEstateTrade').mockResolvedValueOnce(true)
+      jest.spyOn(utils, 'getNotificationEventForTrade').mockResolvedValue(null)
+
+      insertedTrade = { ...mockTrade, id: '1', createdAt: Date.now(), contract: 'OffChainMarketplace' } as unknown as Trade
+
+      writeWithTransaction = jest.fn().mockResolvedValue(insertedTrade)
+      readWithTransaction = jest.fn()
+
+      const makeMockPg = (withTransaction: jest.Mock): IPgComponent =>
+        ({
+          getPool: jest.fn().mockReturnValue({ connect: jest.fn() }),
+          withTransaction,
+          start: jest.fn(),
+          query: jest.fn(),
+          stop: jest.fn(),
+          streamQuery: jest.fn()
+        } as unknown as IPgComponent)
+
+      mockWritePg = makeMockPg(writeWithTransaction)
+      mockReadPg = makeMockPg(readWithTransaction)
+
+      tradesComponent = createTradesComponent({
+        dappsDatabase: mockWritePg,
+        dappsReadDatabase: mockReadPg,
+        eventPublisher: mockEventPublisher,
+        logs
+      })
+
+      await tradesComponent.addTrade(mockTrade, mockSigner)
+      // let the fire-and-forget notification settle
+      await new Promise(resolve => setImmediate(resolve))
+    })
+
+    it('should run the duplicate-check validation against the read replica', () => {
+      expect(utils.validateTradeByType).toHaveBeenCalledWith(mockTrade, mockReadPg)
+    })
+
+    it('should build the creation notification from the read replica', () => {
+      expect(utils.getNotificationEventForTrade).toHaveBeenCalledWith(expect.anything(), mockReadPg, TradeEvent.CREATED, mockSigner)
+    })
+
+    it('should persist the trade on the write primary and never write on the replica', () => {
+      expect(writeWithTransaction).toHaveBeenCalled()
+      expect(readWithTransaction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the independent validations run concurrently', () => {
+    it('should start the estate validation before the structure check resolves', async () => {
+      jest.spyOn(signatureUtils, 'validateTradeSignature').mockReturnValue(true)
+      jest.spyOn(utils, 'getNotificationEventForTrade').mockResolvedValue(null)
+      ;(mockPg.withTransaction as jest.Mock).mockResolvedValue({} as Trade)
+
+      // keep the structure/duplicate check pending until we explicitly release it
+      let releaseStructure!: () => void
+      const pendingStructure = new Promise<boolean>(resolve => {
+        releaseStructure = () => resolve(true)
+      })
+      jest.spyOn(utils, 'validateTradeByType').mockReturnValue(pendingStructure)
+      const isValidEstateTradeSpy = jest.spyOn(utils, 'isValidEstateTrade').mockResolvedValue(true)
+
+      const addTradePromise = tradesComponent.addTrade(mockTrade, mockSigner)
+      // let the kicked-off validation branches run their synchronous prelude
+      await new Promise(resolve => setImmediate(resolve))
+
+      // the estate validation was invoked even though the structure check is still pending — proving
+      // the checks are not serialized behind one another (guards against a regression to serial awaits)
+      expect(isValidEstateTradeSpy).toHaveBeenCalled()
+
+      releaseStructure()
+      await addTradePromise
     })
   })
 })

--- a/test/unit/trades-handler.spec.ts
+++ b/test/unit/trades-handler.spec.ts
@@ -8,8 +8,10 @@ import {
 } from '../../src/controllers/handlers/trades-handler'
 import {
   DuplicatedBidError,
+  DuplicateItemOrderError,
   EstateContractNotFoundForChainId,
   InvalidEstateTrade,
+  InvalidOwnerError,
   EventNotGeneratedError,
   InvalidTradeSignatureError,
   InvalidTradeStructureError,
@@ -101,7 +103,9 @@ describe('when handling the creation of a new trade', () => {
         error: new EstateContractNotFoundForChainId(ChainId.AVALANCHE_MAINNET),
         code: StatusCode.BAD_REQUEST
       },
-      { errorName: 'DuplicatedBidError', error: new DuplicatedBidError(), code: StatusCode.CONFLICT }
+      { errorName: 'InvalidOwnerError', error: new InvalidOwnerError(), code: StatusCode.BAD_REQUEST },
+      { errorName: 'DuplicatedBidError', error: new DuplicatedBidError(), code: StatusCode.CONFLICT },
+      { errorName: 'DuplicateItemOrderError', error: new DuplicateItemOrderError(), code: StatusCode.CONFLICT }
     ])('and the error is an instance of $errorName', ({ error, code }) => {
       beforeEach(() => {
         body = { type: 'bid' } as TradeCreation


### PR DESCRIPTION
## Context

Production Grafana shows `POST /v1/trades` (offchain listing/trade creation) as the **slowest operation in the API (~10s mean)**. Root cause: the creation path runs, **serially**, two on-chain RPC round-trips (`ownerOf` + estate `getFingerprintV2`, each constructing a fresh `JsonRpcProvider`), a catalog-class duplicate-order query, and a blocking SNS publish. This path is also the one the upcoming USD-pricing work reuses, so it's a double win.

## Changes

- **Parallelize the independent I/O-bound validations** (structure/duplicate-check, estate fingerprint, ownership) with `Promise.allSettled` — validation latency goes from the *sum* of the checks to the *max*. The first failure is surfaced in a **fixed precedence** (structure → estate → ownership) so the error returned to the client stays deterministic.
- **Validate the signature before any I/O** — cheap CPU check first; no DB/RPC work is done for forged/unsigned requests (security + faster failure path).
- **Fire-and-forget the creation notification** — the `201` returns as soon as the trade is durably persisted; the asset lookups + SNS publish (already best-effort) no longer block the response.
- **Route the duplicate-check + notification reads to the read replica**, keeping the write primary for the insert transaction (optional `dappsReadDatabase` dep, falls back to the write DB when not wired).
- **Reuse a `JsonRpcProvider` per chain + 5s timeout** on `ownerOf`/`getFingerprintV2` (was: a new provider per call, unbounded).
- **Ownership stays validated on-chain** (deliberate — no security regression; parallelization already removes it from the additive critical path).
- Map `InvalidOwnerError` → 400 and `DuplicateItemOrderError` → 409 in the handler (were falling through to 500).

A cheaper `EXISTS` rewrite of the duplicate-check (vs the current full catalog-class query) is intentionally **deferred** to a follow-up — it must faithfully reproduce the on-sale semantics (legacy `order` + offchain `mv_trades`) and warrants its own integration-test coverage.

## Test plan

- [x] `tsc` typecheck clean
- [x] eslint clean (no new warnings)
- [x] Unit tests green — 86 trades unit tests, incl. new coverage for read-replica routing, validation concurrency, and the new handler error mappings
- [x] CI green (build + lint + unit + integration)
- [ ] Confirm the `POST /v1/trades` p95 drop on staging/prod