### PR TITLE
fix: exclude estate sell orders broken by the registry upgrade from open listings

### DIFF
--- a/src/ports/catalog/queries.ts
+++ b/src/ports/catalog/queries.ts
@@ -639,6 +639,46 @@ LEFT JOIN (
     )
 }
 
+// Unix timestamp (2026-05-20 13:37:12 UTC) of the commit that started validating
+// new Estate trades against EstateRegistry.getFingerprintV2 (`9877d90`). Off-chain
+// trades created before this carry a legacy v1 (XOR) fingerprint in their signed
+// payload; trades created after are guaranteed v2-valid by the creation-time check.
+const ESTATE_V2_FINGERPRINT_VALIDATION_CUTOFF = 1779284232
+
+// Largest Estate (in LANDs) for which the upgraded EstateRegistry still honors the
+// legacy v1 fingerprint via verifyFingerprint's fallback. Estates above this can no
+// longer be executed with a v1 fingerprint. Mirrors the webapp's ESTATE_LR_XOR_SAFE_MAX_SIZE.
+const ESTATE_LR_XOR_SAFE_MAX_SIZE = 18
+
+/**
+ * Excludes off-chain Estate sell orders that are no longer executable on-chain
+ * after the EstateRegistry upgrade, so they are not surfaced as open listings.
+ *
+ * A `public_nft_order` whose sent asset is an Estate larger than the LR-XOR safe
+ * size AND that was signed before the v2-validation cutoff carries a stale v1
+ * fingerprint that `verifyFingerprint` will reject — buying it would revert. We
+ * keep ≤18-LAND estates (still honored via the contract's v1 fallback) and any
+ * trade created after the cutoff (v2-valid by construction).
+ *
+ * Returns a fresh SQLStatement each call (it is appended into multiple queries).
+ *
+ * TODO: once the on-chain v1 fallback deadline (2026-11-26 15:00 UTC) passes, ≤18
+ * LAND estates also stop honoring v1 — the size guard should be dropped then.
+ */
+export const getExcludeBrokenEstateTradesWhere = (): SQLStatement =>
+  SQL`
+    NOT (
+      unified_trades.type = 'public_nft_order'
+      AND unified_trades.sent_nft_category = ${NFTCategory.ESTATE}
+      AND unified_trades.created_at < to_timestamp(${ESTATE_V2_FINGERPRINT_VALIDATION_CUTOFF})
+      AND EXISTS (
+        SELECT 1 FROM `.append(MARKETPLACE_SQUID_SCHEMA).append(SQL`.nft broken_estate_nft
+        WHERE broken_estate_nft.id = unified_trades.sent_nft_id
+          AND broken_estate_nft.search_estate_size > ${ESTATE_LR_XOR_SAFE_MAX_SIZE}
+      )
+    )
+  `)
+
 export const getTradesCTE = ({
   cteName,
   category,

--- a/src/ports/nfts/landQueries.ts
+++ b/src/ports/nfts/landQueries.ts
@@ -138,8 +138,11 @@ function getOpenTradesCTE(filters: GetNFTsFilters): SQLStatement {
           OR ((assets->'received'->>'nft_id') IS NOT NULL))
         AND (((assets->'received'->>'amount') IS NOT NULL)
           OR ((assets->'sent'->>'amount') IS NOT NULL))`,
-    // Drop Estate sell orders left non-executable by the EstateRegistry upgrade.
-    getExcludeBrokenEstateTradesWhere(),
+    // Drop Estate sell orders left non-executable by the EstateRegistry upgrade,
+    // but only from the public browse feed. When the query is owner-scoped
+    // (My Assets), keep them so the owner still sees their now-invalid listing
+    // and knows to re-create it.
+    filters.owner ? null : getExcludeBrokenEstateTradesWhere(),
     FILTER_BY_MIN_TRADE_PRICE,
     FILTER_BY_MAX_TRADE_PRICE
   ])

--- a/src/ports/nfts/landQueries.ts
+++ b/src/ports/nfts/landQueries.ts
@@ -1,7 +1,7 @@
 import SQL, { SQLStatement } from 'sql-template-strings'
 import { NFTSortBy } from '@dcl/schemas'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
-import { getTradesCTE } from '../catalog/queries'
+import { getExcludeBrokenEstateTradesWhere, getTradesCTE } from '../catalog/queries'
 import { getWhereStatementFromFilters } from '../utils'
 import { getNFTLimitAndOffsetStatement } from './queries'
 import { GetNFTsFilters } from './types'
@@ -138,6 +138,8 @@ function getOpenTradesCTE(filters: GetNFTsFilters): SQLStatement {
           OR ((assets->'received'->>'nft_id') IS NOT NULL))
         AND (((assets->'received'->>'amount') IS NOT NULL)
           OR ((assets->'sent'->>'amount') IS NOT NULL))`,
+    // Drop Estate sell orders left non-executable by the EstateRegistry upgrade.
+    getExcludeBrokenEstateTradesWhere(),
     FILTER_BY_MIN_TRADE_PRICE,
     FILTER_BY_MAX_TRADE_PRICE
   ])

--- a/src/ports/orders/queries.ts
+++ b/src/ports/orders/queries.ts
@@ -2,7 +2,7 @@ import SQL, { SQLStatement } from 'sql-template-strings'
 import { OrderFilters, OrderSortBy } from '@dcl/schemas'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getDBNetworks } from '../../utils'
-import { getExcludeBrokenEstateTradesWhere, getTradesCTE } from '../catalog/queries'
+import { getTradesCTE } from '../catalog/queries'
 import { getWhereStatementFromFilters } from '../utils'
 
 function getOrdersSortByStatement(filters: OrderFilters): SQLStatement {
@@ -70,10 +70,10 @@ export function getTradesOrdersQuery(filters: OrderFilters & { nftIds?: string[]
       network
     FROM (`
       .append(SQL`SELECT * FROM unified_trades WHERE type = 'public_nft_order' AND status = 'open'`)
-      // Drop Estate sell orders left non-executable by the EstateRegistry upgrade so
-      // they are not surfaced as a buyable order (e.g. on the asset detail page).
-      .append(SQL` AND `)
-      .append(getExcludeBrokenEstateTradesWhere())
+      // NOTE: broken-by-upgrade Estate orders are intentionally NOT filtered here.
+      // This feeds the asset detail page / My Assets, where the owner must still
+      // see their now-invalid listing (and visitors get the on-page upgrade
+      // warning). They are only hidden from the public browse feed (see landQueries).
       .append(filters.nftIds ? SQL` AND sent_nft_id = ANY(${filters.nftIds})` : SQL``)
       .append(filters.owner ? SQL` AND signer = ${filters.owner.toLowerCase()}` : SQL``)
       .append(SQL`) as trades WHERE signer = assets -> 'sent' ->> 'owner'`)

--- a/src/ports/orders/queries.ts
+++ b/src/ports/orders/queries.ts
@@ -2,7 +2,7 @@ import SQL, { SQLStatement } from 'sql-template-strings'
 import { OrderFilters, OrderSortBy } from '@dcl/schemas'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getDBNetworks } from '../../utils'
-import { getTradesCTE } from '../catalog/queries'
+import { getExcludeBrokenEstateTradesWhere, getTradesCTE } from '../catalog/queries'
 import { getWhereStatementFromFilters } from '../utils'
 
 function getOrdersSortByStatement(filters: OrderFilters): SQLStatement {
@@ -45,7 +45,8 @@ function getInnerOrdersLimitAndOffsetStatement(filters: OrderFilters) {
 }
 
 export function getTradesOrdersQuery(filters: OrderFilters & { nftIds?: string[] }): SQLStatement {
-  return SQL`
+  return (
+    SQL`
     SELECT
       id::text,
       id::text as trade_id,
@@ -68,10 +69,15 @@ export function getTradesOrdersQuery(filters: OrderFilters & { nftIds?: string[]
       EXTRACT(EPOCH FROM expires_at) as expires_at,
       network
     FROM (`
-    .append(SQL`SELECT * FROM unified_trades WHERE type = 'public_nft_order' AND status = 'open'`)
-    .append(filters.nftIds ? SQL` AND sent_nft_id = ANY(${filters.nftIds})` : SQL``)
-    .append(filters.owner ? SQL` AND signer = ${filters.owner.toLowerCase()}` : SQL``)
-    .append(SQL`) as trades WHERE signer = assets -> 'sent' ->> 'owner'`)
+      .append(SQL`SELECT * FROM unified_trades WHERE type = 'public_nft_order' AND status = 'open'`)
+      // Drop Estate sell orders left non-executable by the EstateRegistry upgrade so
+      // they are not surfaced as a buyable order (e.g. on the asset detail page).
+      .append(SQL` AND `)
+      .append(getExcludeBrokenEstateTradesWhere())
+      .append(filters.nftIds ? SQL` AND sent_nft_id = ANY(${filters.nftIds})` : SQL``)
+      .append(filters.owner ? SQL` AND signer = ${filters.owner.toLowerCase()}` : SQL``)
+      .append(SQL`) as trades WHERE signer = assets -> 'sent' ->> 'owner'`)
+  )
 }
 
 export function getLegacyOrdersQuery(): string {


### PR DESCRIPTION
## Context

After the EstateRegistry `getFingerprint` (LR-XOR) → `getFingerprintV2` upgrade, off-chain Estate sell orders signed **before** the server started validating against `getFingerprintV2` carry a stale v1 fingerprint. For Estates > 18 LANDs the upgraded `verifyFingerprint` no longer honors that v1 value, so executing the order reverts on-chain — the listing is dead.

## Change

Hides those dead Estate sell orders **only from the public browse feed** (`/v1/nfts?isLand=true&isOnSale=true`), via a shared SQL guard `getExcludeBrokenEstateTradesWhere()` applied in `nfts/landQueries.ts → getOpenTradesCTE`, gated on the query NOT being owner-scoped:

```ts
filters.owner ? null : getExcludeBrokenEstateTradesWhere()
```

A `public_nft_order` is dropped only when **all** hold:
- sent asset category is `estate`
- the trade was signed before the v2-validation cutoff (`2026-05-20 13:37:12 UTC`, commit `9877d90`) — i.e. it carries a v1 fingerprint
- the Estate has > 18 LANDs (the contract's v1 fallback no longer applies)

### Intentionally NOT hidden

- **Owner-scoped queries (My Assets)** — `filters.owner` is set, so the owner still sees their now-invalid listing and knows to re-create it.
- **The orders endpoint / asset detail page** (`orders/queries.ts`) — no longer filtered, so the order is still returned. The owner (and visitors) see it with the on-page EstateUpgradeWarning; the webapp suppresses BUY and keeps MAKE OFFER available (decentraland/marketplace#2656). This avoids stranding the owner (they can cancel + re-list).
- **Legacy on-chain orders** — store no fingerprint at creation; the buyer supplies the current `getFingerprintV2` at `safeExecuteOrder`, so they remain executable and are untouched.

## Why a `created_at` cutoff (and not an on-chain comparison)

The live `getFingerprintV2` is on-chain and not available to the SQL layer (`mv_trades` is a materialized view, no RPC at refresh). The server already validates every **new** trade's fingerprint against `getFingerprintV2` at creation (since `9877d90`), so trades after the cutoff are v2-valid by construction; only older ones can be stale.

### Follow-ups / limitations

- Does not catch a trade valid at creation that later went stale because the Estate composition changed (rare; affects all sizes). A robust version would index per-listing fingerprint validity in the squid.
- The on-chain v1 fallback also expires for ≤18-LAND estates at `2026-11-26 15:00 UTC`. After that the size guard should be dropped (TODO in code).

## Companion change

The webapp's `isEstateListingAffectedByUpgrade` is being moved from a size-only heuristic to a per-listing check (using `order.createdAt`), so valid new large-Estate listings show BUY normally and the upgrade warning only appears on actually-broken listings. (Separate webapp PR.)

## Test plan

- [ ] Public browse (`/v1/nfts?isLand=true&isOnSale=true`, no owner): a pre-cutoff sell order on a >18-LAND Estate is NOT returned.
- [ ] Owner-scoped (`&owner=<seller>`): the same order IS returned.
- [ ] `/v1/orders?nftIds=<estate>`: the order IS returned (detail page).
- [ ] Post-cutoff sell order on a >18-LAND Estate: returned everywhere.
- [ ] Pre-cutoff sell order on a ≤18-LAND Estate: returned everywhere (v1 fallback still valid).
- [ ] Legacy on-chain orders and non-Estate listings: unaffected.