### PR TITLE
feat: add includeSocialEmotes filter to catalog, items and nfts endpoints

### DIFF
--- a/src/controllers/handlers/items-handler.ts
+++ b/src/controllers/handlers/items-handler.ts
@@ -1,4 +1,3 @@
-import { ItemFilters } from '@dcl/schemas'
 import { fromDBPickStatsToPickStats } from '../../adapters/picks'
 import { isErrorWithMessage } from '../../logic/errors'
 import { enhanceItemsWithPicksStats } from '../../logic/favorites/utils'
@@ -17,7 +16,7 @@ export async function getItemsHandler(
     const params = new Params(context.url.searchParams)
     const caller: string | undefined = context.verification?.auth.toLowerCase()
 
-    const filters: ItemFilters = getItemsParams(params)
+    const filters = getItemsParams(params)
 
     const { data, total } = await items.getItems({
       ...filters

--- a/src/controllers/handlers/nfts-handler.ts
+++ b/src/controllers/handlers/nfts-handler.ts
@@ -1,4 +1,3 @@
-import { NFTFilters } from '@dcl/schemas'
 import { isErrorWithMessage } from '../../logic/errors'
 import { Params } from '../../logic/http/params'
 import { InvalidSearchByTenantAndOwnerError, InvalidTokenIdError, MissingContractAddressParamError } from '../../ports/nfts/errors'
@@ -15,7 +14,7 @@ export async function getNFTsHandler(context: Pick<HandlerContextWithPath<'nfts'
 
     const caller: string | undefined = context.verification?.auth.toLowerCase()
 
-    const filters: NFTFilters = getNFTParams(params)
+    const filters = getNFTParams(params)
 
     const { data, total } = await nfts.getNFTs(
       {

--- a/src/controllers/handlers/trending-handler.ts
+++ b/src/controllers/handlers/trending-handler.ts
@@ -17,13 +17,15 @@ export async function getTrendingsHandler(
     }
 
     const size = params.getNumber('size')
+    // Social emotes are included by default; excluded only when includeSocialEmotes=false is explicitly set
+    const includeSocialEmotes = params.getString('includeSocialEmotes') !== 'false'
 
     const pickedBy: string | undefined = context.verification?.auth.toLowerCase()
 
     return {
       status: StatusCode.OK,
       headers: responseHeaders, //TODO: see headers
-      body: { data: await trendings.fetch({ size, pickedBy }) }
+      body: { data: await trendings.fetch({ size, pickedBy, includeSocialEmotes }) }
     }
   } catch (e) {
     return {

--- a/src/controllers/handlers/utils.ts
+++ b/src/controllers/handlers/utils.ts
@@ -62,11 +62,13 @@ export const getItemsParams = (params: Params) => {
     maxPrice: maxPrice && maxPrice.trim() ? parsePrice(maxPrice, 'maxPrice') : undefined,
     minPrice: minPrice && minPrice.trim() ? parsePrice(minPrice, 'minPrice') : undefined,
     urns: params.getList('urn'),
-    ids: params.getList('id')
+    ids: params.getList('id'),
+    // Social emotes are included by default; excluded only when includeSocialEmotes=false is explicitly set
+    includeSocialEmotes: params.getString('includeSocialEmotes') !== 'false'
   }
 }
 
-export const getNFTParams = (params: Params): NFTFilters => {
+export const getNFTParams = (params: Params): NFTFilters & { includeSocialEmotes?: boolean } => {
   const maxPrice = params.getString('maxPrice')
   const minPrice = params.getString('minPrice')
   return {
@@ -108,7 +110,9 @@ export const getNFTParams = (params: Params): NFTFilters => {
     rentalDays: params
       .getList('rentalDays')
       .map(days => Number.parseInt(days))
-      .filter(number => !Number.isNaN(number))
+      .filter(number => !Number.isNaN(number)),
+    // Social emotes are included by default; excluded only when includeSocialEmotes=false is explicitly set
+    includeSocialEmotes: params.getString('includeSocialEmotes') !== 'false'
   }
 }
 

--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -400,7 +400,7 @@ export const getNetworkWhere = (filters: CatalogFilters) => {
 }
 
 /** Helper to build WHERE clause with item-level filters only (no joins needed) */
-const getItemLevelFiltersWhere = (filters: CatalogFilters) => {
+const getItemLevelFiltersWhere = (filters: CatalogQueryFilters) => {
   const conditions = [
     filters.category ? getCategoryWhere(filters) : undefined,
     filters.rarities?.length ? getRaritiesWhere(filters) : undefined,
@@ -421,7 +421,11 @@ const getItemLevelFiltersWhere = (filters: CatalogFilters) => {
     filters.network ? getNetworkWhere(filters) : undefined
   ].filter(Boolean)
 
+  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false
   const whereClause = SQL`WHERE items.search_is_collection_approved = true`
+  if (filters.includeSocialEmotes === false) {
+    whereClause.append(SQL` AND items.search_emote_outcome_type IS NULL`)
+  }
   if (conditions.length > 0) {
     whereClause.append(SQL` AND `)
     conditions.forEach((condition, index) => {
@@ -437,7 +441,7 @@ const getItemLevelFiltersWhere = (filters: CatalogFilters) => {
   return whereClause
 }
 
-export const getCollectionsQueryWhere = (filters: CatalogFilters, isV2 = false) => {
+export const getCollectionsQueryWhere = (filters: CatalogQueryFilters, isV2 = false) => {
   const conditions = [
     filters.category ? getCategoryWhere(filters) : undefined,
     filters.rarities?.length ? getRaritiesWhere(filters) : undefined,
@@ -463,7 +467,11 @@ export const getCollectionsQueryWhere = (filters: CatalogFilters, isV2 = false) 
     filters.network ? getNetworkWhere(filters) : undefined
   ].filter(Boolean)
 
+  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false
   const result = SQL`WHERE items.search_is_collection_approved = true `
+  if (filters.includeSocialEmotes === false) {
+    result.append(SQL` AND items.search_emote_outcome_type IS NULL `)
+  }
   if (!conditions.length) {
     return result
   } else {

--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -421,7 +421,8 @@ const getItemLevelFiltersWhere = (filters: CatalogQueryFilters) => {
     filters.network ? getNetworkWhere(filters) : undefined
   ].filter(Boolean)
 
-  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false
+  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false.
+  // Note: passing emoteOutcomeType together with includeSocialEmotes=false is contradictory and returns no emotes.
   const whereClause = SQL`WHERE items.search_is_collection_approved = true`
   if (filters.includeSocialEmotes === false) {
     whereClause.append(SQL` AND items.search_emote_outcome_type IS NULL`)
@@ -467,7 +468,8 @@ export const getCollectionsQueryWhere = (filters: CatalogQueryFilters, isV2 = fa
     filters.network ? getNetworkWhere(filters) : undefined
   ].filter(Boolean)
 
-  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false
+  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false.
+  // Note: passing emoteOutcomeType together with includeSocialEmotes=false is contradictory and returns no emotes.
   const result = SQL`WHERE items.search_is_collection_approved = true `
   if (filters.includeSocialEmotes === false) {
     result.append(SQL` AND items.search_emote_outcome_type IS NULL `)

--- a/src/ports/catalog/types.ts
+++ b/src/ports/catalog/types.ts
@@ -49,9 +49,10 @@ export type CatalogQueryFilters = Omit<CatalogFilters, 'sortBy' | 'sortDirection
   sortDirection?: CatalogSortDirection
   limit?: number
   offset?: number
+  includeSocialEmotes?: boolean
 }
 
-export type CatalogOptions = CatalogFilters & { pickedBy?: string }
+export type CatalogOptions = CatalogFilters & { pickedBy?: string; includeSocialEmotes?: boolean }
 
 export interface ICatalogComponent {
   fetch(

--- a/src/ports/items/component.ts
+++ b/src/ports/items/component.ts
@@ -1,11 +1,10 @@
-import { ItemFilters } from '@dcl/schemas'
 import { fromDBItemToItem } from '../../adapters/items'
 import { isErrorWithMessage } from '../../logic/errors'
 import { AppComponents } from '../../types'
 import { QueryFailure } from '../favorites/lists/errors'
 import { ItemNotFoundError } from './errors'
 import { getItemById, getItemsQuery, getUtilityByItem } from './queries'
-import { DBItem, IItemsComponent } from './types'
+import { DBItem, IItemsComponent, ItemQueryFilters } from './types'
 
 export function createItemsComponent(components: Pick<AppComponents, 'dappsDatabase' | 'logs'>): IItemsComponent {
   const { dappsDatabase: database, logs } = components
@@ -32,7 +31,7 @@ export function createItemsComponent(components: Pick<AppComponents, 'dappsDatab
     }
   }
 
-  async function getItems(filters: ItemFilters) {
+  async function getItems(filters: ItemQueryFilters) {
     const query = getItemsQuery(filters)
     const result = await database.query<DBItem>(query)
     const items: DBItem[] = result.rows

--- a/src/ports/items/queries.ts
+++ b/src/ports/items/queries.ts
@@ -7,6 +7,8 @@ import { getWhereStatementFromFilters } from '../utils'
 import { ItemType } from './types'
 import { DEFAULT_LIMIT, getItemTypesFromNFTCategory } from './utils'
 
+type ItemQueryFilters = ItemFilters & { includeSocialEmotes?: boolean }
+
 export function getItemById(itemId: string) {
   return SQL`
         SELECT id
@@ -60,7 +62,7 @@ function getEmotePlayModeWhereStatement(emotePlayMode: EmotePlayMode | EmotePlay
 }
 
 // TODO: Add sort by logic
-function getItemsWhereStatement(filters: ItemFilters): SQLStatement {
+function getItemsWhereStatement(filters: ItemQueryFilters): SQLStatement {
   if (!filters) {
     return SQL``
   }
@@ -99,6 +101,8 @@ function getItemsWhereStatement(filters: ItemFilters): SQLStatement {
   // For now, let's filter if the outcome type is not null
   const FILTER_BY_OUTCOME_TYPE = filters.emoteOutcomeType ? SQL` emote.outcome_type IS NOT NULL ` : null
   const FILTER_BY_URNS = filters.urns && filters.urns.length ? SQL` item.urn = ANY (${filters.urns}) ` : null
+  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false
+  const EXCLUDE_SOCIAL_EMOTES = filters.includeSocialEmotes === false ? SQL` emote.outcome_type IS NULL ` : null
   return getWhereStatementFromFilters([
     FILTER_BY_CATEGORY,
     FILTER_BY_CREATOR,
@@ -123,11 +127,12 @@ function getItemsWhereStatement(filters: ItemFilters): SQLStatement {
     FILTER_BY_HAS_SOUND,
     FILTER_BY_HAS_GEOMETRY,
     FILTER_BY_OUTCOME_TYPE,
-    FILTER_BY_URNS
+    FILTER_BY_URNS,
+    EXCLUDE_SOCIAL_EMOTES
   ])
 }
 
-export function getItemsQuery(filters: ItemFilters = {}) {
+export function getItemsQuery(filters: ItemQueryFilters = {}) {
   return getTradesCTE({
     category: filters.category,
     first: filters.first,

--- a/src/ports/items/queries.ts
+++ b/src/ports/items/queries.ts
@@ -4,10 +4,8 @@ import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getDBNetworks } from '../../utils'
 import { getTradesCTE } from '../catalog/queries'
 import { getWhereStatementFromFilters } from '../utils'
-import { ItemType } from './types'
+import { ItemQueryFilters, ItemType } from './types'
 import { DEFAULT_LIMIT, getItemTypesFromNFTCategory } from './utils'
-
-type ItemQueryFilters = ItemFilters & { includeSocialEmotes?: boolean }
 
 export function getItemById(itemId: string) {
   return SQL`
@@ -101,7 +99,8 @@ function getItemsWhereStatement(filters: ItemQueryFilters): SQLStatement {
   // For now, let's filter if the outcome type is not null
   const FILTER_BY_OUTCOME_TYPE = filters.emoteOutcomeType ? SQL` emote.outcome_type IS NOT NULL ` : null
   const FILTER_BY_URNS = filters.urns && filters.urns.length ? SQL` item.urn = ANY (${filters.urns}) ` : null
-  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false
+  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false.
+  // Note: passing emoteOutcomeType together with includeSocialEmotes=false is contradictory and returns no emotes.
   const EXCLUDE_SOCIAL_EMOTES = filters.includeSocialEmotes === false ? SQL` emote.outcome_type IS NULL ` : null
   return getWhereStatementFromFilters([
     FILTER_BY_CATEGORY,

--- a/src/ports/items/types.ts
+++ b/src/ports/items/types.ts
@@ -1,9 +1,11 @@
 import { BodyShape, EmoteCategory, Item, ItemFilters, Network, Rarity, WearableCategory, EmoteOutcomeType } from '@dcl/schemas'
 import { SquidNetwork } from '../../types'
 
+export type ItemQueryFilters = ItemFilters & { includeSocialEmotes?: boolean }
+
 export interface IItemsComponent {
   validateItemExists(itemId: string): Promise<void>
-  getItems(filters?: ItemFilters): Promise<GetItemsResponse>
+  getItems(filters?: ItemQueryFilters): Promise<GetItemsResponse>
 }
 
 export type GetItemsResponse = {

--- a/src/ports/nfts/component.ts
+++ b/src/ports/nfts/component.ts
@@ -1,4 +1,4 @@
-import { ListingStatus, NFTCategory, NFTFilters, RentalStatus } from '@dcl/schemas'
+import { ListingStatus, NFTCategory, RentalStatus } from '@dcl/schemas'
 import { fromNFTsAndOrdersToNFTsResult } from '../../adapters/nfts'
 import { getEthereumChainId } from '../../logic/chainIds'
 import { getMarketplaceContracts } from '../../logic/contracts'
@@ -10,7 +10,7 @@ import { formatQueryForLogging } from '../utils'
 import { getENSsCount } from './ensQueries'
 import { InvalidSearchByTenantAndOwnerError, InvalidTokenIdError, MissingContractAddressParamError } from './errors'
 import { getNFTsQuery } from './queries'
-import { DBNFT, INFTsComponent } from './types'
+import { DBNFT, INFTsComponent, NFTQueryFilters } from './types'
 import { getNFTFilters } from './utils'
 
 export const MAX_SUBGRAPH_QUERY_IN_ELEMENTS = 500
@@ -18,7 +18,7 @@ export const MAX_SUBGRAPH_QUERY_IN_ELEMENTS = 500
 export function createNFTsComponent(components: Pick<AppComponents, 'dappsDatabase' | 'config' | 'rentals'>): INFTsComponent {
   const { dappsDatabase: pg, config, rentals } = components
 
-  async function getNFTs(filters: NFTFilters) {
+  async function getNFTs(filters: NFTQueryFilters) {
     const { owner, tenant, tokenId, contractAddresses } = filters
     if (owner && tenant) {
       throw new InvalidSearchByTenantAndOwnerError()

--- a/src/ports/nfts/queries.ts
+++ b/src/ports/nfts/queries.ts
@@ -399,7 +399,8 @@ function getNFTWhereStatement(nftFilters: GetNFTsFilters): SQLStatement {
     nftFilters.bannedNames && nftFilters.bannedNames.length
       ? SQL` (nft.category != ${NFTCategory.ENS} OR nft.name <> ALL (${nftFilters.bannedNames})) `
       : null
-  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false
+  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false.
+  // Note: passing emoteOutcomeType together with includeSocialEmotes=false is contradictory and returns no emotes.
   const EXCLUDE_SOCIAL_EMOTES = nftFilters.includeSocialEmotes === false ? SQL` emote.outcome_type IS NULL ` : null
 
   return getWhereStatementFromFilters([

--- a/src/ports/nfts/queries.ts
+++ b/src/ports/nfts/queries.ts
@@ -399,6 +399,8 @@ function getNFTWhereStatement(nftFilters: GetNFTsFilters): SQLStatement {
     nftFilters.bannedNames && nftFilters.bannedNames.length
       ? SQL` (nft.category != ${NFTCategory.ENS} OR nft.name <> ALL (${nftFilters.bannedNames})) `
       : null
+  // Social emotes (those with an outcome type) are included by default; excluded only when includeSocialEmotes=false
+  const EXCLUDE_SOCIAL_EMOTES = nftFilters.includeSocialEmotes === false ? SQL` emote.outcome_type IS NULL ` : null
 
   return getWhereStatementFromFilters([
     FILTER_BY_HAS_SOUND,
@@ -414,32 +416,36 @@ function getNFTWhereStatement(nftFilters: GetNFTsFilters): SQLStatement {
     FILTER_BY_MIN_PRICE,
     FILTER_BY_MAX_PRICE,
     FILTER_BY_ON_SALE,
-    FITLER_BANNED_NAMES
+    FITLER_BANNED_NAMES,
+    EXCLUDE_SOCIAL_EMOTES
   ])
 }
 
 function getRecentlyListedNFTsQuery(nftFilters: GetNFTsFilters): SQLStatement {
-  const FILTER_BY_OWNER = nftFilters.owner ? SQL` owner_address = ${nftFilters.owner} ` : null
-  const FILTER_BY_CATEGORY = nftFilters.category ? SQL` category = ${nftFilters.category.toLowerCase()} ` : null
-  const FILTER_BY_TOKEN_ID = nftFilters.tokenId ? SQL` token_id = ${nftFilters.tokenId} ` : null
-  const FILTER_BY_ITEM_ID = nftFilters.itemId ? SQL` LOWER(item_id) = LOWER(${nftFilters.itemId}) ` : null
-  const FILTER_BY_NETWORK = nftFilters.network ? SQL` network = ANY (${getDBNetworks(nftFilters.network)}) ` : null
-  const FILTER_BY_WEARABLE_HEAD = nftFilters.isWearableHead ? SQL` search_is_wearable_head = true ` : null
-  const FILTER_BY_LAND = nftFilters.isLand ? SQL` search_is_land = true ` : null
-  const FILTER_BY_WEARABLE_ACCESSORY = nftFilters.isWearableAccessory ? SQL` search_is_wearable_accessory = true ` : null
-  const FILTER_BY_SMART_WEARABLE = nftFilters.isWearableSmart ? SQL` item_type = ${ItemType.SMART_WEARABLE_V1} ` : null
+  // These filters are reused across sub-queries that join the nft table with trade_assets/trade_assets_erc721
+  // and unified_trades, which share column names (contract_address, token_id, id). Qualify every column with the
+  // nft alias so the references are never ambiguous regardless of which sub-query they are appended to.
+  const FILTER_BY_OWNER = nftFilters.owner ? SQL` nft.owner_address = ${nftFilters.owner} ` : null
+  const FILTER_BY_CATEGORY = nftFilters.category ? SQL` nft.category = ${nftFilters.category.toLowerCase()} ` : null
+  const FILTER_BY_TOKEN_ID = nftFilters.tokenId ? SQL` nft.token_id = ${nftFilters.tokenId} ` : null
+  const FILTER_BY_ITEM_ID = nftFilters.itemId ? SQL` LOWER(nft.item_id) = LOWER(${nftFilters.itemId}) ` : null
+  const FILTER_BY_NETWORK = nftFilters.network ? SQL` nft.network = ANY (${getDBNetworks(nftFilters.network)}) ` : null
+  const FILTER_BY_WEARABLE_HEAD = nftFilters.isWearableHead ? SQL` nft.search_is_wearable_head = true ` : null
+  const FILTER_BY_LAND = nftFilters.isLand ? SQL` nft.search_is_land = true ` : null
+  const FILTER_BY_WEARABLE_ACCESSORY = nftFilters.isWearableAccessory ? SQL` nft.search_is_wearable_accessory = true ` : null
+  const FILTER_BY_SMART_WEARABLE = nftFilters.isWearableSmart ? SQL` nft.item_type = ${ItemType.SMART_WEARABLE_V1} ` : null
   const FILTER_BY_CONTRACT_ADDRESSES = nftFilters.contractAddresses?.length
-    ? SQL` contract_address = ANY (${nftFilters.contractAddresses}) `
+    ? SQL` nft.contract_address = ANY (${nftFilters.contractAddresses}) `
     : null
-  const FILTER_BY_SEARCH = nftFilters.search ? SQL` search_text % ${nftFilters.search} ` : null
+  const FILTER_BY_SEARCH = nftFilters.search ? SQL` nft.search_text % ${nftFilters.search} ` : null
   const FILTER_BY_MIN_PLAZA_DISTANCE = nftFilters.minDistanceToPlaza
-    ? SQL` search_distance_to_plaza >= ${nftFilters.minDistanceToPlaza} `
+    ? SQL` nft.search_distance_to_plaza >= ${nftFilters.minDistanceToPlaza} `
     : null
   const FILTER_BY_MAX_PLAZA_DISTANCE = nftFilters.maxDistanceToPlaza
-    ? SQL` search_distance_to_plaza <= ${nftFilters.maxDistanceToPlaza} `
+    ? SQL` nft.search_distance_to_plaza <= ${nftFilters.maxDistanceToPlaza} `
     : null
-  const FILTER_BY_ROAD_ADJACENT = nftFilters.adjacentToRoad ? SQL` search_adjacent_to_road = true ` : null
-  const FILTER_BY_IDS = nftFilters.ids?.length ? SQL` id = ANY (${nftFilters.ids}) ` : null
+  const FILTER_BY_ROAD_ADJACENT = nftFilters.adjacentToRoad ? SQL` nft.search_adjacent_to_road = true ` : null
+  const FILTER_BY_IDS = nftFilters.ids?.length ? SQL` nft.id = ANY (${nftFilters.ids}) ` : null
 
   const FILTER_BY_ON_SALE = nftFilters.isOnSale
     ? SQL` (nft.search_order_status = ${ListingStatus.OPEN} AND nft.search_order_expires_at < `.append(MAX_ORDER_TIMESTAMP).append(` 
@@ -451,12 +457,15 @@ function getRecentlyListedNFTsQuery(nftFilters: GetNFTsFilters): SQLStatement {
   const FILTER_NFT_BY_MIN_PRICE = nftFilters.minPrice ? SQL` nft.search_order_price >= ${nftFilters.minPrice}` : null
   const FILTER_NFT_BY_MAX_PRICE = nftFilters.maxPrice ? SQL` nft.search_order_price <= ${nftFilters.maxPrice}` : null
 
-  const FILTER_TRADES_BY_MIN_PRICE = nftFilters.minPrice
-    ? SQL` trades.assets -> 'received' ->> 'amount')::numeric(78) >= ${nftFilters.minPrice}`
-    : null
-  const FILTER_TRADES_BY_MAX_PRICE = nftFilters.maxPrice
-    ? SQL` trades.assets -> 'received' ->> 'amount')::numeric(78) <= ${nftFilters.maxPrice}`
-    : null
+  // Trade price filters compare against the received amount of the joined unified_trades row (aliased `t`),
+  // so they must live in the outer query of the recent_trade_nft_ids CTE where `t` is in scope.
+  const tradePriceWhere = SQL``
+  if (nftFilters.minPrice) {
+    tradePriceWhere.append(SQL` AND (t.assets -> 'received' ->> 'amount')::numeric(78) >= ${nftFilters.minPrice}`)
+  }
+  if (nftFilters.maxPrice) {
+    tradePriceWhere.append(SQL` AND (t.assets -> 'received' ->> 'amount')::numeric(78) <= ${nftFilters.maxPrice}`)
+  }
 
   const filters = [
     FILTER_BY_OWNER,
@@ -476,7 +485,7 @@ function getRecentlyListedNFTsQuery(nftFilters: GetNFTsFilters): SQLStatement {
     FILTER_BY_IDS
   ]
 
-  const whereClauseForTradeNFTsIds = getWhereStatementFromFilters([...filters, FILTER_TRADES_BY_MIN_PRICE, FILTER_TRADES_BY_MAX_PRICE])
+  const whereClauseForTradeNFTsIds = getWhereStatementFromFilters([...filters])
   const whereClauseForNFTsWithOrders = getWhereStatementFromFilters([
     ...filters,
     FILTER_BY_ON_SALE,
@@ -510,7 +519,10 @@ function getRecentlyListedNFTsQuery(nftFilters: GetNFTsFilters): SQLStatement {
           .append(
             SQL`
       ) assets_with_values ON t.id = assets_with_values.trade_id
-      WHERE t.type = 'public_nft_order'
+      WHERE t.type = 'public_nft_order'`
+              .append(tradePriceWhere)
+              .append(
+                SQL`
       ORDER BY assets_with_values.nft_id, t.created_at DESC
     ),
     nfts_with_trades AS (
@@ -520,6 +532,7 @@ function getRecentlyListedNFTsQuery(nftFilters: GetNFTsFilters): SQLStatement {
         unified_trades.assets,
         'trade' AS reason
       FROM `
+              )
               .append(MARKETPLACE_SQUID_SCHEMA)
               .append(
                 SQL`.nft nft
@@ -687,8 +700,20 @@ function getRecentlyListedNFTsQuery(nftFilters: GetNFTsFilters): SQLStatement {
                                                                                           .append(MARKETPLACE_SQUID_SCHEMA)
                                                                                           .append(
                                                                                             SQL`.item item ON item.id = combined.item_id
+    `
+                                                                                              .append(
+                                                                                                nftFilters.includeSocialEmotes === false
+                                                                                                  ? SQL`WHERE emote.outcome_type IS NULL`
+                                                                                                  : SQL``
+                                                                                              )
+                                                                                              .append(
+                                                                                                SQL`
     ORDER BY sort_field DESC
-    `.append(getNFTLimitAndOffsetStatement(nftFilters)).append(SQL`
+    `
+                                                                                              )
+                                                                                              .append(
+                                                                                                getNFTLimitAndOffsetStatement(nftFilters)
+                                                                                              ).append(SQL`
     `)
                                                                                           )
                                                                                       )

--- a/src/ports/nfts/types.ts
+++ b/src/ports/nfts/types.ts
@@ -18,7 +18,7 @@ export type INFTsComponent = {
   getNFTs(filters?: NFTFilters, caller?: string): Promise<GetNFTsResponse>
 }
 
-export type GetNFTsFilters = NFTFilters & { bannedNames?: string[] }
+export type GetNFTsFilters = NFTFilters & { bannedNames?: string[]; includeSocialEmotes?: boolean }
 
 export type NFTResult = {
   nft: NFT

--- a/src/ports/nfts/types.ts
+++ b/src/ports/nfts/types.ts
@@ -15,10 +15,12 @@ import { SquidNetwork } from '../../types'
 import { ItemType } from '../items'
 
 export type INFTsComponent = {
-  getNFTs(filters?: NFTFilters, caller?: string): Promise<GetNFTsResponse>
+  getNFTs(filters?: NFTQueryFilters, caller?: string): Promise<GetNFTsResponse>
 }
 
-export type GetNFTsFilters = NFTFilters & { bannedNames?: string[]; includeSocialEmotes?: boolean }
+export type NFTQueryFilters = NFTFilters & { includeSocialEmotes?: boolean }
+
+export type GetNFTsFilters = NFTQueryFilters & { bannedNames?: string[] }
 
 export type NFTResult = {
   nft: NFT

--- a/src/ports/nfts/utils.ts
+++ b/src/ports/nfts/utils.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch'
-import { NFTCategory, NFTFilters, RentalListing, RentalStatus } from '@dcl/schemas'
+import { NFTCategory, RentalListing, RentalStatus } from '@dcl/schemas'
 import { IRentalsComponent } from '../rentals/types'
-import { GetNFTsFilters } from './types'
+import { GetNFTsFilters, NFTQueryFilters } from './types'
 
 export async function getBannedNames(listsServer: string): Promise<string[]> {
   try {
@@ -19,7 +19,7 @@ export async function getBannedNames(listsServer: string): Promise<string[]> {
 }
 
 export async function getNFTFilters(
-  filters: NFTFilters,
+  filters: NFTQueryFilters,
   listsServer: string,
   rentals: IRentalsComponent
 ): Promise<{ filters: GetNFTsFilters; listings?: RentalListing[] }> {

--- a/src/ports/trendings/component.ts
+++ b/src/ports/trendings/component.ts
@@ -27,7 +27,7 @@ export function createTrendingsComponent(components: Pick<AppComponents, 'dappsD
    * @param filters TrendingFilters
    * @returns NFT
    */
-  async function fetch({ pickedBy, ...filters }: TrendingFilters) {
+  async function fetch({ pickedBy, includeSocialEmotes, ...filters }: TrendingFilters) {
     const sales = await fetchTrendingSales(0)
     const trendingSales = sales.reduce((acc, sale) => {
       if (sale.itemId) {
@@ -42,7 +42,8 @@ export function createTrendingsComponent(components: Pick<AppComponents, 'dappsD
         const [contractAddress, itemId] = key.split('-')
         return itemsComponent.getItems({
           contractAddresses: [contractAddress],
-          itemId: itemId || undefined
+          itemId: itemId || undefined,
+          includeSocialEmotes
         })
       })
     )

--- a/src/ports/trendings/queries.ts
+++ b/src/ports/trendings/queries.ts
@@ -19,7 +19,7 @@ export function getTrendingSalesQuery(filters: TrendingFilters) {
 
   if (from) {
     const fromTimestamp = Math.round(from / 1000)
-    query.append(SQL`WHERE timestamp > ${fromTimestamp}`)
+    query.append(SQL`WHERE timestamp > ${fromTimestamp} `)
   }
 
   query.append(SQL`ORDER BY timestamp DESC `)

--- a/src/ports/trendings/types.ts
+++ b/src/ports/trendings/types.ts
@@ -6,6 +6,7 @@ export type TrendingFilters = {
   skip?: number
   first?: number
   pickedBy?: string
+  includeSocialEmotes?: boolean
 }
 
 export interface ITrendingsComponent {

--- a/test/integration/catalog-controller.spec.ts
+++ b/test/integration/catalog-controller.spec.ts
@@ -13,7 +13,9 @@ import {
   deleteSquidDBItem,
   deleteSquidDBNFT,
   deleteSquidDBTrade,
-  refreshTradesMaterializedView
+  refreshTradesMaterializedView,
+  createSquidDBEmoteItem,
+  deleteSquidDBEmoteItem
 } from './utils/dbItems'
 
 test('when fetching items from the catalog', function ({ components }) {
@@ -1447,6 +1449,68 @@ test('when fetching items from the catalog', function ({ components }) {
           expect(response.status).toEqual(200)
           expect(responseBody.total).toBe(responseBody.data.length)
         })
+      })
+    })
+  })
+
+  describe('and a social emote and a regular emote exist', () => {
+    const socialEmoteItemId = '7001'
+    const regularEmoteItemId = '7002'
+    let response: Response
+    let responseBody: { data: Item[]; total: number }
+    let returnedIds: string[]
+
+    beforeEach(async () => {
+      await createSquidDBEmoteItem(components, { itemId: socialEmoteItemId, contractAddress, outcomeType: 'multiple_outcome' })
+      await createSquidDBEmoteItem(components, { itemId: regularEmoteItemId, contractAddress, outcomeType: null })
+    })
+
+    afterEach(async () => {
+      await Promise.all([
+        deleteSquidDBEmoteItem(components, socialEmoteItemId, contractAddress),
+        deleteSquidDBEmoteItem(components, regularEmoteItemId, contractAddress)
+      ])
+    })
+
+    describe('and includeSocialEmotes is not provided', () => {
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(`/v1/catalog?contractAddress=${contractAddress}`)
+        responseBody = await response.json()
+        returnedIds = responseBody.data.map(item => item.id)
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedIds).toContain(`${contractAddress}_${regularEmoteItemId}`)
+      })
+
+      it('should include the social emote', () => {
+        expect(returnedIds).toContain(`${contractAddress}_${socialEmoteItemId}`)
+      })
+    })
+
+    describe('and includeSocialEmotes is false', () => {
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(`/v1/catalog?contractAddress=${contractAddress}&includeSocialEmotes=false`)
+        responseBody = await response.json()
+        returnedIds = responseBody.data.map(item => item.id)
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedIds).toContain(`${contractAddress}_${regularEmoteItemId}`)
+      })
+
+      it('should not include the social emote', () => {
+        expect(returnedIds).not.toContain(`${contractAddress}_${socialEmoteItemId}`)
       })
     })
   })

--- a/test/integration/items-controller.spec.ts
+++ b/test/integration/items-controller.spec.ts
@@ -1,5 +1,7 @@
+import { Response } from 'node-fetch'
+import { Item } from '@dcl/schemas'
 import { test } from '../components'
-import { CreateDBItemOptions, createSquidDBItem, deleteSquidDBItem } from './utils/dbItems'
+import { CreateDBItemOptions, createSquidDBItem, deleteSquidDBItem, createSquidDBEmoteItem, deleteSquidDBEmoteItem } from './utils/dbItems'
 
 test('when getting an item', function ({ components }) {
   const contractAddress = '0xcf898476136602cd9d61e65945b5ecf9128ff339'
@@ -63,6 +65,68 @@ test('when getting an item', function ({ components }) {
           data: [expect.objectContaining({ id: `${contractAddress}_${itemId}`, itemId, contractAddress, tradeId: null, isOnSale: true })],
           total: 1
         })
+      })
+    })
+  })
+
+  describe('and a social emote and a regular emote exist', () => {
+    const socialEmoteItemId = '7101'
+    const regularEmoteItemId = '7102'
+    let response: Response
+    let responseBody: { data: Item[]; total: number }
+    let returnedIds: string[]
+
+    beforeEach(async () => {
+      await createSquidDBEmoteItem(components, { itemId: socialEmoteItemId, contractAddress, outcomeType: 'multiple_outcome' })
+      await createSquidDBEmoteItem(components, { itemId: regularEmoteItemId, contractAddress, outcomeType: null })
+    })
+
+    afterEach(async () => {
+      await Promise.all([
+        deleteSquidDBEmoteItem(components, socialEmoteItemId, contractAddress),
+        deleteSquidDBEmoteItem(components, regularEmoteItemId, contractAddress)
+      ])
+    })
+
+    describe('and includeSocialEmotes is not provided', () => {
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(`/v1/items?contractAddress=${contractAddress}`)
+        responseBody = await response.json()
+        returnedIds = responseBody.data.map(item => item.id)
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedIds).toContain(`${contractAddress}_${regularEmoteItemId}`)
+      })
+
+      it('should include the social emote', () => {
+        expect(returnedIds).toContain(`${contractAddress}_${socialEmoteItemId}`)
+      })
+    })
+
+    describe('and includeSocialEmotes is false', () => {
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch(`/v1/items?contractAddress=${contractAddress}&includeSocialEmotes=false`)
+        responseBody = await response.json()
+        returnedIds = responseBody.data.map(item => item.id)
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedIds).toContain(`${contractAddress}_${regularEmoteItemId}`)
+      })
+
+      it('should not include the social emote', () => {
+        expect(returnedIds).not.toContain(`${contractAddress}_${socialEmoteItemId}`)
       })
     })
   })

--- a/test/integration/nfts-controller.spec.ts
+++ b/test/integration/nfts-controller.spec.ts
@@ -11,7 +11,9 @@ import {
   createEstateNFT,
   deleteSquidDBNFT,
   createNFTOnSaleTrade,
-  deleteSquidDBTrade
+  deleteSquidDBTrade,
+  createSquidDBEmoteNFT,
+  deleteSquidDBEmoteNFT
 } from './utils/dbItems'
 
 interface NFTResponse {
@@ -1402,6 +1404,161 @@ test('when getting NFTs', function ({ components }) {
 
       it('should respond with 400 status', async () => {
         expect(response.status).toEqual(400)
+      })
+    })
+  })
+
+  describe('and filtering emotes by their social outcome', () => {
+    const socialEmoteTokenId = '7201'
+    const regularEmoteTokenId = '7202'
+
+    describe('and a social emote and a regular emote both exist', () => {
+      let response: Response
+      let responseBody: NFTsResponse
+      let returnedTokenIds: string[]
+
+      beforeEach(async () => {
+        await createSquidDBEmoteNFT(components, { tokenId: socialEmoteTokenId, contractAddress, outcomeType: 'multiple_outcome' })
+        await createSquidDBEmoteNFT(components, { tokenId: regularEmoteTokenId, contractAddress, outcomeType: null })
+
+        const { localFetch } = components
+        response = await localFetch.fetch(`/v1/nfts?contractAddress=${contractAddress}`)
+        responseBody = await response.json()
+        returnedTokenIds = responseBody.data.map(nftResponse => nftResponse.nft.tokenId)
+      })
+
+      afterEach(async () => {
+        await Promise.all([
+          deleteSquidDBEmoteNFT(components, socialEmoteTokenId, contractAddress),
+          deleteSquidDBEmoteNFT(components, regularEmoteTokenId, contractAddress)
+        ])
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedTokenIds).toContain(regularEmoteTokenId)
+      })
+
+      it('should include the social emote', () => {
+        expect(returnedTokenIds).toContain(socialEmoteTokenId)
+      })
+    })
+
+    describe('and both emotes are on sale and sorted by recently listed', () => {
+      let response: Response
+      let responseBody: NFTsResponse
+      let returnedTokenIds: string[]
+
+      beforeEach(async () => {
+        await createSquidDBEmoteNFT(components, {
+          tokenId: socialEmoteTokenId,
+          contractAddress,
+          outcomeType: 'multiple_outcome',
+          isOnSale: true
+        })
+        await createSquidDBEmoteNFT(components, { tokenId: regularEmoteTokenId, contractAddress, outcomeType: null, isOnSale: true })
+
+        const { localFetch } = components
+        response = await localFetch.fetch(`/v1/nfts?contractAddress=${contractAddress}&sortBy=recently_listed`)
+        responseBody = await response.json()
+        returnedTokenIds = responseBody.data.map(nftResponse => nftResponse.nft.tokenId)
+      })
+
+      afterEach(async () => {
+        await Promise.all([
+          deleteSquidDBEmoteNFT(components, socialEmoteTokenId, contractAddress),
+          deleteSquidDBEmoteNFT(components, regularEmoteTokenId, contractAddress)
+        ])
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedTokenIds).toContain(regularEmoteTokenId)
+      })
+
+      it('should include the social emote', () => {
+        expect(returnedTokenIds).toContain(socialEmoteTokenId)
+      })
+    })
+
+    describe('and both emotes are on sale and sorted by recently listed with a price range filter', () => {
+      let response: Response
+      let responseBody: NFTsResponse
+      let returnedTokenIds: string[]
+
+      beforeEach(async () => {
+        await createSquidDBEmoteNFT(components, {
+          tokenId: socialEmoteTokenId,
+          contractAddress,
+          outcomeType: 'multiple_outcome',
+          isOnSale: true
+        })
+        await createSquidDBEmoteNFT(components, { tokenId: regularEmoteTokenId, contractAddress, outcomeType: null, isOnSale: true })
+
+        const { localFetch } = components
+        response = await localFetch.fetch(`/v1/nfts?contractAddress=${contractAddress}&sortBy=recently_listed&minPrice=1&maxPrice=1000`)
+        responseBody = await response.json()
+        returnedTokenIds = responseBody.data.map(nftResponse => nftResponse.nft.tokenId)
+      })
+
+      afterEach(async () => {
+        await Promise.all([
+          deleteSquidDBEmoteNFT(components, socialEmoteTokenId, contractAddress),
+          deleteSquidDBEmoteNFT(components, regularEmoteTokenId, contractAddress)
+        ])
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedTokenIds).toContain(regularEmoteTokenId)
+      })
+
+      it('should include the social emote', () => {
+        expect(returnedTokenIds).toContain(socialEmoteTokenId)
+      })
+    })
+
+    describe('and includeSocialEmotes is false', () => {
+      let response: Response
+      let responseBody: NFTsResponse
+      let returnedTokenIds: string[]
+
+      beforeEach(async () => {
+        await createSquidDBEmoteNFT(components, { tokenId: socialEmoteTokenId, contractAddress, outcomeType: 'multiple_outcome' })
+        await createSquidDBEmoteNFT(components, { tokenId: regularEmoteTokenId, contractAddress, outcomeType: null })
+
+        const { localFetch } = components
+        response = await localFetch.fetch(`/v1/nfts?contractAddress=${contractAddress}&includeSocialEmotes=false`)
+        responseBody = await response.json()
+        returnedTokenIds = responseBody.data.map(nftResponse => nftResponse.nft.tokenId)
+      })
+
+      afterEach(async () => {
+        await Promise.all([
+          deleteSquidDBEmoteNFT(components, socialEmoteTokenId, contractAddress),
+          deleteSquidDBEmoteNFT(components, regularEmoteTokenId, contractAddress)
+        ])
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedTokenIds).toContain(regularEmoteTokenId)
+      })
+
+      it('should not include the social emote', () => {
+        expect(returnedTokenIds).not.toContain(socialEmoteTokenId)
       })
     })
   })

--- a/test/integration/nfts-controller.spec.ts
+++ b/test/integration/nfts-controller.spec.ts
@@ -1527,6 +1527,46 @@ test('when getting NFTs', function ({ components }) {
       })
     })
 
+    describe('and both emotes are on sale and sorted by recently listed with includeSocialEmotes false', () => {
+      let response: Response
+      let responseBody: NFTsResponse
+      let returnedTokenIds: string[]
+
+      beforeEach(async () => {
+        await createSquidDBEmoteNFT(components, {
+          tokenId: socialEmoteTokenId,
+          contractAddress,
+          outcomeType: 'multiple_outcome',
+          isOnSale: true
+        })
+        await createSquidDBEmoteNFT(components, { tokenId: regularEmoteTokenId, contractAddress, outcomeType: null, isOnSale: true })
+
+        const { localFetch } = components
+        response = await localFetch.fetch(`/v1/nfts?contractAddress=${contractAddress}&sortBy=recently_listed&includeSocialEmotes=false`)
+        responseBody = await response.json()
+        returnedTokenIds = responseBody.data.map(nftResponse => nftResponse.nft.tokenId)
+      })
+
+      afterEach(async () => {
+        await Promise.all([
+          deleteSquidDBEmoteNFT(components, socialEmoteTokenId, contractAddress),
+          deleteSquidDBEmoteNFT(components, regularEmoteTokenId, contractAddress)
+        ])
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedTokenIds).toContain(regularEmoteTokenId)
+      })
+
+      it('should not include the social emote', () => {
+        expect(returnedTokenIds).not.toContain(socialEmoteTokenId)
+      })
+    })
+
     describe('and includeSocialEmotes is false', () => {
       let response: Response
       let responseBody: NFTsResponse

--- a/test/integration/trendings-controller.spec.ts
+++ b/test/integration/trendings-controller.spec.ts
@@ -1,0 +1,78 @@
+import { Response } from 'node-fetch'
+import { Item } from '@dcl/schemas'
+import { test } from '../components'
+import { createSquidDBEmoteItem, createSquidDBSale, deleteSquidDBEmoteItem, deleteSquidDBSale } from './utils/dbItems'
+
+test('when fetching trending items', function ({ components }) {
+  const contractAddress = '0x4444444444444444444444444444444444444444'
+  const socialEmoteItemId = '8001'
+  const regularEmoteItemId = '8002'
+
+  describe('and a trending social emote and a trending regular emote exist', () => {
+    beforeEach(async () => {
+      await createSquidDBEmoteItem(components, { itemId: socialEmoteItemId, contractAddress, outcomeType: 'multiple_outcome' })
+      await createSquidDBEmoteItem(components, { itemId: regularEmoteItemId, contractAddress, outcomeType: null })
+      await createSquidDBSale(components, { itemId: socialEmoteItemId, contractAddress })
+      await createSquidDBSale(components, { itemId: regularEmoteItemId, contractAddress })
+    })
+
+    afterEach(async () => {
+      await Promise.all([
+        deleteSquidDBSale(components, socialEmoteItemId, contractAddress),
+        deleteSquidDBSale(components, regularEmoteItemId, contractAddress),
+        deleteSquidDBEmoteItem(components, socialEmoteItemId, contractAddress),
+        deleteSquidDBEmoteItem(components, regularEmoteItemId, contractAddress)
+      ])
+    })
+
+    describe('and includeSocialEmotes is not provided', () => {
+      let response: Response
+      let responseBody: { data: Item[] }
+      let returnedIds: string[]
+
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch('/v1/trendings')
+        responseBody = await response.json()
+        returnedIds = responseBody.data.map(item => item.id)
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedIds).toContain(`${contractAddress}_${regularEmoteItemId}`)
+      })
+
+      it('should include the social emote', () => {
+        expect(returnedIds).toContain(`${contractAddress}_${socialEmoteItemId}`)
+      })
+    })
+
+    describe('and includeSocialEmotes is false', () => {
+      let response: Response
+      let responseBody: { data: Item[] }
+      let returnedIds: string[]
+
+      beforeEach(async () => {
+        const { localFetch } = components
+        response = await localFetch.fetch('/v1/trendings?includeSocialEmotes=false')
+        responseBody = await response.json()
+        returnedIds = responseBody.data.map(item => item.id)
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toEqual(200)
+      })
+
+      it('should include the regular emote', () => {
+        expect(returnedIds).toContain(`${contractAddress}_${regularEmoteItemId}`)
+      })
+
+      it('should not include the social emote', () => {
+        expect(returnedIds).not.toContain(`${contractAddress}_${socialEmoteItemId}`)
+      })
+    })
+  })
+})

--- a/test/integration/utils/dbItems.ts
+++ b/test/integration/utils/dbItems.ts
@@ -1119,3 +1119,44 @@ export async function deleteSquidDBEmoteNFT(
   await dappsDatabase.query(`DELETE FROM squid_marketplace."metadata" WHERE id = '${nftId}-metadata'`)
   await dappsDatabase.query(`DELETE FROM squid_marketplace."emote" WHERE id = '${nftId}-emote'`)
 }
+
+export type CreateDBSaleOptions = {
+  itemId: string
+  contractAddress: string
+  saleId?: string
+  price?: string
+  timestamp?: number
+}
+
+// Seeds a recent sale for an item so it shows up in the trending endpoint (which reads from the sale table).
+export async function createSquidDBSale(dbComponent: Pick<BaseComponents, 'dappsDatabase'>, options: CreateDBSaleOptions): Promise<void> {
+  const { dappsDatabase } = dbComponent
+  const {
+    itemId,
+    contractAddress,
+    saleId = `sale_${contractAddress}_${itemId}`,
+    price = '100000000000000000000',
+    timestamp = Math.floor(Date.now() / 1000)
+  } = options
+
+  await dappsDatabase.query(`
+    INSERT INTO squid_marketplace."sale" (
+      id, type, buyer, seller, price, timestamp, tx_hash, search_token_id,
+      search_contract_address, search_category, search_item_id, network
+    ) VALUES (
+      '${saleId}', 'order', '0x1234567890123456789012345678901234567890', '0x1234567890123456789012345678901234567890',
+      ${price}, ${timestamp}, '0xtxhash_${saleId}', ${itemId}, '${contractAddress}', 'emote', ${itemId}, 'matic'
+    ) ON CONFLICT (id) DO NOTHING
+  `)
+}
+
+export async function deleteSquidDBSale(
+  dbComponent: Pick<BaseComponents, 'dappsDatabase'>,
+  itemId: string,
+  contractAddress: string
+): Promise<void> {
+  const { dappsDatabase } = dbComponent
+  await dappsDatabase.query(
+    `DELETE FROM squid_marketplace."sale" WHERE search_contract_address = '${contractAddress}' AND search_item_id = ${itemId}`
+  )
+}

--- a/test/integration/utils/dbItems.ts
+++ b/test/integration/utils/dbItems.ts
@@ -965,3 +965,157 @@ export async function deleteSquidDBLegacyBid(dbComponent: Pick<BaseComponents, '
   const { dappsDatabase } = dbComponent
   await dappsDatabase.query(`DELETE FROM squid_marketplace."bid" WHERE id = '${bidId}'`)
 }
+
+export type CreateDBEmoteItemOptions = {
+  itemId: string
+  contractAddress: string
+  // A non-null outcome type marks the emote as a "social emote", which must be hidden from the marketplace
+  outcomeType?: string | null
+  isStoreMinterSet?: boolean
+  available?: number
+  collectionApproved?: boolean
+  price?: string
+}
+
+// Seeds an emote item together with its metadata and emote rows so the catalog/items joins resolve.
+// Pass an outcomeType to make it a social emote (the case that must be excluded).
+export async function createSquidDBEmoteItem(
+  dbComponent: Pick<BaseComponents, 'dappsDatabase'>,
+  options: CreateDBEmoteItemOptions
+): Promise<void> {
+  const { dappsDatabase } = dbComponent
+  const {
+    itemId,
+    contractAddress,
+    outcomeType = null,
+    isStoreMinterSet = true,
+    available = 1,
+    collectionApproved = true,
+    price = '100000000000000000000'
+  } = options
+
+  const itemDbId = `${contractAddress}_${itemId}`
+  const emoteId = `${itemDbId}_emote`
+  const metadataId = `${itemDbId}_metadata`
+  const outcomeValue = outcomeType ? `'${outcomeType}'` : 'NULL'
+
+  await dappsDatabase.query(`
+    INSERT INTO squid_marketplace."emote" (
+      id, name, description, collection, category, loop, rarity, body_shapes, has_sound, has_geometry, outcome_type
+    ) VALUES (
+      '${emoteId}', 'Test Emote ${itemId}', 'A test emote', '${contractAddress}', 'dance', false, 'unique',
+      ARRAY['BaseMale', 'BaseFemale'], false, false, ${outcomeValue}
+    ) ON CONFLICT (id) DO UPDATE SET outcome_type = ${outcomeValue}
+  `)
+
+  await dappsDatabase.query(`
+    INSERT INTO squid_marketplace."metadata" (
+      id, item_type, wearable_id, emote_id, network
+    ) VALUES (
+      '${metadataId}', 'emote_v1', NULL, '${emoteId}', 'matic'
+    ) ON CONFLICT (id) DO NOTHING
+  `)
+
+  await dappsDatabase.query(`
+    INSERT INTO squid_marketplace."item" (
+      id, blockchain_id, creator, item_type, total_supply, max_supply, rarity, creation_fee, available, price,
+      beneficiary, content_hash, image, uri, minters, managers, raw_metadata, urn, created_at, updated_at, reviewed_at,
+      first_listed_at, sales, volume, search_is_store_minter, search_is_marketplace_v3_minter, search_is_collection_approved,
+      search_emote_category, search_emote_loop, search_emote_rarity, search_emote_body_shapes, search_emote_has_sound,
+      search_emote_has_geometry, search_emote_outcome_type, unique_collectors, unique_collectors_total, collection_id,
+      metadata_id, network
+    ) VALUES (
+      '${itemDbId}', ${itemId}, '${contractAddress}', 'emote_v1', 1, 1, 'unique', 0, ${available}, ${price},
+      '${contractAddress}', 'aContentHash',
+      'https://peer.decentraland.org/lambdas/collections/contents/urn:decentraland:matic:collections-v2:${contractAddress}:${itemId}/thumbnail',
+      'https://example.com/token/${itemId}',
+      ARRAY['${contractAddress}'], ARRAY['${contractAddress}'], '{}', 'urn:decentraland:${contractAddress}:${itemId}',
+      1000000, 1000000, 1000000, 1000000, 0, 0,
+      ${isStoreMinterSet ? 'true' : 'false'}, false, ${collectionApproved ? 'true' : 'false'},
+      'dance', false, 'unique', ARRAY['BaseMale', 'BaseFemale'], false, false, ${outcomeValue},
+      ARRAY[]::text[], 0, '${contractAddress}', '${metadataId}', 'matic'
+    ) ON CONFLICT (id) DO UPDATE SET
+      item_type = 'emote_v1',
+      metadata_id = '${metadataId}',
+      search_emote_outcome_type = ${outcomeValue},
+      search_is_store_minter = ${isStoreMinterSet ? 'true' : 'false'},
+      available = ${available},
+      search_is_collection_approved = ${collectionApproved ? 'true' : 'false'}
+  `)
+}
+
+export async function deleteSquidDBEmoteItem(
+  dbComponent: Pick<BaseComponents, 'dappsDatabase'>,
+  itemId: string,
+  contractAddress: string
+): Promise<void> {
+  const { dappsDatabase } = dbComponent
+  const itemDbId = `${contractAddress}_${itemId}`
+  await dappsDatabase.query(`DELETE FROM squid_marketplace."order" WHERE item_id = '${itemDbId}'`)
+  await dappsDatabase.query(`DELETE FROM squid_marketplace."item" WHERE id = '${itemDbId}'`)
+  await dappsDatabase.query(`DELETE FROM squid_marketplace."metadata" WHERE id = '${itemDbId}_metadata'`)
+  await dappsDatabase.query(`DELETE FROM squid_marketplace."emote" WHERE id = '${itemDbId}_emote'`)
+}
+
+export type CreateDBEmoteNFTOptions = {
+  tokenId: string
+  contractAddress: string
+  // A non-null outcome type marks the emote as a "social emote", which must be hidden from the marketplace
+  outcomeType?: string | null
+  owner?: string
+  isOnSale?: boolean
+  price?: string
+  network?: string
+}
+
+// Seeds an emote NFT together with its metadata and emote rows so the nfts join resolves.
+// Pass an outcomeType to make it a social emote (the case that must be excluded).
+export async function createSquidDBEmoteNFT(
+  dbComponent: Pick<BaseComponents, 'dappsDatabase'>,
+  options: CreateDBEmoteNFTOptions
+): Promise<void> {
+  const { dappsDatabase } = dbComponent
+  const { tokenId, contractAddress, outcomeType = null, owner, isOnSale = false, price, network = Network.MATIC } = options
+
+  // Reuse the base NFT seeding (creates the account and, when on sale, the order)
+  await createSquidDBNFT(dbComponent, { tokenId, contractAddress, owner, category: NFTCategory.EMOTE, isOnSale, price, network })
+
+  const nftId = `${contractAddress}-${tokenId}`
+  const emoteId = `${nftId}-emote`
+  const metadataId = `${nftId}-metadata`
+  const outcomeValue = outcomeType ? `'${outcomeType}'` : 'NULL'
+
+  await dappsDatabase.query(`
+    INSERT INTO squid_marketplace."emote" (
+      id, name, description, collection, category, loop, rarity, body_shapes, has_sound, has_geometry, outcome_type
+    ) VALUES (
+      '${emoteId}', 'Test Emote ${tokenId}', 'A test emote', '${contractAddress}', 'dance', false, 'unique',
+      ARRAY['BaseMale', 'BaseFemale'], false, false, ${outcomeValue}
+    ) ON CONFLICT (id) DO UPDATE SET outcome_type = ${outcomeValue}
+  `)
+
+  await dappsDatabase.query(`
+    INSERT INTO squid_marketplace."metadata" (
+      id, item_type, wearable_id, emote_id, network
+    ) VALUES (
+      '${metadataId}', 'emote_v1', NULL, '${emoteId}', 'matic'
+    ) ON CONFLICT (id) DO NOTHING
+  `)
+
+  await dappsDatabase.query(`
+    UPDATE squid_marketplace."nft" SET metadata_id = '${metadataId}', item_type = 'emote_v1' WHERE id = '${nftId}'
+  `)
+}
+
+export async function deleteSquidDBEmoteNFT(
+  dbComponent: Pick<BaseComponents, 'dappsDatabase'>,
+  tokenId: string,
+  contractAddress: string
+): Promise<void> {
+  const { dappsDatabase } = dbComponent
+  const nftId = `${contractAddress}-${tokenId}`
+  await dappsDatabase.query(`DELETE FROM squid_marketplace."order" WHERE nft_id = '${nftId}'`)
+  await dappsDatabase.query(`DELETE FROM squid_marketplace."nft" WHERE id = '${nftId}'`)
+  await dappsDatabase.query(`DELETE FROM squid_marketplace."metadata" WHERE id = '${nftId}-metadata'`)
+  await dappsDatabase.query(`DELETE FROM squid_marketplace."emote" WHERE id = '${nftId}-emote'`)
+}


### PR DESCRIPTION
## What

Adds an `includeSocialEmotes` query param to the public browse endpoints so social emotes (emotes with a non-null `outcome_type`) can be hidden from the marketplace, and fixes a few pre-existing query bugs found while adding test coverage.

## Why

Social emotes should be hideable from the marketplace browse surfaces. Rather than a hard server-side exclusion (which also broke collection/order management in the builder, since it reads `/v1/items`), this exposes an opt-out param so each client decides. The marketplace webapp passes `includeSocialEmotes=false` (decentraland/marketplace#2651); the builder keeps the default and continues to see them.

## Changes

### `includeSocialEmotes` filter
- Parsed on `/v1/catalog`, `/v2/catalog`, `/v1/items`, `/v1/nfts`, and `/v1/trendings`.
- **Included by default**; excluded **only** when `includeSocialEmotes=false` is explicitly set.
- Implemented as a conditional `outcome_type IS NULL` / `search_emote_outcome_type IS NULL` clause in the catalog, items and nfts query builders (including the recently-listed path). The exclusion triggers on a strict `=== false`, so internal by-id lookups (which never set the flag) keep returning social emotes.
- `/v1/trendings` resolves items via `items.getItems`, so the flag is threaded through the trendings handler → component → `getItems`.
- Type-safety: the parsed filters flow through dedicated `ItemQueryFilters` / `NFTQueryFilters` types (handler → component → query) instead of being narrowed to `ItemFilters` / `NFTFilters`, so the flag can't be silently dropped.
- Documented that combining `emoteOutcomeType` with `includeSocialEmotes=false` is contradictory and returns no emotes (it's used in all three: items, nfts and catalog).

### Pre-existing bug fixes (found while adding tests)
- **`getRecentlyListedNFTsQuery` ambiguous columns** — `contract_address`, `token_id` and `id` were unqualified in the trade-asset sub-query (shared with `trade_assets`/`trade_assets_erc721`), so `?sortBy=recently_listed&contractAddress=…` (and `tokenId`/`ids`) returned a 400 `column reference … is ambiguous`. All nft-table filters are now qualified with the `nft` alias.
- **`getRecentlyListedNFTsQuery` malformed trade price filter** — referenced an out-of-scope `trades` alias with an unbalanced parenthesis, so `?sortBy=recently_listed&minPrice=…` always errored. It now compares against the joined `unified_trades` row in the outer CTE query.
- **`getTrendingSalesQuery` missing space** — `WHERE timestamp > ${fromTimestamp}` had no trailing space before the appended `ORDER BY`, producing `$1ORDER BY` → Postgres `trailing junk after parameter`. Since the component always passes `from`, **`/v1/trendings` was failing on every request**; one-character fix.

### Tests
- New emote seed helpers (`createSquidDBEmoteItem`/`NFT`) building the full `emote` → `metadata` → `item`/`nft` join chain, and `createSquidDBSale` for the trendings/sale table.
- Integration coverage in the catalog/items/nfts/trendings controller specs for both default (included) and `includeSocialEmotes=false` (excluded).
- Regression tests proving the recently-listed `contractAddress`, `minPrice`/`maxPrice`, and `includeSocialEmotes=false` combinations now return 200.

## Test plan
- `npm run build` ✅
- `npm run lint` ✅
- Integration specs (items, catalog, nfts, trendings controllers) pass ✅