### PR TITLE
chore: pin node 24 base image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG RUN
 
-FROM node:24-alpine as builderenv
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995 as builderenv
 
 WORKDIR /app
 
@@ -23,7 +23,7 @@ RUN npm install --only=production --ignore-scripts
 
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:24-alpine
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995
 
 RUN apk update
 RUN apk add --no-cache tini libpng jpeg cairo pango giflib librsvg-dev


### PR DESCRIPTION
Sets the base image to `node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995` (was `node:24-alpine`) and pins it to an immutable sha256 digest for reproducible builds.