### PR TITLE
feat: send x-api-key and end-user ip headers on transak api calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ Optional authentication (provides personalized results):
 | Payments | `GET /v1/transak/orders/{id}` | Get Transak order details |
 | ENS | `GET /v1/ens/generate` | Generate ENS name image |
 
+### Payment Gateway Security (Transak)
+
+The webapp never talks to Transak's REST API directly. It only calls this server's `/v1/transak/*` endpoints, and this server performs every server-to-server call to Transak (token refresh, order lookup, widget session) from `src/ports/transak/component.ts`.
+
+Transak enforces a mandatory partner security policy (effective **2026-07-15**, see the [official guide](https://docs.transak.com/guides/mandatory-security-changes)). Here is how each requirement is satisfied:
+
+1. **Backend-only API access.** Transak's APIs are called exclusively from this backend, so their egress IPs can be whitelisted by Transak. The frontend has no direct access — this was already the architecture.
+2. **Partner API key in a header (`x-api-key`).** `TRANSAK_API_KEY` is sent as the `x-api-key` header on every outbound Transak call, alongside the existing `api-secret` / `access-token` auth.
+3. **End-user IP forwarding (`x-user-ip`).** For user-initiated calls (`getOrder`, `getWidget`) the originating client IP is resolved from the incoming request — `cf-connecting-ip` (Cloudflare), falling back to the left-most `x-forwarded-for` entry — via `getClientIp` (`src/logic/http/ip.ts`), and forwarded as `x-user-ip`. It is intentionally omitted on the partner-level token-refresh call, which is not tied to a single user. This value is only trustworthy while the service is reachable exclusively through the Cloudflare/ingress that overwrites these headers; treat it as a Transak fraud/geo signal, not as an authentication input.
+4. **CORS restricted to Decentraland front-end domains.** Configured operationally via the `CORS_ORIGIN` environment variable (semicolon-separated origins, no wildcard), enforced at deploy time — keep it scoped to the marketplace/account front-ends.
+
+**Operational follow-ups (not code):** share this service's egress IPs (staging + production) with Transak for whitelisting, and complete the Transak partner security checklist.
+
 ## Database Schema
 
 See [docs/database-schema.md](docs/database-schema.md) for detailed schema, column definitions, and relationships.

--- a/src/controllers/handlers/transak-handler.ts
+++ b/src/controllers/handlers/transak-handler.ts
@@ -1,4 +1,5 @@
 import { isErrorWithMessage } from '../../logic/errors'
+import { getClientIp } from '../../logic/http/ip'
 import { WidgetOptions, OrderResponse } from '../../ports/transak/types'
 import { HTTPResponse, HandlerContextWithPath, StatusCode } from '../../types'
 
@@ -7,12 +8,13 @@ export async function createTransakHandler(
 ): Promise<HTTPResponse<OrderResponse>> {
   const {
     verification,
+    request,
     components: { transak }
   } = context
 
   const id = context.params.id
   const userAddress: string | undefined = verification?.auth.toLowerCase()
-  const order = await transak.getOrder(id)
+  const order = await transak.getOrder(id, getClientIp(request))
 
   if (!userAddress || (!!userAddress && userAddress !== order.data.walletAddress.toLocaleLowerCase())) {
     return {
@@ -44,7 +46,7 @@ export async function createTransakWidgetHandler(
   const widgetOptions: Partial<WidgetOptions> = await request.json()
 
   try {
-    const widgetUrl = await transak.getWidget(widgetOptions)
+    const widgetUrl = await transak.getWidget(widgetOptions, getClientIp(request))
 
     return {
       status: StatusCode.OK,

--- a/src/logic/http/ip.ts
+++ b/src/logic/http/ip.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolves the originating end-user IP from an incoming request.
+ *
+ * The API runs behind Cloudflare, which sets `cf-connecting-ip` to the real
+ * client IP, so that header is preferred. The left-most entry of
+ * `x-forwarded-for` (the originating client, before any proxy hops) is used as
+ * a fallback. Returns `undefined` when neither header is present.
+ */
+export function getClientIp(request: { headers: { get(name: string): string | null } }): string | undefined {
+  const cfConnectingIp = request.headers.get('cf-connecting-ip')
+  if (cfConnectingIp?.trim()) {
+    return cfConnectingIp.trim()
+  }
+
+  const forwardedFor = request.headers.get('x-forwarded-for')
+  const originatingIp = forwardedFor?.split(',')[0]?.trim()
+  return originatingIp || undefined
+}

--- a/src/logic/http/ip.ts
+++ b/src/logic/http/ip.ts
@@ -4,15 +4,21 @@
  * The API runs behind Cloudflare, which sets `cf-connecting-ip` to the real
  * client IP, so that header is preferred. The left-most entry of
  * `x-forwarded-for` (the originating client, before any proxy hops) is used as
- * a fallback. Returns `undefined` when neither header is present.
+ * a fallback. Returns `undefined` when the request has no readable headers or
+ * neither header is present.
  */
-export function getClientIp(request: { headers: { get(name: string): string | null } }): string | undefined {
-  const cfConnectingIp = request.headers.get('cf-connecting-ip')
+export function getClientIp(request: { headers?: { get(name: string): string | null } }): string | undefined {
+  const headers = request?.headers
+  if (!headers || typeof headers.get !== 'function') {
+    return undefined
+  }
+
+  const cfConnectingIp = headers.get('cf-connecting-ip')
   if (cfConnectingIp?.trim()) {
     return cfConnectingIp.trim()
   }
 
-  const forwardedFor = request.headers.get('x-forwarded-for')
+  const forwardedFor = headers.get('x-forwarded-for')
   const originatingIp = forwardedFor?.split(',')[0]?.trim()
   return originatingIp || undefined
 }

--- a/src/ports/transak/component.ts
+++ b/src/ports/transak/component.ts
@@ -75,12 +75,12 @@ export function createTransakComponent(
    * @returns A promise that resolves to the order response data from Transak API.
    * @throws Error when the API request fails or returns a non-ok status.
    */
-  async function getOrder(orderId: string): Promise<OrderResponse> {
+  async function getOrder(orderId: string, userIp?: string): Promise<OrderResponse> {
     try {
       const accessToken = await getOrRefreshAccessToken()
       const res = await fetch.fetch(`${apiURL}/v2/order/${orderId}`, {
         method: 'GET',
-        headers: { 'access-token': accessToken }
+        headers: { 'access-token': accessToken, 'x-api-key': apiKey, ...(userIp ? { 'x-user-ip': userIp } : {}) }
       })
 
       if (!res.ok) {
@@ -95,12 +95,18 @@ export function createTransakComponent(
     }
   }
 
-  async function getWidget(options?: WidgetOptions): Promise<string> {
+  async function getWidget(options?: WidgetOptions, userIp?: string): Promise<string> {
     try {
       const accessToken = await getOrRefreshAccessToken()
       const res = await fetch.fetch(`${apiGatewayURL}/v2/auth/session`, {
         method: 'POST',
-        headers: { 'access-token': accessToken, 'content-type': 'application/json', accept: 'application/json' },
+        headers: {
+          'access-token': accessToken,
+          'x-api-key': apiKey,
+          'content-type': 'application/json',
+          accept: 'application/json',
+          ...(userIp ? { 'x-user-ip': userIp } : {})
+        },
         body: JSON.stringify({
           widgetParams: {
             apiKey,
@@ -136,7 +142,7 @@ export function createTransakComponent(
     logger.info(`Getting access token from ${apiURL}/v2/refresh-token`)
     const res = await fetch.fetch(`${apiURL}/v2/refresh-token`, {
       method: 'POST',
-      headers: { 'api-secret': apiSecret, accept: 'application/json', 'content-type': 'application/json' },
+      headers: { 'api-secret': apiSecret, 'x-api-key': apiKey, accept: 'application/json', 'content-type': 'application/json' },
       body: JSON.stringify({ apiKey })
     })
 

--- a/src/ports/transak/types.ts
+++ b/src/ports/transak/types.ts
@@ -1,6 +1,6 @@
 export type ITransakComponent = {
-  getOrder(orderId: string): Promise<OrderResponse>
-  getWidget(options?: WidgetOptions): Promise<string>
+  getOrder(orderId: string, userIp?: string): Promise<OrderResponse>
+  getWidget(options?: WidgetOptions, userIp?: string): Promise<string>
   getOrRefreshAccessToken(force?: boolean): Promise<string>
 }
 

--- a/test/unit/ip.spec.ts
+++ b/test/unit/ip.spec.ts
@@ -39,6 +39,12 @@ describe('when resolving the client IP from a request', () => {
     })
   })
 
+  describe('and the request has no readable headers', () => {
+    it('should return undefined', () => {
+      expect(getClientIp({} as { headers?: { get(name: string): string | null } })).toBeUndefined()
+    })
+  })
+
   describe('and x-forwarded-for is present but empty', () => {
     it('should return undefined', () => {
       expect(getClientIp(requestWithHeaders({ 'x-forwarded-for': '   ' }))).toBeUndefined()

--- a/test/unit/ip.spec.ts
+++ b/test/unit/ip.spec.ts
@@ -1,0 +1,47 @@
+import { getClientIp } from '../../src/logic/http/ip'
+
+function requestWithHeaders(headers: Record<string, string | null>): { headers: { get(name: string): string | null } } {
+  return {
+    headers: {
+      get: (name: string) => (name in headers ? headers[name] : null)
+    }
+  }
+}
+
+describe('when resolving the client IP from a request', () => {
+  describe('and the cf-connecting-ip header is present', () => {
+    it('should return its trimmed value, preferring it over x-forwarded-for', () => {
+      const request = requestWithHeaders({ 'cf-connecting-ip': ' 203.0.113.7 ', 'x-forwarded-for': '198.51.100.1' })
+
+      expect(getClientIp(request)).toBe('203.0.113.7')
+    })
+  })
+
+  describe('and only the x-forwarded-for header is present', () => {
+    it('should return the trimmed left-most (originating) address', () => {
+      const request = requestWithHeaders({ 'x-forwarded-for': ' 198.51.100.4 , 10.0.0.1, 10.0.0.2' })
+
+      expect(getClientIp(request)).toBe('198.51.100.4')
+    })
+  })
+
+  describe('and the cf-connecting-ip header is blank', () => {
+    it('should fall back to x-forwarded-for', () => {
+      const request = requestWithHeaders({ 'cf-connecting-ip': '   ', 'x-forwarded-for': '198.51.100.4' })
+
+      expect(getClientIp(request)).toBe('198.51.100.4')
+    })
+  })
+
+  describe('and no IP headers are present', () => {
+    it('should return undefined', () => {
+      expect(getClientIp(requestWithHeaders({}))).toBeUndefined()
+    })
+  })
+
+  describe('and x-forwarded-for is present but empty', () => {
+    it('should return undefined', () => {
+      expect(getClientIp(requestWithHeaders({ 'x-forwarded-for': '   ' }))).toBeUndefined()
+    })
+  })
+})

--- a/test/unit/transak-component.spec.ts
+++ b/test/unit/transak-component.spec.ts
@@ -116,6 +116,7 @@ describe('when getting or refreshing an access token', () => {
           method: 'POST',
           headers: {
             'api-secret': mockConfig.apiSecret,
+            'x-api-key': mockConfig.apiKey,
             accept: 'application/json',
             'content-type': 'application/json'
           },
@@ -152,6 +153,7 @@ describe('when getting or refreshing an access token', () => {
           method: 'POST',
           headers: {
             'api-secret': mockConfig.apiSecret,
+            'x-api-key': mockConfig.apiKey,
             accept: 'application/json',
             'content-type': 'application/json'
           },
@@ -177,6 +179,7 @@ describe('when getting or refreshing an access token', () => {
           method: 'POST',
           headers: {
             'api-secret': mockConfig.apiSecret,
+            'x-api-key': mockConfig.apiKey,
             accept: 'application/json',
             'content-type': 'application/json'
           },
@@ -287,10 +290,19 @@ describe('when getting an order', () => {
       expect(mockGet).toHaveBeenCalledWith('transak-access-token')
       expect(mockFetch).toHaveBeenCalledWith(`${mockConfig.apiURL}/v2/order/${orderId}`, {
         method: 'GET',
-        headers: { 'access-token': cachedAccessToken }
+        headers: { 'access-token': cachedAccessToken, 'x-api-key': mockConfig.apiKey }
       })
       expect(mockTryReleaseLock).toHaveBeenCalledWith('transak-access-token-lock')
       expect(result).toEqual(mockOrderResponse)
+    })
+
+    it('should forward the end-user IP as the x-user-ip header when provided', async () => {
+      await transakComponent.getOrder(orderId, '203.0.113.7')
+
+      expect(mockFetch).toHaveBeenCalledWith(`${mockConfig.apiURL}/v2/order/${orderId}`, {
+        method: 'GET',
+        headers: { 'access-token': cachedAccessToken, 'x-api-key': mockConfig.apiKey, 'x-user-ip': '203.0.113.7' }
+      })
     })
   })
 
@@ -338,6 +350,7 @@ describe('when getting an order', () => {
         method: 'POST',
         headers: {
           'api-secret': mockConfig.apiSecret,
+          'x-api-key': mockConfig.apiKey,
           accept: 'application/json',
           'content-type': 'application/json'
         },
@@ -346,7 +359,7 @@ describe('when getting an order', () => {
       expect(mockSet).toHaveBeenCalledWith('transak-access-token', newAccessToken, fromMillisecondsToSeconds(3600000))
       expect(mockFetch).toHaveBeenCalledWith(`${mockConfig.apiURL}/v2/order/${orderId}`, {
         method: 'GET',
-        headers: { 'access-token': newAccessToken }
+        headers: { 'access-token': newAccessToken, 'x-api-key': mockConfig.apiKey }
       })
       expect(mockTryReleaseLock).toHaveBeenCalledWith('transak-access-token-lock')
       expect(result).toEqual(mockOrderResponse)
@@ -464,7 +477,12 @@ describe('when getting a widget session URL', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(`${mockConfig.apiGatewayURL}/v2/auth/session`, {
         method: 'POST',
-        headers: { 'access-token': cachedAccessToken, 'content-type': 'application/json', accept: 'application/json' },
+        headers: {
+          'access-token': cachedAccessToken,
+          'x-api-key': mockConfig.apiKey,
+          'content-type': 'application/json',
+          accept: 'application/json'
+        },
         body: JSON.stringify({
           widgetParams: {
             apiKey: mockConfig.apiKey,
@@ -479,6 +497,17 @@ describe('when getting a widget session URL', () => {
         })
       })
       expect(result).toEqual(widgetUrl)
+    })
+
+    it('should forward the end-user IP as the x-user-ip header when provided', async () => {
+      await transakComponent.getWidget({ fiatAmount: 100 }, '203.0.113.7')
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${mockConfig.apiGatewayURL}/v2/auth/session`,
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-api-key': mockConfig.apiKey, 'x-user-ip': '203.0.113.7' })
+        })
+      )
     })
   })
 
@@ -510,7 +539,12 @@ describe('when getting a widget session URL', () => {
 
       expect(mockFetch).toHaveBeenNthCalledWith(1, `${mockConfig.apiURL}/v2/refresh-token`, {
         method: 'POST',
-        headers: { 'api-secret': mockConfig.apiSecret, accept: 'application/json', 'content-type': 'application/json' },
+        headers: {
+          'api-secret': mockConfig.apiSecret,
+          'x-api-key': mockConfig.apiKey,
+          accept: 'application/json',
+          'content-type': 'application/json'
+        },
         body: JSON.stringify({ apiKey: mockConfig.apiKey })
       })
 
@@ -518,7 +552,12 @@ describe('when getting a widget session URL', () => {
 
       expect(mockFetch).toHaveBeenNthCalledWith(2, `${mockConfig.apiGatewayURL}/v2/auth/session`, {
         method: 'POST',
-        headers: { 'access-token': newAccessToken, 'content-type': 'application/json', accept: 'application/json' },
+        headers: {
+          'access-token': newAccessToken,
+          'x-api-key': mockConfig.apiKey,
+          'content-type': 'application/json',
+          accept: 'application/json'
+        },
         body: JSON.stringify({
           widgetParams: {
             apiKey: mockConfig.apiKey,

--- a/test/unit/transak-handler.spec.ts
+++ b/test/unit/transak-handler.spec.ts
@@ -11,11 +11,22 @@ describe('when handling Transak endpoints', () => {
       HandlerContextWithPath<'transak', '/v1/transak/orders/:id'>,
       'url' | 'components' | 'request' | 'verification' | 'params'
     >
+    let mockGetOrder: jest.Mock
 
     beforeEach(() => {
+      mockGetOrder = jest.fn().mockResolvedValue({
+        meta: { orderId: 'an-order-id' },
+        data: {
+          id: 'an-order-id',
+          status: 'COMPLETED',
+          transactionHash: '0x0',
+          walletAddress: '0xabcdef1234567890',
+          errorMessage: null
+        }
+      })
       context = {
         url: new URL('http://localhost/v1/transak/orders/an-order-id'),
-        request: {} as Request,
+        request: { headers: { get: jest.fn().mockReturnValue(null) } } as unknown as Request,
         verification: {
           auth: '0xABCDEF1234567890',
           authMetadata: {}
@@ -23,16 +34,7 @@ describe('when handling Transak endpoints', () => {
         params: { id: 'an-order-id' },
         components: {
           transak: {
-            getOrder: jest.fn().mockResolvedValue({
-              meta: { orderId: 'an-order-id' },
-              data: {
-                id: 'an-order-id',
-                status: 'COMPLETED',
-                transactionHash: '0x0',
-                walletAddress: '0xabcdef1234567890',
-                errorMessage: null
-              }
-            }),
+            getOrder: mockGetOrder,
             getWidget: jest.fn(),
             getOrRefreshAccessToken: jest.fn()
           }
@@ -81,6 +83,16 @@ describe('when handling Transak endpoints', () => {
           data: expect.objectContaining({ meta: { orderId: 'an-order-id' } })
         })
       })
+
+      it('should forward the client IP from cf-connecting-ip to getOrder', async () => {
+        ;(context.request.headers.get as jest.Mock).mockImplementation((header: string) =>
+          header === 'cf-connecting-ip' ? '203.0.113.7' : null
+        )
+
+        await createTransakHandler(context)
+
+        expect(mockGetOrder).toHaveBeenCalledWith('an-order-id', '203.0.113.7')
+      })
     })
   })
 
@@ -103,7 +115,8 @@ describe('when handling Transak endpoints', () => {
           }
         },
         request: {
-          json: mockJson
+          json: mockJson,
+          headers: { get: jest.fn().mockReturnValue(null) }
         } as unknown as Request
       }
     })
@@ -123,10 +136,13 @@ describe('when handling Transak endpoints', () => {
       it('should call getWidget with provided options and return 200 with the widget URL', async () => {
         const result = await createTransakWidgetHandler(context)
 
-        expect(mockGetWidget).toHaveBeenCalledWith({
-          fiatAmount: 150,
-          fiatCurrency: 'EUR'
-        })
+        expect(mockGetWidget).toHaveBeenCalledWith(
+          {
+            fiatAmount: 150,
+            fiatCurrency: 'EUR'
+          },
+          undefined
+        )
 
         expect(result).toEqual({
           status: StatusCode.OK,
@@ -143,12 +159,24 @@ describe('when handling Transak endpoints', () => {
       it('should call getWidget with empty options and return 200 with the widget URL', async () => {
         const result = await createTransakWidgetHandler(context)
 
-        expect(mockGetWidget).toHaveBeenCalledWith({})
+        expect(mockGetWidget).toHaveBeenCalledWith({}, undefined)
 
         expect(result).toEqual({
           status: StatusCode.OK,
           body: { ok: true, data: 'https://widget-url' }
         })
+      })
+    })
+
+    describe('and the request carries a client IP', () => {
+      it('should forward the originating IP from x-forwarded-for to getWidget', async () => {
+        ;(context.request.headers.get as jest.Mock).mockImplementation((header: string) =>
+          header === 'x-forwarded-for' ? '198.51.100.4, 10.0.0.1' : null
+        )
+
+        await createTransakWidgetHandler(context)
+
+        expect(mockGetWidget).toHaveBeenCalledWith({}, '198.51.100.4')
       })
     })
 


### PR DESCRIPTION
Transak now requires every call to their APIs to carry the partner API key and the originating end-user IP (mandatory security changes, deadline 2026-07-15).

This adds:
- `x-api-key` header on the three outbound Transak calls (refresh-token, auth/session, order).
- `x-user-ip` forwarded on the widget-url and order endpoints. A new `getClientIp` helper reads `cf-connecting-ip` (Cloudflare) with an `x-forwarded-for` fallback, and the handlers pass it through to the Transak component. The refresh-token call is a server-side partner operation with no associated end-user, so it does not carry `x-user-ip`.

Out of scope (infra/config, not code): validating the production `CORS_ORIGIN` value and whitelisting the backend egress IPs with Transak.

Verified: build, lint and unit tests (transak component + handler + the IP helper) pass.