### PR TITLE
perf: drop unused aggregates from the catalog queries

### DIFF
--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -668,13 +668,11 @@ const getTradesJoin = (filters: CatalogQueryFilters) => {
               MIN(amount_received) FILTER (WHERE status = 'open' and type = 'public_nft_order') AS min_order_amount_received,
               MAX(amount_received) FILTER (WHERE status = 'open' and type = 'public_nft_order') AS max_order_amount_received,
               -- Item amount is the minimum value for public_item_order
-              MAX(assets -> 'sent' ->> 'token_id') AS token_id, -- Max token_id for public_nft_order
-              assets -> 'sent' ->> 'item_id' AS item_id, -- Max item_id for public_item_order
+              assets -> 'sent' ->> 'item_id' AS item_id, -- item_id grouping key for public_item_order
               MAX(created_at) AS max_created_at,
               MAX(id::text) FILTER (WHERE status = 'open' and type = 'public_item_order') AS open_item_trade_id,
               MAX(amount_received) FILTER (WHERE status = 'open' and type = 'public_item_order') AS open_item_trade_price,
-              MIN(created_at) FILTER (WHERE type = 'public_item_order') AS item_first_listed_at,
-              json_agg(assets) AS aggregated_assets -- Aggregate the assets into a JSON array
+              MIN(created_at) FILTER (WHERE type = 'public_item_order') AS item_first_listed_at
           FROM unified_trades
             WHERE status = 'open' and (available IS NULL OR available > 0)`
     .append(filters.onlyMinting ? SQL` AND type = 'public_item_order'` : SQL``)
@@ -1163,7 +1161,6 @@ export const getItemIdsBySearchTextQuery = (filters: CatalogQueryFilters) => {
 export const getCollectionsItemsCatalogQuery = (filters: CatalogQueryFilters) => {
   const query = SQL`
             SELECT
-              COUNT(*) OVER() as total_rows,
               items.id,
               items.blockchain_id,
               items.search_is_collection_approved,

--- a/src/ports/catalog/types.ts
+++ b/src/ports/catalog/types.ts
@@ -2,7 +2,6 @@ import { CatalogFilters, CatalogSortBy, CatalogSortDirection, Item } from '@dcl/
 
 export type CollectionsItemDBResult = {
   total?: number // for UNION queries, this field will be defined
-  total_rows: number
   id: string
   urn: string
   image: string

--- a/test/unit/catalog-queries.spec.ts
+++ b/test/unit/catalog-queries.spec.ts
@@ -1,0 +1,36 @@
+import { getCollectionsItemsCatalogQuery, getCollectionsItemsCatalogQueryWithTrades } from '../../src/ports/catalog/queries'
+import { CatalogQueryFilters } from '../../src/ports/catalog/types'
+
+// Whitespace-tolerant matcher for a reintroduced window aggregate (COUNT(*) OVER ( ... )).
+const COUNT_OVER = /COUNT\(\s*\*\s*\)\s*OVER\s*\(/i
+
+describe('when building the catalog queries', () => {
+  let filters: CatalogQueryFilters
+
+  beforeEach(() => {
+    filters = { first: 20, skip: 0 }
+  })
+
+  describe('and building the v2 (with-trades) catalog query', () => {
+    it('should not build the json_agg(assets) aggregate: it was never consumed and is expensive over all grouped trades', () => {
+      const text = getCollectionsItemsCatalogQueryWithTrades(filters).text
+      expect(text).not.toContain('json_agg')
+      expect(text).not.toContain('aggregated_assets')
+    })
+
+    it('should still compute the offchain order aggregates the query actually reads', () => {
+      const text = getCollectionsItemsCatalogQueryWithTrades(filters).text
+      expect(text).toContain('nfts_listings_count')
+      expect(text).toContain('open_item_trade_price')
+      expect(text).toContain('item_first_listed_at')
+    })
+  })
+
+  describe('and building the v1 catalog query', () => {
+    it('should not compute a COUNT(*) OVER() total_rows window: it was never read (the total comes from the count query)', () => {
+      const text = getCollectionsItemsCatalogQuery(filters).text
+      expect(text).not.toMatch(COUNT_OVER)
+      expect(text).not.toContain('total_rows')
+    })
+  })
+})


### PR DESCRIPTION
## Context

The catalog endpoints are the heaviest read path (`/v2/catalog` has the highest cumulative time in prod). Two of the catalog SQL builders compute values that are **never consumed**, including an expensive `json_agg` over all grouped trades. Removing them is a strict no-op on the response while cutting work.

This is meant to be **byte-identical** in output — please response-diff `/v1/catalog` and `/v2/catalog` on staging alongside the benchmark.

## Changes

All three are provably-dead computation (the removed values are read nowhere — not in the query, the catalog component, the adapter, or the other v2 consumer in `prices`):

- **`/v2/catalog` (`getTradesJoin`):** removed `json_agg(assets) AS aggregated_assets`. It aggregated every trade's assets into a JSON array per group and was never read — the expensive one. Also removed `MAX(assets -> 'sent' ->> 'token_id') AS token_id` (unused). Dropping these lets the offchain-orders aggregation do less work per group.
- **`/v1/catalog` (`getCollectionsItemsCatalogQuery`):** removed `COUNT(*) OVER() as total_rows`. The data query's row count was never read — the total comes from the separate `getCollectionsItemsCountQuery`. Removing the window aggregate lets `ORDER BY … LIMIT` short-circuit to a top-N. Also dropped the now-dead `total_rows` field from `CollectionsItemDBResult`.

Retained aggregates that ARE consumed (`nfts_listings_count`, `min/max_order_amount_received`, `open_item_trade_*`, `max_created_at`, `item_first_listed_at`, …) are untouched. GROUP BY keys, row counts, ordering and pagination are unchanged.

## Test plan

- [x] `tsc` typecheck clean
- [x] eslint clean
- [x] New `catalog-queries.spec.ts` regression guards (no `json_agg`/`aggregated_assets`/`total_rows`/`COUNT(*) OVER()`, while still emitting the consumed aggregates)
- [x] **Full integration suite green (8 suites / 143 tests)** against a real Postgres — covers both `/v1/catalog` and `/v2/catalog` → output unchanged
- [x] Code-reviewed: confirmed the removed columns are unconsumed everywhere (incl. the `prices` consumer) and the SQL has no dangling commas
- [ ] CI (build + lint + unit + integration)
- [ ] Staging: response-diff `/v1` & `/v2/catalog` (must be identical) + latency benchmark