### PR TITLE
perf: drop redundant window counts from the orders query

### DIFF
--- a/src/ports/orders/queries.ts
+++ b/src/ports/orders/queries.ts
@@ -145,14 +145,17 @@ export function getOrderAndTradeQueries(filters: OrderFilters & { nftIds?: strin
   }
   const commonQueryParts = getOrdersSortByStatement(filters).append(getInnerOrdersLimitAndOffsetStatement(filters))
 
-  const orderTradesQuery = SQL`SELECT *, COUNT(*) OVER() as count `
+  // No COUNT(*) OVER() here: the data query's row count is never read (the orders component and the
+  // nfts component both ignore it and the total comes from getOrdersCountQuery). Dropping the window
+  // aggregate lets the ORDER BY + LIMIT short-circuit to a top-N instead of scanning the full set.
+  const orderTradesQuery = SQL`SELECT * `
     .append(SQL`FROM (`)
     .append(getTradesOrdersQuery(filters))
     .append(SQL`) as order_trades`)
     .append(getWhereStatementFromFilters(tradesFilters))
     .append(commonQueryParts)
 
-  const legacyOrdersQuery = SQL`SELECT *, COUNT(*) OVER() as count `
+  const legacyOrdersQuery = SQL`SELECT * `
     .append(SQL`FROM (`)
     .append(getLegacyOrdersQuery())
     .append(getWhereStatementFromFilters(ordersFilters))
@@ -208,8 +211,8 @@ export function getOrdersCountQuery(filters: OrderFilters & { nftIds?: string[] 
         SELECT COUNT(*) AS trades_count, 
                NULL::bigint AS orders_count
         FROM (
-          SELECT *, 
-                 COUNT(*) OVER() AS trades_count
+          -- inner window count removed: the outer COUNT(*) above already produces the total
+          SELECT 1
           FROM (
             `
       .append(getTradesOrdersQuery(filters))

--- a/test/unit/orders-queries.spec.ts
+++ b/test/unit/orders-queries.spec.ts
@@ -1,0 +1,52 @@
+import { ListingStatus, OrderFilters } from '@dcl/schemas'
+import { getOrdersCountQuery, getOrdersQuery } from '../../src/ports/orders/queries'
+
+// Whitespace-tolerant matcher so the regression guard still catches a reintroduced window aggregate
+// written as `COUNT(*) OVER ()`, `COUNT( * )OVER(`, etc.
+const COUNT_OVER = /COUNT\(\s*\*\s*\)\s*OVER\s*\(/i
+
+describe('when building the orders queries', () => {
+  let filters: OrderFilters
+
+  beforeEach(() => {
+    filters = { first: 20, skip: 0 }
+  })
+
+  describe('and building the data query (getOrdersQuery)', () => {
+    it('should not compute a COUNT(*) OVER() window: its row count is unused (the total comes from getOrdersCountQuery)', () => {
+      expect(getOrdersQuery(filters).text).not.toMatch(COUNT_OVER)
+    })
+
+    it('should still union the offchain trades and legacy orders sources', () => {
+      const text = getOrdersQuery(filters).text
+      expect(text).toContain('UNION ALL')
+      expect(text).toContain('order_trades')
+      expect(text).toContain('legacy_orders')
+    })
+
+    it('should still apply the LIMIT/OFFSET pagination', () => {
+      const text = getOrdersQuery(filters).text
+      expect(text).toContain('LIMIT')
+      expect(text).toContain('OFFSET')
+    })
+
+    it('should keep both union branches free of the window count for a filtered shape too', () => {
+      const text = getOrdersQuery({ ...filters, owner: '0x1', status: ListingStatus.OPEN }).text
+      expect(text).not.toMatch(COUNT_OVER)
+      expect(text).toContain('UNION ALL')
+    })
+  })
+
+  describe('and building the count query (getOrdersCountQuery)', () => {
+    it('should not compute a redundant COUNT(*) OVER() window: the outer COUNT(*) already produces the total', () => {
+      expect(getOrdersCountQuery(filters).text).not.toMatch(COUNT_OVER)
+    })
+
+    it('should still aggregate the trades and orders counts into a single total', () => {
+      const text = getOrdersCountQuery(filters).text
+      expect(text).toContain('total_trades')
+      expect(text).toContain('total_orders')
+      expect(text).toContain('AS count')
+    })
+  })
+})


### PR DESCRIPTION
## Context

From the prod latency baseline, `GET /v1/orders` **unfiltered takes ~3s**, while the same endpoint **filtered by `owner` returns in ~0.48s**. The unfiltered path was doing avoidable work computing `COUNT(*) OVER()` window aggregates over the full set of open orders.

`orders.getOrders` runs two queries in parallel: the data query (`getOrdersQuery`) and a dedicated total query (`getOrdersCountQuery`). Two of the window counts in those builders are redundant.

## Changes

- **`getOrdersQuery` (data query):** removed `COUNT(*) OVER() as count` from both UNION branches (`orderTradesQuery` + `legacyOrdersQuery`). That column was **never read** — `fromDBOrderToOrder` ignores it, the orders component takes `total` from the separate `getOrdersCountQuery`, and the nfts consumer of this query only maps rows. Dropping the window aggregate lets `ORDER BY … LIMIT/OFFSET` short-circuit to a top-N instead of materializing/counting the whole set. **No change to results.**
- **`getOrdersCountQuery`:** replaced an inner `SELECT *, COUNT(*) OVER() AS trades_count` with `SELECT 1`. The inner per-row window was redundant — the **outer** `COUNT(*)` already produces the total. **No change to the total.**

Both changes are pure no-ops on the response (same rows, same `total`); they only remove duplicated counting work. Verified the change is safe for the shared `getOrdersQuery` consumer in the nfts component (its `.count` comes from `getNFTsQuery`, not this query).

> Note: the remaining floor on the *unfiltered* endpoint is the necessary total-count over all open orders + the full `mv_trades` CTE scan. Pushing that further (cache/approximate count, filter push-down into the CTE) is a deeper follow-up that should be validated against a prod-shaped dataset.

## Test plan

- [x] `tsc` typecheck clean
- [x] eslint clean
- [x] Unit tests green — new `orders-queries.spec.ts` (regression guards that neither builder reintroduces a window count, with whitespace-tolerant matching) + existing `orders-adapters` / `nfts-adapters` / `nfts-handler` suites
- [ ] CI (build + lint + unit + integration)
- [ ] Confirm the `GET /v1/orders` latency drop on staging/prod