### PR TITLE
feat: add /v1/wallets/:address/mana-transfers endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2854,6 +2854,74 @@ paths:
                   message:
                     type: string
                     example: Could not fetch accounts
+  /v1/wallets/{address}/mana-transfers:
+    get:
+      tags:
+        - Accounts
+      summary: Get a wallet's MANA transfer history
+      description: |
+        Returns the wallet's MANA ERC20 transfer history across Ethereum and Polygon, read on-chain
+        via eth_getLogs (no indexer). Includes plain sends and receiveds plus Polygon PoS bridge
+        swaps (deposits) and withdrawals.
+
+        A swap is anchored on its L1 deposit; the correlated L2 mint is exposed as `counterpartHash`
+        and never shown as a separate received. A deposit whose L2 credit has not landed yet
+        (~20-30 min PoS checkpoint window) has status `bridging`. Withdrawals are anchored on the L2
+        burn symmetrically. Public read — no authentication.
+      operationId: getManaTransfers
+      security: []
+      parameters:
+        - name: address
+          in: path
+          required: true
+          description: The wallet address
+          schema:
+            type: string
+            example: '0xd9b96b5dc720fc52bede1ec3b40a930e15f70ddd'
+      responses:
+        '200':
+          description: The wallet's MANA transfer feed, newest first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ManaTransfer'
+                  total:
+                    type: number
+                    description: Total number of transfers
+                required:
+                  - data
+                  - total
+        '400':
+          description: Invalid address
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Invalid address
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Could not fetch MANA transfers
   /v1/collections:
     get:
       tags:
@@ -3759,6 +3827,68 @@ components:
         - earned
         - royalties
         - collections
+    ManaTransfer:
+      type: object
+      properties:
+        hash:
+          type: string
+          description: Transaction hash of the transfer (the L1 deposit for a swap, the L2 burn for a withdraw)
+          example: '0x6b6db6ddcae2c7180de9c6db1172dd92fb14fd113f2e9a88845ee42572a3f37c'
+        type:
+          type: string
+          description: 'send / received: plain transfer. swap: Ethereum→Polygon bridge deposit. withdraw: Polygon→Ethereum bridge withdrawal.'
+          enum:
+            - send
+            - received
+            - swap
+            - withdraw
+          example: swap
+        network:
+          type: string
+          description: Chain the anchor leg lives on
+          enum:
+            - ETHEREUM
+            - MATIC
+          example: ETHEREUM
+        from:
+          type: string
+          description: Sender address (lowercased)
+        to:
+          type: string
+          description: Recipient address (lowercased)
+        amount:
+          type: string
+          description: Human-readable MANA amount
+          example: '306.0'
+        value:
+          type: string
+          description: Raw amount in Wei
+          example: '306000000000000000000'
+        timestamp:
+          type: number
+          description: Milliseconds since epoch (from the log's blockTimestamp)
+          example: 1687803171000
+        status:
+          type: string
+          description: 'confirmed: settled on the destination chain. bridging: a swap/withdraw whose destination leg has not landed yet (~20-30 min).'
+          enum:
+            - confirmed
+            - bridging
+          example: confirmed
+        counterpartHash:
+          type: string
+          description: For a swap, the L2 mint tx hash; for a withdraw, the L1 exit tx hash. Absent while bridging.
+          example: '0xf3eec8d6f570cb1cc2e2e2b...'
+      required:
+        - hash
+        - type
+        - network
+        - from
+        - to
+        - amount
+        - value
+        - timestamp
+        - status
     Collection:
       type: object
       properties:

--- a/src/components.ts
+++ b/src/components.ts
@@ -27,6 +27,7 @@ import { createPicksComponent } from './ports/favorites/picks'
 import { createSnapshotComponent } from './ports/favorites/snapshot'
 import { createItemsComponent } from './ports/items'
 import { createJobComponent } from './ports/job'
+import { createManaTransfersComponent } from './ports/mana-transfers/component'
 import { createNFTsComponent } from './ports/nfts/component'
 import { createOrdersComponent } from './ports/orders/component'
 import { createOwnersComponent } from './ports/owners/component'
@@ -161,6 +162,7 @@ export async function initComponents(): Promise<AppComponents> {
   const volumes = await createVolumeComponent({ analyticsData })
   const userAssets = await createUserAssetsComponent({ logs, dappsDatabase: dappsReadDatabase })
   const activity = createActivityComponent({ sales, bids, orders, trades, logs })
+  const manaTransfers = createManaTransfersComponent({ logs, inMemoryCache })
 
   const transak = await createTransakComponent(
     { fetch, logs, cache },
@@ -218,6 +220,7 @@ export async function initComponents(): Promise<AppComponents> {
     analyticsData,
     volumes,
     userAssets,
-    activity
+    activity,
+    manaTransfers
   }
 }

--- a/src/controllers/handlers/mana-transfers-handler.ts
+++ b/src/controllers/handlers/mana-transfers-handler.ts
@@ -1,0 +1,48 @@
+import { isAddress } from '../../logic/address'
+import { isErrorWithMessage } from '../../logic/errors'
+import { HandlerContextWithPath, StatusCode } from '../../types'
+
+/**
+ * Handler for GET /v1/wallets/:address/mana-transfers
+ *
+ * Returns the wallet's MANA ERC20 transfer history (sends, receiveds, bridge swaps and withdraws)
+ * across Ethereum and Polygon, read on-chain via eth_getLogs. Public read — no authentication.
+ */
+export async function getManaTransfersHandler(
+  context: Pick<HandlerContextWithPath<'manaTransfers', '/v1/wallets/:address/mana-transfers'>, 'components' | 'params'>
+) {
+  const {
+    components: { manaTransfers },
+    params: { address }
+  } = context
+
+  if (!isAddress(address)) {
+    return {
+      status: StatusCode.BAD_REQUEST,
+      body: {
+        ok: false,
+        message: 'Invalid address'
+      }
+    }
+  }
+
+  try {
+    const { data, total } = await manaTransfers.getManaTransfers(address)
+
+    return {
+      status: StatusCode.OK,
+      body: {
+        data,
+        total
+      }
+    }
+  } catch (e) {
+    return {
+      status: StatusCode.INTERNAL_SERVER_ERROR,
+      body: {
+        ok: false,
+        message: isErrorWithMessage(e) ? e.message : 'Could not fetch MANA transfers'
+      }
+    }
+  }
+}

--- a/src/controllers/handlers/mana-transfers-handler.ts
+++ b/src/controllers/handlers/mana-transfers-handler.ts
@@ -9,10 +9,10 @@ import { HandlerContextWithPath, StatusCode } from '../../types'
  * across Ethereum and Polygon, read on-chain via eth_getLogs. Public read — no authentication.
  */
 export async function getManaTransfersHandler(
-  context: Pick<HandlerContextWithPath<'manaTransfers', '/v1/wallets/:address/mana-transfers'>, 'components' | 'params'>
+  context: Pick<HandlerContextWithPath<'manaTransfers' | 'logs', '/v1/wallets/:address/mana-transfers'>, 'components' | 'params'>
 ) {
   const {
-    components: { manaTransfers },
+    components: { manaTransfers, logs },
     params: { address }
   } = context
 
@@ -37,11 +37,17 @@ export async function getManaTransfersHandler(
       }
     }
   } catch (e) {
+    // Public, unauthenticated endpoint: log the real error server-side but never surface RPC /
+    // provider / internal details to the caller — always return the generic message.
+    logs.getLogger('mana-transfers-handler').error('Failed to fetch MANA transfers', {
+      address,
+      error: isErrorWithMessage(e) ? e.message : String(e)
+    })
     return {
       status: StatusCode.INTERNAL_SERVER_ERROR,
       body: {
         ok: false,
-        message: isErrorWithMessage(e) ? e.message : 'Could not fetch MANA transfers'
+        message: 'Could not fetch MANA transfers'
       }
     }
   }

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -14,6 +14,7 @@ import { getContractsHandler } from './handlers/contracts-handler'
 import { createENSImageGeratorHandler } from './handlers/ens'
 import { setupFavoritesRouter } from './handlers/favorites/routes'
 import { getItemsHandler } from './handlers/items-handler'
+import { getManaTransfersHandler } from './handlers/mana-transfers-handler'
 import { getNFTsHandler } from './handlers/nfts-handler'
 import { getOrdersHandler } from './handlers/orders-handler'
 import { getOwnersHandler } from './handlers/owners-handler'
@@ -126,6 +127,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   router.get('/v1/collections', getCollectionsHandler)
   router.get('/v1/accounts', getAccountsHandler)
   router.get('/v1/owners', getOwnersHandler)
+  router.get('/v1/wallets/:address/mana-transfers', getManaTransfersHandler)
 
   router.get(
     '/v1/items',

--- a/src/logic/rpc.ts
+++ b/src/logic/rpc.ts
@@ -1,0 +1,19 @@
+import { ChainId } from '@dcl/schemas'
+
+const RPC_BASE_URL = 'https://rpc.decentraland.org'
+
+/** Resolves the DCL RPC URL for a supported chain id. */
+export function getRpcUrlByChainId(chainId: ChainId): string {
+  switch (chainId) {
+    case ChainId.ETHEREUM_MAINNET:
+      return `${RPC_BASE_URL}/mainnet`
+    case ChainId.ETHEREUM_SEPOLIA:
+      return `${RPC_BASE_URL}/sepolia`
+    case ChainId.MATIC_MAINNET:
+      return `${RPC_BASE_URL}/polygon`
+    case ChainId.MATIC_AMOY:
+      return `${RPC_BASE_URL}/amoy`
+    default:
+      throw new Error(`Unsupported chainId ${chainId}`)
+  }
+}

--- a/src/logic/trades/utils.ts
+++ b/src/logic/trades/utils.ts
@@ -4,28 +4,8 @@ import { ChainId, ERC721TradeAsset, TradeAsset, TradeAssetType, TradeCreation } 
 import { ContractData, ContractName, getContract } from 'decentraland-transactions'
 import { InvalidECDSASignatureError, MarketplaceContractNotFound } from '../../ports/trades/errors'
 import { fromMillisecondsToSeconds } from '../date'
+import { getRpcUrlByChainId } from '../rpc'
 import { hasECDSASignatureAValidV } from '../signatures'
-
-function getRPCUrlByChainId(chainId: ChainId): string {
-  let rpcPath: string
-  switch (chainId) {
-    case ChainId.ETHEREUM_MAINNET:
-      rpcPath = 'mainnet'
-      break
-    case ChainId.ETHEREUM_SEPOLIA:
-      rpcPath = 'sepolia'
-      break
-    case ChainId.MATIC_MAINNET:
-      rpcPath = 'polygon'
-      break
-    case ChainId.MATIC_AMOY:
-      rpcPath = 'amoy'
-      break
-    default:
-      throw new Error('Unsupported chainId')
-  }
-  return `https://rpc.decentraland.org/${rpcPath}`
-}
 
 export function getValueFromTradeAsset(asset: TradeAsset) {
   switch (asset.assetType) {
@@ -140,7 +120,7 @@ export function isERC721TradeAsset(asset: TradeAsset): asset is ERC721TradeAsset
 
 async function getContractOwner(contractAddress: string, tokenId: string, chainId: ChainId): Promise<string> {
   const abi = ['function ownerOf(uint256 tokenId) view returns (address)']
-  const provider = new JsonRpcProvider(getRPCUrlByChainId(chainId))
+  const provider = new JsonRpcProvider(getRpcUrlByChainId(chainId))
   const contract = new Contract(contractAddress, abi, provider)
   return await contract.ownerOf(tokenId)
 }
@@ -152,7 +132,7 @@ export async function isEstateFingerprintValid(
   fingerprint: string
 ): Promise<boolean> {
   const abi = ['function getFingerprintV2(uint256 tokenId) view returns (bytes32)']
-  const provider = new JsonRpcProvider(getRPCUrlByChainId(chainId))
+  const provider = new JsonRpcProvider(getRpcUrlByChainId(chainId))
   const contract = new Contract(contractAddress, abi, provider)
   const estateFingerprint = await contract.getFingerprintV2(tokenId)
   return estateFingerprint.toLowerCase() === fingerprint.toLowerCase()

--- a/src/ports/mana-transfers/component.ts
+++ b/src/ports/mana-transfers/component.ts
@@ -89,7 +89,16 @@ export function createManaTransfersComponent(components: Pick<AppComponents, 'lo
       fetchTransferLogs(network, mana, [userTopic, null]),
       fetchTransferLogs(network, mana, [null, userTopic])
     ])
-    return [...sent, ...received].filter(isStandardTransferLog).map(log => decodeTransferLog(log, network))
+    // Decode defensively: a non-hex `data` that slips past isStandardTransferLog would make
+    // BigInt() throw and abort the whole feed — skip the offending log instead.
+    return [...sent, ...received].filter(isStandardTransferLog).reduce<DecodedTransfer[]>((decoded, log) => {
+      try {
+        decoded.push(decodeTransferLog(log, network))
+      } catch {
+        logger.warn('Skipping malformed MANA transfer log', { network, transactionHash: log.transactionHash })
+      }
+      return decoded
+    }, [])
   }
 
   /**

--- a/src/ports/mana-transfers/component.ts
+++ b/src/ports/mana-transfers/component.ts
@@ -1,0 +1,136 @@
+import { JsonRpcProvider } from 'ethers'
+import { Network } from '@dcl/schemas'
+import { isAddress } from '../../logic/address'
+import { getEthereumChainId, getPolygonChainId } from '../../logic/chainIds'
+import { AppComponents } from '../../types'
+import {
+  addressToTopic,
+  buildManaTransferFeed,
+  decodeTransferLog,
+  getBridgeAddresses,
+  getRpcUrlByChainId,
+  TRANSFER_EVENT_TOPIC
+} from './logic'
+import { DecodedTransfer, IManaTransfersComponent, ManaTransfer, RawTransferLog } from './types'
+
+// MANA transfer logs are immutable once mined, so a short TTL is enough; it only bounds how long a
+// freshly-credited bridge swap stays `bridging` before the next fetch flips it to `confirmed`.
+const CACHE_TTL_IN_SECONDS = 120
+
+// The DCL RPC (Alchemy) returns at most 10k logs for an arbitrary block range. Hitting the cap means
+// the response is truncated — see fetchTransferLogs.
+const RPC_LOG_RESULT_CAP = 10_000
+
+/**
+ * Creates the MANA Transfers component.
+ *
+ * Reads a wallet's MANA ERC20 `Transfer` history directly from the DCL RPC via `eth_getLogs`
+ * (server-side), classifies sends/receiveds/swaps/withdraws, correlates the two bridge legs, and
+ * caches the result. No indexer/database is involved — this is the read path the standalone account
+ * dapp never had.
+ *
+ * @param components Required components: logs, inMemoryCache
+ * @returns IManaTransfersComponent implementation
+ */
+export function createManaTransfersComponent(components: Pick<AppComponents, 'logs' | 'inMemoryCache'>): IManaTransfersComponent {
+  const { logs, inMemoryCache } = components
+  const logger = logs.getLogger('mana-transfers-component')
+
+  const ethereumChainId = getEthereumChainId()
+  const polygonChainId = getPolygonChainId()
+  const ethereumAddresses = getBridgeAddresses(ethereumChainId)
+  const polygonAddresses = getBridgeAddresses(polygonChainId)
+
+  let ethereumProvider: JsonRpcProvider | undefined
+  let polygonProvider: JsonRpcProvider | undefined
+
+  function getProvider(network: Network): JsonRpcProvider {
+    if (network === Network.ETHEREUM) {
+      ethereumProvider = ethereumProvider ?? new JsonRpcProvider(getRpcUrlByChainId(ethereumChainId))
+      return ethereumProvider
+    }
+    polygonProvider = polygonProvider ?? new JsonRpcProvider(getRpcUrlByChainId(polygonChainId))
+    return polygonProvider
+  }
+
+  // A raw eth_getLogs call (not ethers' typed getLogs) so the DCL RPC's `blockTimestamp` extension
+  // survives — that avoids an eth_getBlock per log to date each transfer.
+  async function fetchTransferLogs(network: Network, mana: string, topics: (string | null)[]): Promise<RawTransferLog[]> {
+    const provider = getProvider(network)
+    const logsResult = (await provider.send('eth_getLogs', [
+      {
+        address: mana,
+        fromBlock: '0x0',
+        toBlock: 'latest',
+        topics: [TRANSFER_EVENT_TOPIC, ...topics]
+      }
+    ])) as RawTransferLog[]
+    if (!Array.isArray(logsResult)) {
+      return []
+    }
+    // Fail loudly on a truncated response instead of caching a partial feed: a truncated set would
+    // silently drop transfers AND corrupt the bridge-leg correlation (kept origins, dropped closings
+    // → spurious `bridging`). A wallet with >10k MANA transfers in one direction is the rare case
+    // that needs block-range pagination (a follow-up); until then it 500s rather than lying.
+    if (logsResult.length >= RPC_LOG_RESULT_CAP) {
+      throw new Error('MANA transfer history exceeds the RPC log result cap for this wallet; range pagination required')
+    }
+    return logsResult
+  }
+
+  // Skip non-conforming logs (the topic filter pins a standard Transfer, so this is defensive) — a
+  // malformed `data`/`topics` would otherwise abort the whole feed when decoded.
+  function isStandardTransferLog(log: RawTransferLog): boolean {
+    return !log.removed && Array.isArray(log.topics) && log.topics.length >= 3 && typeof log.data === 'string' && log.data.length > 2
+  }
+
+  async function fetchChainTransfers(network: Network, mana: string, userTopic: string): Promise<DecodedTransfer[]> {
+    const [sent, received] = await Promise.all([
+      fetchTransferLogs(network, mana, [userTopic, null]),
+      fetchTransferLogs(network, mana, [null, userTopic])
+    ])
+    return [...sent, ...received].filter(isStandardTransferLog).map(log => decodeTransferLog(log, network))
+  }
+
+  /**
+   * Returns the wallet's MANA transfer history across Ethereum and Polygon, newest first.
+   *
+   * @param address - The wallet address
+   * @returns Promise resolving to the transfer feed and its total count
+   */
+  async function getManaTransfers(address: string): Promise<{ data: ManaTransfer[]; total: number }> {
+    if (!isAddress(address)) {
+      throw new Error('Invalid address')
+    }
+
+    const user = address.toLowerCase()
+    const cacheKey = `mana-transfers:${user}`
+    const cached = await inMemoryCache.get<{ data: ManaTransfer[]; total: number }>(cacheKey)
+    if (cached) {
+      return cached
+    }
+
+    const userTopic = addressToTopic(user)
+    const [ethereumTransfers, polygonTransfers] = await Promise.all([
+      fetchChainTransfers(Network.ETHEREUM, ethereumAddresses.mana, userTopic),
+      fetchChainTransfers(Network.MATIC, polygonAddresses.mana, userTopic)
+    ])
+
+    const data = buildManaTransferFeed({
+      ethereumTransfers,
+      polygonTransfers,
+      user,
+      ethereumPredicate: ethereumAddresses.erc20Predicate
+    })
+
+    const result = { data, total: data.length }
+    await inMemoryCache.set(cacheKey, result, CACHE_TTL_IN_SECONDS)
+    logger.debug('Fetched MANA transfers', { address: user, total: data.length })
+
+    return result
+  }
+
+  return {
+    getManaTransfers
+  }
+}

--- a/src/ports/mana-transfers/index.ts
+++ b/src/ports/mana-transfers/index.ts
@@ -1,0 +1,2 @@
+export * from './component'
+export * from './types'

--- a/src/ports/mana-transfers/logic.ts
+++ b/src/ports/mana-transfers/logic.ts
@@ -1,7 +1,10 @@
 import { formatEther } from 'ethers'
 import { ChainId, Network } from '@dcl/schemas'
 import { isAddressZero } from '../../logic/address'
+import { getRpcUrlByChainId } from '../../logic/rpc'
 import { DecodedTransfer, ManaTransfer, ManaTransferStatus, ManaTransferType, RawTransferLog } from './types'
+
+export { getRpcUrlByChainId }
 
 // keccak256("Transfer(address,address,uint256)")
 export const TRANSFER_EVENT_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
@@ -36,21 +39,6 @@ export const BRIDGE_ADDRESSES: Partial<Record<ChainId, BridgeAddresses>> = {
   }
 }
 
-export function getRpcUrlByChainId(chainId: ChainId): string {
-  switch (chainId) {
-    case ChainId.ETHEREUM_MAINNET:
-      return 'https://rpc.decentraland.org/mainnet'
-    case ChainId.ETHEREUM_SEPOLIA:
-      return 'https://rpc.decentraland.org/sepolia'
-    case ChainId.MATIC_MAINNET:
-      return 'https://rpc.decentraland.org/polygon'
-    case ChainId.MATIC_AMOY:
-      return 'https://rpc.decentraland.org/amoy'
-    default:
-      throw new Error(`Unsupported chainId ${chainId}`)
-  }
-}
-
 export function getBridgeAddresses(chainId: ChainId): BridgeAddresses {
   const addresses = BRIDGE_ADDRESSES[chainId]
   if (!addresses) {
@@ -70,6 +58,11 @@ export function topicToAddress(topic: string): string {
 }
 
 export function decodeTransferLog(log: RawTransferLog, network: Network): DecodedTransfer {
+  // Defensive: the component pre-filters with isStandardTransferLog, but this is exported and may be
+  // called without that guard. A standard ERC20 Transfer has topic0 + indexed `from` + indexed `to`.
+  if (!Array.isArray(log.topics) || log.topics.length < 3) {
+    throw new Error('Malformed Transfer log: expected at least 3 topics')
+  }
   return {
     network,
     from: topicToAddress(log.topics[1]),
@@ -126,20 +119,33 @@ function byChronology(a: DecodedTransfer, b: DecodedTransfer): number {
  * (credits/exits). There is NO common id between the two chains' Transfer logs (the L1 StateSynced
  * id never appears on the L2 mint), so origins are matched to the earliest unused closing with the
  * exact same wei value that did not happen before the origin. Each closing is consumed once.
+ *
+ * Closings are bucketed into a per-value FIFO queue so the match is near-linear instead of
+ * O(origins × closings) — only same-value closings are ever scanned.
  */
 export function correlateFifo(origins: DecodedTransfer[], closings: DecodedTransfer[]): Map<string, DecodedTransfer> {
   const sortedOrigins = [...origins].sort(byChronology)
-  const sortedClosings = [...closings].sort(byChronology)
-  const consumed = new Set<string>()
-  const matches = new Map<string, DecodedTransfer>()
+  const queuesByValue = new Map<string, DecodedTransfer[]>()
+  for (const closing of [...closings].sort(byChronology)) {
+    const key = closing.value.toString()
+    const queue = queuesByValue.get(key)
+    if (queue) {
+      queue.push(closing)
+    } else {
+      queuesByValue.set(key, [closing])
+    }
+  }
 
+  const matches = new Map<string, DecodedTransfer>()
   for (const origin of sortedOrigins) {
-    const match = sortedClosings.find(
-      closing => !consumed.has(legKey(closing)) && closing.value === origin.value && closing.timestamp >= origin.timestamp
-    )
-    if (match) {
-      consumed.add(legKey(match))
-      matches.set(legKey(origin), match)
+    const queue = queuesByValue.get(origin.value.toString())
+    if (!queue) {
+      continue
+    }
+    // Earliest still-queued closing at or after the origin (queue is chronologically sorted).
+    const index = queue.findIndex(closing => closing.timestamp >= origin.timestamp)
+    if (index !== -1) {
+      matches.set(legKey(origin), queue.splice(index, 1)[0])
     }
   }
 

--- a/src/ports/mana-transfers/logic.ts
+++ b/src/ports/mana-transfers/logic.ts
@@ -1,0 +1,248 @@
+import { formatEther } from 'ethers'
+import { ChainId, Network } from '@dcl/schemas'
+import { isAddressZero } from '../../logic/address'
+import { DecodedTransfer, ManaTransfer, ManaTransferStatus, ManaTransferType, RawTransferLog } from './types'
+
+// keccak256("Transfer(address,address,uint256)")
+export const TRANSFER_EVENT_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+/** MANA token + Polygon PoS ERC20 predicate per chain. Mirrors sites' manaContract.ts/bridgeContract.ts. */
+export type BridgeAddresses = {
+  // MANA ERC20 contract on this chain (lowercased).
+  mana: string
+  // ERC20 predicate the L1 deposit transfers MANA to (lowercased). Only meaningful on L1 (Ethereum);
+  // on L2 (Polygon) the bridge credits via a mint from the zero address, so this is empty.
+  erc20Predicate: string
+}
+
+export const BRIDGE_ADDRESSES: Partial<Record<ChainId, BridgeAddresses>> = {
+  [ChainId.ETHEREUM_MAINNET]: {
+    mana: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
+    erc20Predicate: '0x40ec5b33f54e0e8a33a975908c5ba1c14e5bbbdf'
+  },
+  [ChainId.ETHEREUM_SEPOLIA]: {
+    mana: '0xfa04d2e2ba9aec166c93dfeeba7427b2303befa9',
+    erc20Predicate: '0x4258c75b752c812b7fa586bdeb259f2d4bd17f4f'
+  },
+  [ChainId.MATIC_MAINNET]: {
+    mana: '0xa1c57f48f0deb89f569dfbe6e2b7f46d33606fd4',
+    erc20Predicate: ''
+  },
+  [ChainId.MATIC_AMOY]: {
+    mana: '0x7ad72b9f944ea9793cf4055d88f81138cc2c63a0',
+    erc20Predicate: ''
+  }
+}
+
+export function getRpcUrlByChainId(chainId: ChainId): string {
+  switch (chainId) {
+    case ChainId.ETHEREUM_MAINNET:
+      return 'https://rpc.decentraland.org/mainnet'
+    case ChainId.ETHEREUM_SEPOLIA:
+      return 'https://rpc.decentraland.org/sepolia'
+    case ChainId.MATIC_MAINNET:
+      return 'https://rpc.decentraland.org/polygon'
+    case ChainId.MATIC_AMOY:
+      return 'https://rpc.decentraland.org/amoy'
+    default:
+      throw new Error(`Unsupported chainId ${chainId}`)
+  }
+}
+
+export function getBridgeAddresses(chainId: ChainId): BridgeAddresses {
+  const addresses = BRIDGE_ADDRESSES[chainId]
+  if (!addresses) {
+    throw new Error(`No MANA/bridge addresses configured for chainId ${chainId}`)
+  }
+  return addresses
+}
+
+/** 20-byte address → 32-byte left-padded topic (lowercased), for the indexed `from`/`to` filter. */
+export function addressToTopic(address: string): string {
+  return `0x000000000000000000000000${address.slice(2).toLowerCase()}`
+}
+
+/** 32-byte indexed topic → 20-byte address (lowercased). */
+export function topicToAddress(topic: string): string {
+  return `0x${topic.slice(26).toLowerCase()}`
+}
+
+export function decodeTransferLog(log: RawTransferLog, network: Network): DecodedTransfer {
+  return {
+    network,
+    from: topicToAddress(log.topics[1]),
+    to: topicToAddress(log.topics[2]),
+    value: BigInt(log.data),
+    hash: log.transactionHash.toLowerCase(),
+    logIndex: parseInt(log.logIndex, 16),
+    blockNumber: parseInt(log.blockNumber, 16),
+    timestamp: log.blockTimestamp ? parseInt(log.blockTimestamp, 16) * 1000 : 0
+  }
+}
+
+type Leg = 'deposit' | 'credit' | 'burn' | 'exit' | 'send' | 'received' | 'other'
+
+/**
+ * Classifies a decoded transfer relative to `user`. `predicate` is the L1 ERC20 predicate address
+ * (empty on L2). Bridge legs:
+ * - L1 `deposit` (swap origin): from === user, to === predicate.
+ * - L1 `exit` (withdraw close): from === predicate, to === user.
+ * - L2 `credit` (swap credit): from === 0x0 (mint), to === user.
+ * - L2 `burn` (withdraw origin): from === user, to === 0x0.
+ */
+export function classifyLeg(transfer: DecodedTransfer, user: string, predicate: string): Leg {
+  const normalizedUser = user.toLowerCase()
+  const normalizedPredicate = predicate.toLowerCase()
+  const isFromUser = transfer.from === normalizedUser
+  const isToUser = transfer.to === normalizedUser
+
+  if (transfer.network === Network.ETHEREUM) {
+    if (normalizedPredicate && isFromUser && transfer.to === normalizedPredicate) return 'deposit'
+    if (normalizedPredicate && isToUser && transfer.from === normalizedPredicate) return 'exit'
+    if (isFromUser) return 'send'
+    if (isToUser) return 'received'
+    return 'other'
+  }
+
+  if (isAddressZero(transfer.from) && isToUser) return 'credit'
+  if (isFromUser && isAddressZero(transfer.to)) return 'burn'
+  if (isFromUser) return 'send'
+  if (isToUser) return 'received'
+  return 'other'
+}
+
+function legKey(transfer: DecodedTransfer): string {
+  return `${transfer.network}-${transfer.hash}-${transfer.logIndex}`
+}
+
+function byChronology(a: DecodedTransfer, b: DecodedTransfer): number {
+  return a.timestamp - b.timestamp || a.blockNumber - b.blockNumber
+}
+
+/**
+ * Greedy FIFO correlation of bridge origin legs (deposits/burns) with their closing legs
+ * (credits/exits). There is NO common id between the two chains' Transfer logs (the L1 StateSynced
+ * id never appears on the L2 mint), so origins are matched to the earliest unused closing with the
+ * exact same wei value that did not happen before the origin. Each closing is consumed once.
+ */
+export function correlateFifo(origins: DecodedTransfer[], closings: DecodedTransfer[]): Map<string, DecodedTransfer> {
+  const sortedOrigins = [...origins].sort(byChronology)
+  const sortedClosings = [...closings].sort(byChronology)
+  const consumed = new Set<string>()
+  const matches = new Map<string, DecodedTransfer>()
+
+  for (const origin of sortedOrigins) {
+    const match = sortedClosings.find(
+      closing => !consumed.has(legKey(closing)) && closing.value === origin.value && closing.timestamp >= origin.timestamp
+    )
+    if (match) {
+      consumed.add(legKey(match))
+      matches.set(legKey(origin), match)
+    }
+  }
+
+  return matches
+}
+
+function dedupeTransfers(transfers: DecodedTransfer[]): DecodedTransfer[] {
+  const seen = new Set<string>()
+  const result: DecodedTransfer[] = []
+  for (const transfer of transfers) {
+    const key = legKey(transfer)
+    if (!seen.has(key)) {
+      seen.add(key)
+      result.push(transfer)
+    }
+  }
+  return result
+}
+
+function toManaTransfer(
+  transfer: DecodedTransfer,
+  type: ManaTransferType,
+  status: ManaTransferStatus,
+  counterpartHash?: string
+): ManaTransfer {
+  return {
+    hash: transfer.hash,
+    type,
+    network: transfer.network,
+    from: transfer.from,
+    to: transfer.to,
+    amount: formatEther(transfer.value),
+    value: transfer.value.toString(),
+    timestamp: transfer.timestamp,
+    status,
+    ...(counterpartHash ? { counterpartHash } : {})
+  }
+}
+
+/**
+ * Builds the wallet's MANA transfer feed from the decoded L1 + L2 `Transfer` logs.
+ *
+ * - One row per swap, anchored on the L1 deposit; the correlated L2 mint is suppressed from the feed
+ *   and exposed as `counterpartHash`. A deposit without a credit is `bridging`.
+ * - An orphan L2 mint (a deposit made by a third party, or a swap from another wallet) becomes its
+ *   own `swap` row so bridge-credited MANA is never lost.
+ * - Symmetrically for withdraws: one row per L2 burn, the L1 exit correlated as `counterpartHash`.
+ * - Plain sends/receiveds pass through. The L2 mint (from 0x0) is NEVER shown as a `received`.
+ */
+export function buildManaTransferFeed(params: {
+  ethereumTransfers: DecodedTransfer[]
+  polygonTransfers: DecodedTransfer[]
+  user: string
+  ethereumPredicate: string
+}): ManaTransfer[] {
+  const { user, ethereumPredicate } = params
+  const all = dedupeTransfers([...params.ethereumTransfers, ...params.polygonTransfers])
+  const classified = all.map(transfer => ({
+    transfer,
+    leg: classifyLeg(transfer, user, transfer.network === Network.ETHEREUM ? ethereumPredicate : '')
+  }))
+
+  const pick = (leg: Leg) => classified.filter(entry => entry.leg === leg).map(entry => entry.transfer)
+  const deposits = pick('deposit')
+  const credits = pick('credit')
+  const burns = pick('burn')
+  const exits = pick('exit')
+
+  const swapMatches = correlateFifo(deposits, credits)
+  const withdrawMatches = correlateFifo(burns, exits)
+  const consumedCredits = new Set([...swapMatches.values()].map(legKey))
+  const consumedExits = new Set([...withdrawMatches.values()].map(legKey))
+
+  const rows: ManaTransfer[] = []
+
+  for (const deposit of deposits) {
+    const credit = swapMatches.get(legKey(deposit))
+    rows.push(
+      toManaTransfer(deposit, ManaTransferType.SWAP, credit ? ManaTransferStatus.CONFIRMED : ManaTransferStatus.BRIDGING, credit?.hash)
+    )
+  }
+  for (const credit of credits) {
+    if (!consumedCredits.has(legKey(credit))) {
+      rows.push(toManaTransfer(credit, ManaTransferType.SWAP, ManaTransferStatus.CONFIRMED))
+    }
+  }
+  for (const burn of burns) {
+    const exit = withdrawMatches.get(legKey(burn))
+    rows.push(
+      toManaTransfer(burn, ManaTransferType.WITHDRAW, exit ? ManaTransferStatus.CONFIRMED : ManaTransferStatus.BRIDGING, exit?.hash)
+    )
+  }
+  for (const exit of exits) {
+    if (!consumedExits.has(legKey(exit))) {
+      rows.push(toManaTransfer(exit, ManaTransferType.WITHDRAW, ManaTransferStatus.CONFIRMED))
+    }
+  }
+  for (const send of pick('send')) {
+    rows.push(toManaTransfer(send, ManaTransferType.SEND, ManaTransferStatus.CONFIRMED))
+  }
+  for (const received of pick('received')) {
+    rows.push(toManaTransfer(received, ManaTransferType.RECEIVED, ManaTransferStatus.CONFIRMED))
+  }
+
+  return rows.sort((a, b) => b.timestamp - a.timestamp)
+}

--- a/src/ports/mana-transfers/types.ts
+++ b/src/ports/mana-transfers/types.ts
@@ -1,0 +1,80 @@
+import { Network } from '@dcl/schemas'
+
+/**
+ * A MANA movement in a wallet's history, derived from on-chain ERC20 `Transfer` logs.
+ *
+ * - `send` / `received`: plain MANA transfers out of / into the wallet.
+ * - `swap`: a Polygon PoS bridge deposit (Ethereum→Polygon). Anchored on the L1 deposit; the L2
+ *   mint that credits Polygon is correlated and exposed as `counterpartHash` (not a separate row).
+ * - `withdraw`: a Polygon PoS bridge withdrawal (Polygon→Ethereum). Anchored on the L2 burn; the L1
+ *   exit is correlated and exposed as `counterpartHash`.
+ */
+export enum ManaTransferType {
+  SEND = 'send',
+  RECEIVED = 'received',
+  SWAP = 'swap',
+  WITHDRAW = 'withdraw'
+}
+
+/**
+ * `confirmed`: the movement is fully settled on its destination chain.
+ * `bridging`: a swap/withdraw whose origin leg is mined but whose destination leg (the bridge
+ * credit/exit) has not been observed yet (~20-30 min PoS checkpoint window).
+ */
+export enum ManaTransferStatus {
+  CONFIRMED = 'confirmed',
+  BRIDGING = 'bridging'
+}
+
+export type ManaTransfer = {
+  hash: string
+  type: ManaTransferType
+  network: Network
+  from: string
+  to: string
+  // Human-readable MANA amount (formatEther of `value`).
+  amount: string
+  // Raw amount in wei, as a decimal string (lossless; clients reconcile by hash, not amount).
+  value: string
+  // Milliseconds since epoch (from the log's blockTimestamp).
+  timestamp: number
+  status: ManaTransferStatus
+  // For a swap: the L2 mint tx hash once Polygon is credited. For a withdraw: the L1 exit tx hash
+  // once completed. Undefined while still `bridging`. Best-effort: the two bridge legs share no
+  // on-chain id, so they are correlated by exact wei amount + chronological order — for two
+  // in-flight transfers of the identical amount the paired hash (and status) may be swapped.
+  counterpartHash?: string
+}
+
+export type IManaTransfersComponent = {
+  getManaTransfers(address: string): Promise<{ data: ManaTransfer[]; total: number }>
+}
+
+/**
+ * Raw `eth_getLogs` entry as returned by the DCL RPC. The DCL RPC (Alchemy) includes
+ * `blockTimestamp` on each log, so the transfer date is read from the log itself without an extra
+ * `eth_getBlockByNumber` call.
+ */
+export type RawTransferLog = {
+  address: string
+  topics: string[]
+  data: string
+  blockNumber: string
+  blockTimestamp?: string
+  transactionHash: string
+  logIndex: string
+  removed?: boolean
+}
+
+/** A decoded MANA `Transfer` event, normalized (lowercased addresses) for classification. */
+export type DecodedTransfer = {
+  network: Network
+  from: string
+  to: string
+  value: bigint
+  hash: string
+  logIndex: number
+  blockNumber: number
+  // Milliseconds since epoch; 0 when the RPC omitted blockTimestamp.
+  timestamp: number
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ import { IPicksComponent } from './ports/favorites/picks'
 import { ISnapshotComponent } from './ports/favorites/snapshot'
 import { IItemsComponent } from './ports/items'
 import { IJobComponent } from './ports/job'
+import { IManaTransfersComponent } from './ports/mana-transfers/types'
 import { INFTsComponent } from './ports/nfts/types'
 import { IOrdersComponent } from './ports/orders/types'
 import { IOwnersComponent } from './ports/owners/types'
@@ -89,6 +90,7 @@ export type BaseComponents = {
   collections: ICollectionsComponent
   accounts: IAccountsComponent
   activity: IActivityComponent
+  manaTransfers: IManaTransfersComponent
 }
 
 // components used in runtime

--- a/test/components.ts
+++ b/test/components.ts
@@ -29,6 +29,7 @@ import { IPicksComponent, createPicksComponent } from '../src/ports/favorites/pi
 import { ISnapshotComponent, createSnapshotComponent } from '../src/ports/favorites/snapshot'
 import { IItemsComponent, createItemsComponent } from '../src/ports/items'
 import { createJobComponent } from '../src/ports/job'
+import { createManaTransfersComponent } from '../src/ports/mana-transfers/component'
 import { createNFTsComponent } from '../src/ports/nfts/component'
 import { createOrdersComponent } from '../src/ports/orders/component'
 import { createOwnersComponent } from '../src/ports/owners/component'
@@ -157,6 +158,7 @@ async function initComponents(): Promise<TestComponents> {
   const volumes = await createVolumeComponent({ analyticsData })
   const userAssets = await createUserAssetsComponent({ logs, dappsDatabase: dappsReadDatabase })
   const activity = createActivityComponent({ sales, bids, orders, trades, logs })
+  const manaTransfers = createManaTransfersComponent({ logs, inMemoryCache })
 
   return {
     cache,
@@ -200,7 +202,8 @@ async function initComponents(): Promise<TestComponents> {
     analyticsData,
     volumes,
     userAssets,
-    activity
+    activity,
+    manaTransfers
   }
 }
 

--- a/test/integration/mana-transfers-controller.spec.ts
+++ b/test/integration/mana-transfers-controller.spec.ts
@@ -1,0 +1,67 @@
+import { Network } from '@dcl/schemas'
+import { ManaTransfer, ManaTransferStatus, ManaTransferType } from '../../src/ports/mana-transfers/types'
+import { test } from '../components'
+
+test('when getting MANA transfers for a wallet', function ({ components, spyComponents }) {
+  const address = '0xd9b96b5dc720fc52bede1ec3b40a930e15f70ddd'
+
+  describe('and the address is not a valid wallet address', () => {
+    it('should respond with a 400 and not query the component', async () => {
+      const { localFetch } = components
+      spyComponents.manaTransfers.getManaTransfers
+
+      const response = await localFetch.fetch('/v1/wallets/not-an-address/mana-transfers')
+
+      expect(response.status).toEqual(400)
+      expect(await response.json()).toEqual({ ok: false, message: 'Invalid address' })
+      expect(spyComponents.manaTransfers.getManaTransfers).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the address is valid', () => {
+    let transfers: ManaTransfer[]
+
+    beforeEach(() => {
+      transfers = [
+        {
+          hash: '0xdep',
+          type: ManaTransferType.SWAP,
+          network: Network.ETHEREUM,
+          from: address,
+          to: '0x40ec5b33f54e0e8a33a975908c5ba1c14e5bbbdf',
+          amount: '306.0',
+          value: '306000000000000000000',
+          timestamp: 1000,
+          status: ManaTransferStatus.CONFIRMED,
+          counterpartHash: '0xcre'
+        }
+      ]
+      spyComponents.manaTransfers.getManaTransfers.mockResolvedValueOnce({ data: transfers, total: 1 })
+    })
+
+    it('should respond with a 200 and the transfer feed', async () => {
+      const { localFetch } = components
+
+      const response = await localFetch.fetch(`/v1/wallets/${address}/mana-transfers`)
+
+      expect(response.status).toEqual(200)
+      expect(await response.json()).toEqual({ data: transfers, total: 1 })
+      expect(spyComponents.manaTransfers.getManaTransfers).toHaveBeenCalledWith(address)
+    })
+  })
+
+  describe('and the component fails to fetch the transfers', () => {
+    beforeEach(() => {
+      spyComponents.manaTransfers.getManaTransfers.mockRejectedValueOnce(new Error('RPC unavailable'))
+    })
+
+    it('should respond with a 500', async () => {
+      const { localFetch } = components
+
+      const response = await localFetch.fetch(`/v1/wallets/${address}/mana-transfers`)
+
+      expect(response.status).toEqual(500)
+      expect(await response.json()).toEqual({ ok: false, message: 'RPC unavailable' })
+    })
+  })
+})

--- a/test/integration/mana-transfers-controller.spec.ts
+++ b/test/integration/mana-transfers-controller.spec.ts
@@ -55,13 +55,13 @@ test('when getting MANA transfers for a wallet', function ({ components, spyComp
       spyComponents.manaTransfers.getManaTransfers.mockRejectedValueOnce(new Error('RPC unavailable'))
     })
 
-    it('should respond with a 500', async () => {
+    it('should respond with a 500 and the generic message without leaking the internal error', async () => {
       const { localFetch } = components
 
       const response = await localFetch.fetch(`/v1/wallets/${address}/mana-transfers`)
 
       expect(response.status).toEqual(500)
-      expect(await response.json()).toEqual({ ok: false, message: 'RPC unavailable' })
+      expect(await response.json()).toEqual({ ok: false, message: 'Could not fetch MANA transfers' })
     })
   })
 })

--- a/test/unit/mana-transfers-component.spec.ts
+++ b/test/unit/mana-transfers-component.spec.ts
@@ -154,6 +154,28 @@ describe('when the result is not cached', () => {
     expect(total).toBe(0)
   })
 
+  it('should skip a log whose data is non-hex (decode throws) without aborting the feed', async () => {
+    mockSend.mockImplementation(async (_method: string, params: [{ address: string; topics: (string | null)[] }]) => {
+      const [filter] = params
+      if (filter.address === ETHEREUM.mana && filter.topics[1] === USER_TOPIC) {
+        return [
+          {
+            address: ETHEREUM.mana,
+            topics: [TRANSFER_EVENT_TOPIC, addressToTopic(USER), addressToTopic(OTHER_ADDRESS)],
+            data: '0xnothex',
+            blockNumber: '0x1',
+            blockTimestamp: '0x3e8',
+            transactionHash: '0xbaddata',
+            logIndex: '0x0'
+          }
+        ]
+      }
+      return []
+    })
+    const { total } = await component.getManaTransfers(USER)
+    expect(total).toBe(0)
+  })
+
   it('should throw rather than cache a truncated feed when a filter hits the RPC result cap', async () => {
     const truncated = Array.from({ length: 10000 }, (_unused, index) => rawLog(USER, OTHER_ADDRESS, 1n, `0x${index.toString(16)}`))
     mockSend.mockResolvedValue(truncated)

--- a/test/unit/mana-transfers-component.spec.ts
+++ b/test/unit/mana-transfers-component.spec.ts
@@ -1,0 +1,163 @@
+import { JsonRpcProvider } from 'ethers'
+import { ICacheStorageComponent } from '@dcl/core-commons'
+import { ChainId, Network } from '@dcl/schemas'
+import { createManaTransfersComponent } from '../../src/ports/mana-transfers/component'
+import { addressToTopic, getBridgeAddresses, TRANSFER_EVENT_TOPIC } from '../../src/ports/mana-transfers/logic'
+import { IManaTransfersComponent, ManaTransferStatus, ManaTransferType, RawTransferLog } from '../../src/ports/mana-transfers/types'
+import { createCacheMockedComponent } from '../mocks/cache-mock'
+import { createLoggerMockedComponent } from '../mocks/logger-mock'
+
+const mockSend = jest.fn()
+
+jest.mock('ethers', () => {
+  const actual = jest.requireActual('ethers')
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    JsonRpcProvider: jest.fn().mockImplementation(() => ({ send: mockSend }))
+  }
+})
+
+// Pin the chain ids so getBridgeAddresses resolves to mainnet/polygon in the test.
+jest.mock('../../src/logic/chainIds', () => ({
+  getEthereumChainId: () => 1, // ChainId.ETHEREUM_MAINNET
+  getPolygonChainId: () => 137 // ChainId.MATIC_MAINNET
+}))
+
+const USER = '0xd9b96b5dc720fc52bede1ec3b40a930e15f70ddd'
+const OTHER_ADDRESS = '0x9a6ebe7e2a7722f8200d0ffb63a1f6406a0d7dce'
+const ZERO = '0x0000000000000000000000000000000000000000'
+const ETHEREUM = getBridgeAddresses(ChainId.ETHEREUM_MAINNET)
+const USER_TOPIC = addressToTopic(USER)
+const MANA_306 = 306n * 10n ** 18n
+
+const rawLog = (from: string, to: string, value: bigint, hash: string, removed = false): RawTransferLog => ({
+  address: ETHEREUM.mana,
+  topics: [TRANSFER_EVENT_TOPIC, addressToTopic(from), addressToTopic(to)],
+  data: `0x${value.toString(16).padStart(64, '0')}`,
+  blockNumber: '0x1',
+  blockTimestamp: '0x3e8',
+  transactionHash: hash,
+  logIndex: '0x0',
+  removed
+})
+
+let inMemoryCache: ICacheStorageComponent
+let mockGet: jest.MockedFn<ICacheStorageComponent['get']>
+let mockSet: jest.MockedFn<ICacheStorageComponent['set']>
+let component: IManaTransfersComponent
+
+beforeEach(() => {
+  // resetMocks: true wipes the factory implementation between tests, so re-establish it here.
+  ;(JsonRpcProvider as unknown as jest.Mock).mockImplementation(() => ({ send: mockSend }))
+  mockGet = jest.fn()
+  mockSet = jest.fn()
+  mockGet.mockResolvedValue(undefined)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inMemoryCache = createCacheMockedComponent({ get: mockGet as any, set: mockSet })
+  component = createManaTransfersComponent({ logs: createLoggerMockedComponent(), inMemoryCache })
+})
+
+describe('when getting MANA transfers for an invalid address', () => {
+  it('should throw', async () => {
+    await expect(component.getManaTransfers('not-an-address')).rejects.toThrow('Invalid address')
+  })
+})
+
+describe('when the result is already cached', () => {
+  let cached: { data: []; total: number }
+
+  beforeEach(() => {
+    cached = { data: [], total: 0 }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockGet.mockResolvedValueOnce(cached as any)
+  })
+
+  it('should return the cached value', async () => {
+    const result = await component.getManaTransfers(USER)
+    expect(result).toBe(cached)
+  })
+
+  it('should not hit the RPC', async () => {
+    await component.getManaTransfers(USER)
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+})
+
+describe('when the result is not cached', () => {
+  beforeEach(() => {
+    mockSend.mockImplementation(async (_method: string, params: [{ address: string; topics: (string | null)[] }]) => {
+      const [filter] = params
+      const isEthereum = filter.address === ETHEREUM.mana
+      const fromUser = filter.topics[1] === USER_TOPIC
+      const toUser = filter.topics[2] === USER_TOPIC
+      // L1 outgoing: a bridge deposit to the predicate. L2 incoming: the matching mint credit.
+      if (isEthereum && fromUser) return [rawLog(USER, ETHEREUM.erc20Predicate, MANA_306, '0xdep')]
+      if (!isEthereum && toUser) return [rawLog(ZERO, USER, MANA_306, '0xcre')]
+      return []
+    })
+  })
+
+  it('should query the four log filters (sent + received per chain)', async () => {
+    await component.getManaTransfers(USER)
+    expect(mockSend).toHaveBeenCalledTimes(4)
+    expect(mockSend).toHaveBeenCalledWith('eth_getLogs', expect.any(Array))
+  })
+
+  it('should build a single confirmed swap from the deposit correlated with the credit', async () => {
+    const { data, total } = await component.getManaTransfers(USER)
+    expect(total).toBe(1)
+    expect(data[0]).toMatchObject({
+      hash: '0xdep',
+      type: ManaTransferType.SWAP,
+      network: Network.ETHEREUM,
+      status: ManaTransferStatus.CONFIRMED,
+      counterpartHash: '0xcre'
+    })
+  })
+
+  it('should cache the result with a TTL', async () => {
+    await component.getManaTransfers(USER)
+    expect(mockSet).toHaveBeenCalledWith(`mana-transfers:${USER}`, expect.objectContaining({ total: 1 }), 120)
+  })
+
+  it('should ignore removed logs', async () => {
+    mockSend.mockImplementation(async (_method: string, params: [{ address: string; topics: (string | null)[] }]) => {
+      const [filter] = params
+      if (filter.address === ETHEREUM.mana && filter.topics[1] === USER_TOPIC) {
+        return [rawLog(USER, ETHEREUM.erc20Predicate, MANA_306, '0xremoved', true)]
+      }
+      return []
+    })
+    const { total } = await component.getManaTransfers(USER)
+    expect(total).toBe(0)
+  })
+
+  it('should ignore malformed logs (missing topics or empty data)', async () => {
+    mockSend.mockImplementation(async (_method: string, params: [{ address: string; topics: (string | null)[] }]) => {
+      const [filter] = params
+      if (filter.address === ETHEREUM.mana && filter.topics[1] === USER_TOPIC) {
+        return [
+          {
+            address: ETHEREUM.mana,
+            topics: [TRANSFER_EVENT_TOPIC],
+            data: '0x',
+            blockNumber: '0x1',
+            transactionHash: '0xbad',
+            logIndex: '0x0'
+          }
+        ]
+      }
+      return []
+    })
+    const { total } = await component.getManaTransfers(USER)
+    expect(total).toBe(0)
+  })
+
+  it('should throw rather than cache a truncated feed when a filter hits the RPC result cap', async () => {
+    const truncated = Array.from({ length: 10000 }, (_unused, index) => rawLog(USER, OTHER_ADDRESS, 1n, `0x${index.toString(16)}`))
+    mockSend.mockResolvedValue(truncated)
+    await expect(component.getManaTransfers(USER)).rejects.toThrow('result cap')
+    expect(mockSet).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/mana-transfers-handler.spec.ts
+++ b/test/unit/mana-transfers-handler.spec.ts
@@ -2,6 +2,7 @@ import { Network } from '@dcl/schemas'
 import { getManaTransfersHandler } from '../../src/controllers/handlers/mana-transfers-handler'
 import { IManaTransfersComponent, ManaTransfer, ManaTransferStatus, ManaTransferType } from '../../src/ports/mana-transfers/types'
 import { StatusCode } from '../../src/types'
+import { createLoggerMockedComponent } from '../mocks/logger-mock'
 
 const USER = '0xd9b96b5dc720fc52bede1ec3b40a930e15f70ddd'
 
@@ -10,7 +11,7 @@ let manaTransfers: IManaTransfersComponent
 
 const buildContext = (address: string) =>
   ({
-    components: { manaTransfers },
+    components: { manaTransfers, logs: createLoggerMockedComponent() },
     params: { address }
   } as Parameters<typeof getManaTransfersHandler>[0])
 
@@ -66,11 +67,11 @@ describe('when the address is valid', () => {
 })
 
 describe('when the component throws', () => {
-  it('should surface a generic message and 500 with an Error', async () => {
-    getManaTransfers.mockRejectedValue(new Error('rpc exploded'))
+  it('should not leak the raw error message — always return the generic message and 500', async () => {
+    getManaTransfers.mockRejectedValue(new Error('rpc exploded: https://rpc.decentraland.org/mainnet'))
     const response = await getManaTransfersHandler(buildContext(USER))
     expect(response.status).toBe(StatusCode.INTERNAL_SERVER_ERROR)
-    expect(response.body).toEqual({ ok: false, message: 'rpc exploded' })
+    expect(response.body).toEqual({ ok: false, message: 'Could not fetch MANA transfers' })
   })
 
   it('should fall back to a default message on a non-error throw', async () => {

--- a/test/unit/mana-transfers-handler.spec.ts
+++ b/test/unit/mana-transfers-handler.spec.ts
@@ -1,0 +1,82 @@
+import { Network } from '@dcl/schemas'
+import { getManaTransfersHandler } from '../../src/controllers/handlers/mana-transfers-handler'
+import { IManaTransfersComponent, ManaTransfer, ManaTransferStatus, ManaTransferType } from '../../src/ports/mana-transfers/types'
+import { StatusCode } from '../../src/types'
+
+const USER = '0xd9b96b5dc720fc52bede1ec3b40a930e15f70ddd'
+
+let getManaTransfers: jest.MockedFn<IManaTransfersComponent['getManaTransfers']>
+let manaTransfers: IManaTransfersComponent
+
+const buildContext = (address: string) =>
+  ({
+    components: { manaTransfers },
+    params: { address }
+  } as Parameters<typeof getManaTransfersHandler>[0])
+
+beforeEach(() => {
+  getManaTransfers = jest.fn()
+  manaTransfers = { getManaTransfers }
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('when the address is invalid', () => {
+  it('should respond 400 without querying the component', async () => {
+    const response = await getManaTransfersHandler(buildContext('not-an-address'))
+    expect(response.status).toBe(StatusCode.BAD_REQUEST)
+    expect(response.body).toEqual({ ok: false, message: 'Invalid address' })
+    expect(getManaTransfers).not.toHaveBeenCalled()
+  })
+})
+
+describe('when the address is valid', () => {
+  let transfers: ManaTransfer[]
+
+  beforeEach(() => {
+    transfers = [
+      {
+        hash: '0xdep',
+        type: ManaTransferType.SWAP,
+        network: Network.ETHEREUM,
+        from: USER,
+        to: '0x40ec5b33f54e0e8a33a975908c5ba1c14e5bbbdf',
+        amount: '306.0',
+        value: '306000000000000000000',
+        timestamp: 1000,
+        status: ManaTransferStatus.CONFIRMED,
+        counterpartHash: '0xcre'
+      }
+    ]
+    getManaTransfers.mockResolvedValue({ data: transfers, total: 1 })
+  })
+
+  it('should respond 200 with the transfer feed and total', async () => {
+    const response = await getManaTransfersHandler(buildContext(USER))
+    expect(response.status).toBe(StatusCode.OK)
+    expect(response.body).toEqual({ data: transfers, total: 1 })
+  })
+
+  it('should pass the address to the component', async () => {
+    await getManaTransfersHandler(buildContext(USER))
+    expect(getManaTransfers).toHaveBeenCalledWith(USER)
+  })
+})
+
+describe('when the component throws', () => {
+  it('should surface a generic message and 500 with an Error', async () => {
+    getManaTransfers.mockRejectedValue(new Error('rpc exploded'))
+    const response = await getManaTransfersHandler(buildContext(USER))
+    expect(response.status).toBe(StatusCode.INTERNAL_SERVER_ERROR)
+    expect(response.body).toEqual({ ok: false, message: 'rpc exploded' })
+  })
+
+  it('should fall back to a default message on a non-error throw', async () => {
+    getManaTransfers.mockRejectedValue('boom')
+    const response = await getManaTransfersHandler(buildContext(USER))
+    expect(response.status).toBe(StatusCode.INTERNAL_SERVER_ERROR)
+    expect(response.body).toEqual({ ok: false, message: 'Could not fetch MANA transfers' })
+  })
+})

--- a/test/unit/mana-transfers-logic.spec.ts
+++ b/test/unit/mana-transfers-logic.spec.ts
@@ -1,0 +1,282 @@
+import { ChainId, Network } from '@dcl/schemas'
+import {
+  addressToTopic,
+  buildManaTransferFeed,
+  classifyLeg,
+  correlateFifo,
+  decodeTransferLog,
+  getBridgeAddresses,
+  getRpcUrlByChainId,
+  TRANSFER_EVENT_TOPIC,
+  topicToAddress
+} from '../../src/ports/mana-transfers/logic'
+import { DecodedTransfer, ManaTransferStatus, ManaTransferType, RawTransferLog } from '../../src/ports/mana-transfers/types'
+
+const USER = '0xd9b96b5dc720fc52bede1ec3b40a930e15f70ddd'
+const OTHER = '0x9a6ebe7e2a7722f8200d0ffb63a1f6406a0d7dce'
+const CONTRACT = '0x0ff58e235b154dd7785c4829d48948ce114248c4'
+const ZERO = '0x0000000000000000000000000000000000000000'
+const PREDICATE = getBridgeAddresses(ChainId.ETHEREUM_MAINNET).erc20Predicate
+
+const mana = (units: number): bigint => BigInt(units) * 10n ** 18n
+
+const decoded = (overrides: Partial<DecodedTransfer> = {}): DecodedTransfer => ({
+  network: Network.ETHEREUM,
+  from: USER,
+  to: OTHER,
+  value: mana(100),
+  hash: '0xaaa',
+  logIndex: 0,
+  blockNumber: 1,
+  timestamp: 1000,
+  ...overrides
+})
+
+describe('when converting addresses to and from indexed topics', () => {
+  it('should left-pad an address to a 32-byte lowercased topic', () => {
+    expect(addressToTopic(USER)).toBe(`0x000000000000000000000000${USER.slice(2)}`)
+  })
+
+  it('should recover the lowercased address from a topic', () => {
+    expect(topicToAddress(addressToTopic(USER))).toBe(USER)
+  })
+})
+
+describe('when resolving the RPC url by chain id', () => {
+  it('should map each supported chain to its DCL RPC path', () => {
+    expect(getRpcUrlByChainId(ChainId.ETHEREUM_MAINNET)).toBe('https://rpc.decentraland.org/mainnet')
+    expect(getRpcUrlByChainId(ChainId.ETHEREUM_SEPOLIA)).toBe('https://rpc.decentraland.org/sepolia')
+    expect(getRpcUrlByChainId(ChainId.MATIC_MAINNET)).toBe('https://rpc.decentraland.org/polygon')
+    expect(getRpcUrlByChainId(ChainId.MATIC_AMOY)).toBe('https://rpc.decentraland.org/amoy')
+  })
+
+  it('should throw on an unsupported chain', () => {
+    expect(() => getRpcUrlByChainId(999999 as ChainId)).toThrow()
+  })
+})
+
+describe('when decoding a raw transfer log', () => {
+  let log: RawTransferLog
+
+  beforeEach(() => {
+    log = {
+      address: getBridgeAddresses(ChainId.ETHEREUM_MAINNET).mana,
+      topics: [TRANSFER_EVENT_TOPIC, addressToTopic(OTHER), addressToTopic(USER)],
+      data: `0x${mana(306).toString(16).padStart(64, '0')}`,
+      blockNumber: '0x10c0796',
+      blockTimestamp: '0x6499e323',
+      transactionHash: '0xFADTX',
+      logIndex: '0x76'
+    }
+  })
+
+  it('should extract from, to, value, hash, indexes and a millisecond timestamp', () => {
+    const result = decodeTransferLog(log, Network.ETHEREUM)
+    expect(result).toEqual({
+      network: Network.ETHEREUM,
+      from: OTHER,
+      to: USER,
+      value: mana(306),
+      hash: '0xfadtx',
+      logIndex: 118,
+      blockNumber: 17565590,
+      timestamp: 0x6499e323 * 1000
+    })
+  })
+
+  it('should default the timestamp to 0 when blockTimestamp is missing', () => {
+    const result = decodeTransferLog({ ...log, blockTimestamp: undefined }, Network.ETHEREUM)
+    expect(result.timestamp).toBe(0)
+  })
+})
+
+describe('when classifying a transfer leg', () => {
+  describe('and the network is Ethereum (L1)', () => {
+    it('should classify a transfer to the ERC20 predicate as a deposit', () => {
+      expect(classifyLeg(decoded({ from: USER, to: PREDICATE }), USER, PREDICATE)).toBe('deposit')
+    })
+
+    it('should classify a transfer from the ERC20 predicate as an exit', () => {
+      expect(classifyLeg(decoded({ from: PREDICATE, to: USER }), USER, PREDICATE)).toBe('exit')
+    })
+
+    it('should classify any other outgoing transfer as a send', () => {
+      expect(classifyLeg(decoded({ from: USER, to: OTHER }), USER, PREDICATE)).toBe('send')
+    })
+
+    it('should classify any other incoming transfer as a received', () => {
+      expect(classifyLeg(decoded({ from: OTHER, to: USER }), USER, PREDICATE)).toBe('received')
+    })
+  })
+
+  describe('and the network is Polygon (L2)', () => {
+    it('should classify a mint from the zero address as a bridge credit', () => {
+      expect(classifyLeg(decoded({ network: Network.MATIC, from: ZERO, to: USER }), USER, '')).toBe('credit')
+    })
+
+    it('should classify a burn to the zero address as a withdraw origin', () => {
+      expect(classifyLeg(decoded({ network: Network.MATIC, from: USER, to: ZERO }), USER, '')).toBe('burn')
+    })
+
+    it('should classify a transfer from a contract as a received, not a credit', () => {
+      expect(classifyLeg(decoded({ network: Network.MATIC, from: CONTRACT, to: USER }), USER, '')).toBe('received')
+    })
+
+    it('should classify an outgoing transfer as a send', () => {
+      expect(classifyLeg(decoded({ network: Network.MATIC, from: USER, to: OTHER }), USER, '')).toBe('send')
+    })
+  })
+})
+
+describe('when correlating bridge legs with FIFO', () => {
+  it('should match an origin with the earliest later closing of the same value', () => {
+    const deposit = decoded({ value: mana(306), timestamp: 1000, hash: '0xdep' })
+    const credit = decoded({ network: Network.MATIC, value: mana(306), timestamp: 2000, hash: '0xcre' })
+    const matches = correlateFifo([deposit], [credit])
+    expect(matches.get(`${Network.ETHEREUM}-0xdep-0`)).toEqual(credit)
+  })
+
+  it('should not match a closing that happened before the origin', () => {
+    const deposit = decoded({ value: mana(306), timestamp: 5000, hash: '0xdep' })
+    const credit = decoded({ network: Network.MATIC, value: mana(306), timestamp: 1000, hash: '0xcre' })
+    expect(correlateFifo([deposit], [credit]).size).toBe(0)
+  })
+
+  it('should not match when values differ', () => {
+    const deposit = decoded({ value: mana(306), timestamp: 1000, hash: '0xdep' })
+    const credit = decoded({ network: Network.MATIC, value: mana(200), timestamp: 2000, hash: '0xcre' })
+    expect(correlateFifo([deposit], [credit]).size).toBe(0)
+  })
+
+  it('should pair repeated amounts in chronological order and consume each closing once', () => {
+    const d1 = decoded({ value: mana(100), timestamp: 1000, hash: '0xd1' })
+    const d2 = decoded({ value: mana(100), timestamp: 1500, hash: '0xd2' })
+    const c1 = decoded({ network: Network.MATIC, value: mana(100), timestamp: 2000, hash: '0xc1' })
+    const c2 = decoded({ network: Network.MATIC, value: mana(100), timestamp: 2500, hash: '0xc2' })
+    const matches = correlateFifo([d2, d1], [c2, c1])
+    expect(matches.get(`${Network.ETHEREUM}-0xd1-0`)).toEqual(c1)
+    expect(matches.get(`${Network.ETHEREUM}-0xd2-0`)).toEqual(c2)
+  })
+})
+
+describe('when building the MANA transfer feed', () => {
+  it('should anchor a swap on the L1 deposit and correlate the L2 credit as counterpartHash', () => {
+    const deposit = decoded({ from: USER, to: PREDICATE, value: mana(306), timestamp: 1000, hash: '0xdep' })
+    const credit = decoded({ network: Network.MATIC, from: ZERO, to: USER, value: mana(306), timestamp: 3000, hash: '0xcre' })
+
+    const feed = buildManaTransferFeed({
+      ethereumTransfers: [deposit],
+      polygonTransfers: [credit],
+      user: USER,
+      ethereumPredicate: PREDICATE
+    })
+
+    expect(feed).toHaveLength(1)
+    expect(feed[0]).toMatchObject({
+      hash: '0xdep',
+      type: ManaTransferType.SWAP,
+      network: Network.ETHEREUM,
+      status: ManaTransferStatus.CONFIRMED,
+      counterpartHash: '0xcre',
+      amount: '306.0',
+      value: mana(306).toString()
+    })
+  })
+
+  it('should never surface the L2 mint as a received row', () => {
+    const deposit = decoded({ from: USER, to: PREDICATE, value: mana(306), timestamp: 1000, hash: '0xdep' })
+    const credit = decoded({ network: Network.MATIC, from: ZERO, to: USER, value: mana(306), timestamp: 3000, hash: '0xcre' })
+
+    const feed = buildManaTransferFeed({
+      ethereumTransfers: [deposit],
+      polygonTransfers: [credit],
+      user: USER,
+      ethereumPredicate: PREDICATE
+    })
+
+    expect(feed.some(t => t.type === ManaTransferType.RECEIVED)).toBe(false)
+  })
+
+  it('should mark a deposit without a credit as bridging', () => {
+    const deposit = decoded({ from: USER, to: PREDICATE, value: mana(500), timestamp: 1000, hash: '0xdep' })
+
+    const feed = buildManaTransferFeed({ ethereumTransfers: [deposit], polygonTransfers: [], user: USER, ethereumPredicate: PREDICATE })
+
+    expect(feed[0]).toMatchObject({ type: ManaTransferType.SWAP, status: ManaTransferStatus.BRIDGING })
+    expect(feed[0].counterpartHash).toBeUndefined()
+  })
+
+  it('should promote an orphan L2 credit to its own swap row', () => {
+    const credit = decoded({ network: Network.MATIC, from: ZERO, to: USER, value: mana(200), timestamp: 3000, hash: '0xcre' })
+
+    const feed = buildManaTransferFeed({ ethereumTransfers: [], polygonTransfers: [credit], user: USER, ethereumPredicate: PREDICATE })
+
+    expect(feed).toHaveLength(1)
+    expect(feed[0]).toMatchObject({
+      hash: '0xcre',
+      type: ManaTransferType.SWAP,
+      network: Network.MATIC,
+      status: ManaTransferStatus.CONFIRMED
+    })
+  })
+
+  it('should anchor a withdraw on the L2 burn and correlate the L1 exit', () => {
+    const burn = decoded({ network: Network.MATIC, from: USER, to: ZERO, value: mana(50), timestamp: 1000, hash: '0xburn' })
+    const exit = decoded({ network: Network.ETHEREUM, from: PREDICATE, to: USER, value: mana(50), timestamp: 4000, hash: '0xexit' })
+
+    const feed = buildManaTransferFeed({ ethereumTransfers: [exit], polygonTransfers: [burn], user: USER, ethereumPredicate: PREDICATE })
+
+    expect(feed).toHaveLength(1)
+    expect(feed[0]).toMatchObject({
+      hash: '0xburn',
+      type: ManaTransferType.WITHDRAW,
+      network: Network.MATIC,
+      status: ManaTransferStatus.CONFIRMED,
+      counterpartHash: '0xexit'
+    })
+  })
+
+  it('should pass plain sends and receiveds through', () => {
+    const send = decoded({ from: USER, to: OTHER, value: mana(100), timestamp: 2000, hash: '0xsend' })
+    const received = decoded({ network: Network.MATIC, from: CONTRACT, to: USER, value: mana(10), timestamp: 1000, hash: '0xrec' })
+
+    const feed = buildManaTransferFeed({
+      ethereumTransfers: [send],
+      polygonTransfers: [received],
+      user: USER,
+      ethereumPredicate: PREDICATE
+    })
+
+    expect(feed.map(t => ({ hash: t.hash, type: t.type }))).toEqual([
+      { hash: '0xsend', type: ManaTransferType.SEND },
+      { hash: '0xrec', type: ManaTransferType.RECEIVED }
+    ])
+  })
+
+  it('should dedupe transfers by network, hash and logIndex', () => {
+    const send = decoded({ from: USER, to: OTHER, value: mana(100), timestamp: 1000, hash: '0xdup', logIndex: 0 })
+
+    const feed = buildManaTransferFeed({
+      ethereumTransfers: [send, { ...send }],
+      polygonTransfers: [],
+      user: USER,
+      ethereumPredicate: PREDICATE
+    })
+
+    expect(feed).toHaveLength(1)
+  })
+
+  it('should sort the feed newest first', () => {
+    const older = decoded({ from: USER, to: OTHER, value: mana(1), timestamp: 1000, hash: '0xold' })
+    const newer = decoded({ from: USER, to: OTHER, value: mana(2), timestamp: 9000, hash: '0xnew' })
+
+    const feed = buildManaTransferFeed({
+      ethereumTransfers: [older, newer],
+      polygonTransfers: [],
+      user: USER,
+      ethereumPredicate: PREDICATE
+    })
+
+    expect(feed.map(t => t.hash)).toEqual(['0xnew', '0xold'])
+  })
+})

--- a/test/unit/mana-transfers-logic.spec.ts
+++ b/test/unit/mana-transfers-logic.spec.ts
@@ -88,6 +88,10 @@ describe('when decoding a raw transfer log', () => {
     const result = decodeTransferLog({ ...log, blockTimestamp: undefined }, Network.ETHEREUM)
     expect(result.timestamp).toBe(0)
   })
+
+  it('should throw on a log with fewer than 3 topics (defensive guard for external callers)', () => {
+    expect(() => decodeTransferLog({ ...log, topics: [TRANSFER_EVENT_TOPIC] }, Network.ETHEREUM)).toThrow('Malformed Transfer log')
+  })
 })
 
 describe('when classifying a transfer leg', () => {


### PR DESCRIPTION
Adds `GET /v1/wallets/:address/mana-transfers`, returning a wallet's MANA ERC20 transfer history across Ethereum and Polygon.

The endpoint reads logs on-chain via `eth_getLogs` server-side (ethers `JsonRpcProvider` against the DCL RPC) — no indexer or database. It classifies plain sends and receiveds plus Polygon PoS bridge movements:

- A swap (Ethereum→Polygon deposit) is a MANA transfer to the L1 ERC20 predicate; the L2 credit is a mint from the zero address. The swap is anchored on the L1 deposit as a single row, the L2 mint is suppressed from the feed (never shown as a duplicate received) and surfaced as `counterpartHash`. A deposit whose L2 credit has not landed yet (~20-30 min PoS checkpoint) has status `bridging`.
- A withdrawal (Polygon→Ethereum) is anchored on the L2 burn symmetrically, with the L1 exit correlated.

The two bridge legs share no common on-chain id, so they are correlated with a best-effort FIFO heuristic by exact wei amount + chronological order. Results are cached in `inMemoryCache` (120s TTL). A `getLogs` sub-query that hits the RPC's 10k-result cap throws rather than caching a truncated/miscorrelated feed (block-range pagination for wallets with >10k transfers in one direction is a follow-up).

Public read — no authentication.

## Verification

- `npm run build`, lint and prettier clean.
- Unit suite green: classification/correlation/dedup logic, the component (RPC + cache, provider mocked), and the handler.
- Integration test exercises the route end-to-end through the test runner's `spyComponents` (no RPC).
- Endpoint and `ManaTransfer` schema documented in `docs/openapi.yaml` (redocly lint passes).
