### PR TITLE
feat: usd-pegged trades support and v3 shop catalog endpoints

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -34,6 +34,7 @@ import { createPricesComponents } from './ports/prices'
 import { createRankingsComponent } from './ports/rankings/component'
 import { createRentalsComponent } from './ports/rentals/components'
 import { createSalesComponents } from './ports/sales'
+import { createShopCatalogComponent } from './ports/shop-catalog/component'
 import { createStatsComponent } from './ports/stats/component'
 import { createTradesComponent } from './ports/trades'
 import { createTransakComponent } from './ports/transak/component'
@@ -144,6 +145,7 @@ export async function initComponents(): Promise<AppComponents> {
 
   // catalog
   const catalog = await createCatalogComponent({ dappsDatabase: dappsReadDatabase, dappsWriteDatabase, picks }, SEGMENT_WRITE_KEY)
+  const shopCatalog = createShopCatalogComponent({ dappsDatabase: dappsReadDatabase, logs })
   const trades = await createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs })
   const bids = await createBidsComponents({ dappsDatabase: dappsReadDatabase })
   const nfts = await createNFTsComponent({ dappsDatabase: dappsReadDatabase, config, rentals })
@@ -197,6 +199,7 @@ export async function initComponents(): Promise<AppComponents> {
     dappsDatabase: dappsReadDatabase,
     dappsWriteDatabase,
     catalog,
+    shopCatalog,
     wertSigner,
     wertApi,
     ens,

--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -1,0 +1,71 @@
+import { IHttpServerComponent } from '@dcl/core-commons'
+import { Params } from '../../logic/http/params'
+import { asJSON } from '../../logic/http/response'
+import { ShopSortBy, SHOP_DEFAULT_PAGE_SIZE, SHOP_MAX_PAGE_SIZE } from '../../ports/shop-catalog/types'
+import { AppComponents, Context } from '../../types'
+
+const SORTS: ShopSortBy[] = ['newest', 'cheapest', 'most_expensive', 'name']
+
+function csv(value?: string): string[] | undefined {
+  const parts = value
+    ?.split(',')
+    .map(v => v.trim())
+    .filter(Boolean)
+  return parts && parts.length ? parts : undefined
+}
+
+// GET /v3/catalog/shop -- curated feed of credit-buyable (USD-pegged) listings for the Shop.
+export function createShopCatalogHandler(
+  components: Pick<AppComponents, 'shopCatalog'>
+): IHttpServerComponent.IRequestHandler<Context<'/v3/catalog/shop'>> {
+  const { shopCatalog } = components
+
+  return async context => {
+    const params = new Params(context.url.searchParams)
+    const first = Math.min(params.getNumber('first', SHOP_DEFAULT_PAGE_SIZE) ?? SHOP_DEFAULT_PAGE_SIZE, SHOP_MAX_PAGE_SIZE)
+    const skip = params.getNumber('skip', 0) ?? 0
+    const category = params.getString('category')
+    const contractAddress = params.getString('contractAddress')
+    const itemId = params.getString('itemId')
+    const rarities = csv(params.getString('rarity'))
+    const wearableCategories = csv(params.getString('wearableCategory'))
+    const minPriceCredits = params.getNumber('minPriceCredits')
+    const maxPriceCredits = params.getNumber('maxPriceCredits')
+    const search = params.getString('search')
+    const sortByRaw = params.getString('sortBy') as ShopSortBy | undefined
+    const sortBy = sortByRaw && SORTS.includes(sortByRaw) ? sortByRaw : undefined
+
+    return asJSON(async () => {
+      const { data, total } = await shopCatalog.getShopListings({
+        first,
+        skip,
+        category,
+        contractAddress,
+        itemId,
+        rarities,
+        wearableCategories,
+        minPriceCredits,
+        maxPriceCredits,
+        search,
+        sortBy
+      })
+      return { data, total }
+    })
+  }
+}
+
+// GET /v3/catalog/importable?seller=0x... -- a seller's OLD classic (MANA-priced) listings they can
+// import into the Shop. Public read (open orders are already public).
+export function createShopImportableHandler(
+  components: Pick<AppComponents, 'shopCatalog'>
+): IHttpServerComponent.IRequestHandler<Context<'/v3/catalog/importable'>> {
+  const { shopCatalog } = components
+
+  return async context => {
+    const seller = new Params(context.url.searchParams).getAddress('seller')
+    return asJSON(async () => {
+      if (!seller) return { data: [] }
+      return { data: await shopCatalog.getImportableListings(seller) }
+    })
+  }
+}

--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -4,7 +4,14 @@ import { asJSON } from '../../logic/http/response'
 import { ShopSortBy, SHOP_DEFAULT_PAGE_SIZE, SHOP_MAX_PAGE_SIZE } from '../../ports/shop-catalog/types'
 import { AppComponents, Context } from '../../types'
 
-const SORTS: ShopSortBy[] = ['newest', 'cheapest', 'most_expensive', 'name']
+// Valid sort values, as a map so Params.getValue can validate the query param against them (mirrors
+// how the catalog handler validates CatalogSortBy) and return undefined for anything unexpected.
+const SORT_VALUES: Record<ShopSortBy, ShopSortBy> = {
+  newest: 'newest',
+  cheapest: 'cheapest',
+  most_expensive: 'most_expensive',
+  name: 'name'
+}
 
 function csv(value?: string): string[] | undefined {
   const parts = value
@@ -32,8 +39,7 @@ export function createShopCatalogHandler(
     const minPriceCredits = params.getNumber('minPriceCredits')
     const maxPriceCredits = params.getNumber('maxPriceCredits')
     const search = params.getString('search')
-    const sortByRaw = params.getString('sortBy') as ShopSortBy | undefined
-    const sortBy = sortByRaw && SORTS.includes(sortByRaw) ? sortByRaw : undefined
+    const sortBy = params.getValue<ShopSortBy>('sortBy', SORT_VALUES)
 
     return asJSON(async () => {
       const { data, total } = await shopCatalog.getShopListings({

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -21,6 +21,7 @@ import { pingHandler } from './handlers/ping-handler'
 import { getPricesHandler } from './handlers/prices-handler'
 import { getRankingsHandler } from './handlers/rankings-handler'
 import { getSalesHandler } from './handlers/sales-handler'
+import { createShopCatalogHandler, createShopImportableHandler } from './handlers/shop-catalog-handler'
 import { getStatsHandler } from './handlers/stats-handler'
 import {
   addTradeHandler,
@@ -95,6 +96,9 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   )
   router.put('/v1/transak/access-token', bearerTokenMiddleware(transakAccessTokenAuth), refreshTransakAccessTokenHandler)
   router.get('/v1/ens/generate', createENSImageGeratorHandler)
+
+  router.get('/v3/catalog/shop', createShopCatalogHandler(components))
+  router.get('/v3/catalog/importable', createShopImportableHandler(components))
 
   router.get('/v1/trades', getTradesHandler)
   router.post(

--- a/src/logic/trades/utils.ts
+++ b/src/logic/trades/utils.ts
@@ -32,6 +32,7 @@ export function getValueFromTradeAsset(asset: TradeAsset) {
     case TradeAssetType.COLLECTION_ITEM:
       return asset.itemId
     case TradeAssetType.ERC20:
+    case TradeAssetType.USD_PEGGED_MANA:
       return asset.amount
     case TradeAssetType.ERC721:
       return asset.tokenId

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -79,13 +79,34 @@ function topLevelCategory(itemType: string | null): string {
   return itemType?.toLowerCase().startsWith('emote') ? 'emote' : 'wearable'
 }
 
+// A whole-credit price bound -> USD wei. Returns null for non-finite input (e.g. `?minPriceCredits=Infinity`,
+// which parseFloat accepts) so the caller can skip the filter instead of throwing on BigInt(Infinity).
+function creditsToWei(credits: number): bigint | null {
+  if (!Number.isFinite(credits)) return null
+  return BigInt(Math.max(0, Math.floor(credits))) * USD_WEI_PER_CREDIT
+}
+
+// Escape LIKE/ILIKE metacharacters so user input is matched literally (Postgres default escape is `\`).
+// The value is already bound as a parameter (no injection); this only stops `%`/`_` from turning a
+// search into an unbounded wildcard scan.
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&')
+}
+
+// Clamp a caller-supplied count to [min, max], flooring and falling back to `fallback` for
+// missing/non-finite input.
+function clampCount(value: number | undefined, fallback: number, min: number, max: number): number {
+  const n = Number.isFinite(value) ? Math.floor(value as number) : fallback
+  return Math.min(Math.max(n, min), max)
+}
+
 export function createShopCatalogComponent(components: Pick<AppComponents, 'dappsDatabase' | 'logs'>): IShopCatalogComponent {
   const { dappsDatabase: pg } = components
   const logger = components.logs.getLogger('shop-catalog-component')
 
   async function getShopListings(filters: ShopCatalogFilters): Promise<{ data: ShopListing[]; total: number }> {
-    const first = Math.min(Math.max(Math.floor(filters.first ?? SHOP_DEFAULT_PAGE_SIZE), SHOP_MIN_PAGE_SIZE), SHOP_MAX_PAGE_SIZE)
-    const skip = Math.max(Math.floor(filters.skip ?? 0), 0)
+    const first = clampCount(filters.first, SHOP_DEFAULT_PAGE_SIZE, SHOP_MIN_PAGE_SIZE, SHOP_MAX_PAGE_SIZE)
+    const skip = clampCount(filters.skip, 0, 0, Number.MAX_SAFE_INTEGER)
 
     const query = SQL`
       SELECT
@@ -142,13 +163,15 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
       )
     }
     if (filters.minPriceCredits != null) {
-      query.append(SQL` AND mv.amount_received >= ${(BigInt(Math.floor(filters.minPriceCredits)) * USD_WEI_PER_CREDIT).toString()}`)
+      const minWei = creditsToWei(filters.minPriceCredits)
+      if (minWei != null) query.append(SQL` AND mv.amount_received >= ${minWei.toString()}`)
     }
     if (filters.maxPriceCredits != null) {
-      query.append(SQL` AND mv.amount_received <= ${(BigInt(Math.floor(filters.maxPriceCredits)) * USD_WEI_PER_CREDIT).toString()}`)
+      const maxWei = creditsToWei(filters.maxPriceCredits)
+      if (maxWei != null) query.append(SQL` AND mv.amount_received <= ${maxWei.toString()}`)
     }
     if (filters.search) {
-      query.append(SQL` AND COALESCE(nft.name, w_p.name, e_p.name) ILIKE ${'%' + filters.search + '%'}`)
+      query.append(SQL` AND COALESCE(nft.name, w_p.name, e_p.name) ILIKE ${'%' + escapeLike(filters.search) + '%'}`)
     }
 
     // Sort (fixed expressions only -- never interpolate user input into ORDER BY).
@@ -232,7 +255,8 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
           SELECT 1 FROM marketplace.trade_assets ta
           WHERE ta.trade_id = mv.id AND ta.direction = 'received' AND ta.asset_type = ${ERC20_ASSET_TYPE}
         )
-      ORDER BY mv.created_at DESC`
+      ORDER BY mv.created_at DESC
+      LIMIT ${SHOP_MAX_PAGE_SIZE}`
       )
 
     const result = await pg.query<ImportableListingRow>(query)

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -1,0 +1,264 @@
+import SQL from 'sql-template-strings'
+import { Network, TradeAssetType } from '@dcl/schemas'
+import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
+import { getEthereumChainId, getPolygonChainId } from '../../logic/chainIds'
+import { AppComponents } from '../../types'
+import {
+  IShopCatalogComponent,
+  ImportableListing,
+  ImportableListingRow,
+  ShopCatalogFilters,
+  ShopListing,
+  ShopListingRow,
+  SHOP_DEFAULT_PAGE_SIZE,
+  SHOP_MAX_PAGE_SIZE,
+  SHOP_MIN_PAGE_SIZE
+} from './types'
+
+// The received-asset type that marks a credit-buyable (Shop) listing, as opposed to a classic
+// ERC20-MANA one. Sourced from @dcl/schemas so it stays in lockstep with the on-chain encoding.
+const USD_PEGGED_ASSET_TYPE = TradeAssetType.USD_PEGGED_MANA
+// A classic MANA-priced received asset: a listing that predates the Shop and can be imported.
+const ERC20_ASSET_TYPE = TradeAssetType.ERC20
+
+// The shared FROM + metadata joins used by the shop feed + the import feed. Resolves item metadata
+// for primary (item_p -> wearable/emote) and secondary (nft + item_s) listings.
+function metadataJoins() {
+  const s = MARKETPLACE_SQUID_SCHEMA
+  return SQL`FROM marketplace.mv_trades mv
+      LEFT JOIN `
+    .append(s)
+    .append(
+      SQL`.item item_p ON mv.type = 'public_item_order'
+        AND item_p.collection_id = mv.sent_contract_address
+        AND item_p.blockchain_id = mv.sent_item_id::numeric
+      LEFT JOIN `
+    )
+    .append(s)
+    .append(
+      SQL`.metadata meta_p ON meta_p.id = item_p.metadata_id
+      LEFT JOIN `
+    )
+    .append(s)
+    .append(
+      SQL`.wearable w_p ON w_p.id = meta_p.wearable_id
+      LEFT JOIN `
+    )
+    .append(s)
+    .append(
+      SQL`.emote e_p ON e_p.id = meta_p.emote_id
+      LEFT JOIN `
+    )
+    .append(s)
+    .append(
+      SQL`.nft nft ON mv.type = 'public_nft_order' AND nft.id = mv.sent_nft_id
+      LEFT JOIN `
+    )
+    .append(s)
+    .append(SQL`.item item_s ON mv.type = 'public_nft_order' AND item_s.id = nft.item_id`)
+}
+
+// 1 credit = $0.10; $1 = 1e18 USD wei = 10 credits, so 1 credit = 1e17 USD wei.
+const USD_WEI_PER_CREDIT = 100000000000000000n
+
+// Shop listings are created at whole-credit prices, so amount_received is expected to be an exact
+// multiple of USD_WEI_PER_CREDIT. We round UP (ceil) as a defensive measure: a non-conforming price
+// can then never be advertised for less than it would settle at on-chain. A non-positive or
+// unparseable amount yields null so the caller can drop the row instead of advertising a free item.
+function toCredits(usdWei: string): number | null {
+  try {
+    const wei = BigInt(usdWei)
+    if (wei <= 0n) return null
+    return Number((wei + USD_WEI_PER_CREDIT - 1n) / USD_WEI_PER_CREDIT)
+  } catch {
+    return null
+  }
+}
+
+function topLevelCategory(itemType: string | null): string {
+  return itemType?.toLowerCase().startsWith('emote') ? 'emote' : 'wearable'
+}
+
+export function createShopCatalogComponent(components: Pick<AppComponents, 'dappsDatabase' | 'logs'>): IShopCatalogComponent {
+  const { dappsDatabase: pg } = components
+  const logger = components.logs.getLogger('shop-catalog-component')
+
+  async function getShopListings(filters: ShopCatalogFilters): Promise<{ data: ShopListing[]; total: number }> {
+    const first = Math.min(Math.max(Math.floor(filters.first ?? SHOP_DEFAULT_PAGE_SIZE), SHOP_MIN_PAGE_SIZE), SHOP_MAX_PAGE_SIZE)
+    const skip = Math.max(Math.floor(filters.skip ?? 0), 0)
+
+    const query = SQL`
+      SELECT
+        mv.id AS trade_id,
+        mv.type AS trade_type,
+        mv.sent_contract_address AS contract_address,
+        mv.sent_item_id AS item_id,
+        mv.sent_token_id AS token_id,
+        COALESCE(nft.name, w_p.name, e_p.name) AS name,
+        COALESCE(nft.image, item_p.image, item_s.image) AS image,
+        COALESCE(item_p.rarity, item_s.rarity, nft.search_wearable_rarity) AS rarity,
+        COALESCE(item_p.item_type, item_s.item_type, nft.item_type) AS item_type,
+        COALESCE(
+          item_p.search_wearable_category, item_p.search_emote_category,
+          item_s.search_wearable_category, item_s.search_emote_category
+        ) AS wearable_category,
+        COALESCE(item_p.creator, item_s.creator, '') AS creator,
+        mv.amount_received::text AS price,
+        mv.available::text AS available,
+        mv.network AS network,
+        EXTRACT(EPOCH FROM mv.created_at)::bigint * 1000 AS created_at,
+        COUNT(*) OVER() AS total
+      `.append(metadataJoins()).append(SQL`
+      WHERE mv.status = 'open'
+        AND (mv.available IS NULL OR mv.available > 0)
+        AND EXISTS (
+          SELECT 1 FROM marketplace.trade_assets ta
+          WHERE ta.trade_id = mv.id AND ta.direction = 'received' AND ta.asset_type = ${USD_PEGGED_ASSET_TYPE}
+        )`)
+
+    if (filters.contractAddress) {
+      query.append(SQL` AND mv.sent_contract_address = ${filters.contractAddress.toLowerCase()}`)
+    }
+    if (filters.itemId != null) {
+      query.append(SQL` AND mv.sent_item_id = ${filters.itemId}`)
+    }
+    if (filters.category === 'emote') {
+      query.append(SQL` AND COALESCE(item_p.item_type, item_s.item_type, nft.item_type) ILIKE 'emote%'`)
+    } else if (filters.category === 'wearable') {
+      query.append(SQL` AND COALESCE(item_p.item_type, item_s.item_type, nft.item_type) NOT ILIKE 'emote%'`)
+    }
+    if (filters.rarities?.length) {
+      query.append(
+        SQL` AND lower(COALESCE(item_p.rarity, item_s.rarity, nft.search_wearable_rarity)) = ANY(${filters.rarities.map(r =>
+          r.toLowerCase()
+        )})`
+      )
+    }
+    if (filters.wearableCategories?.length) {
+      query.append(
+        SQL` AND lower(COALESCE(item_p.search_wearable_category, item_s.search_wearable_category, item_p.search_emote_category, item_s.search_emote_category)) = ANY(${filters.wearableCategories.map(
+          c => c.toLowerCase()
+        )})`
+      )
+    }
+    if (filters.minPriceCredits != null) {
+      query.append(SQL` AND mv.amount_received >= ${(BigInt(Math.floor(filters.minPriceCredits)) * USD_WEI_PER_CREDIT).toString()}`)
+    }
+    if (filters.maxPriceCredits != null) {
+      query.append(SQL` AND mv.amount_received <= ${(BigInt(Math.floor(filters.maxPriceCredits)) * USD_WEI_PER_CREDIT).toString()}`)
+    }
+    if (filters.search) {
+      query.append(SQL` AND COALESCE(nft.name, w_p.name, e_p.name) ILIKE ${'%' + filters.search + '%'}`)
+    }
+
+    // Sort (fixed expressions only -- never interpolate user input into ORDER BY).
+    const order =
+      filters.sortBy === 'cheapest'
+        ? SQL` ORDER BY mv.amount_received ASC`
+        : filters.sortBy === 'most_expensive'
+        ? SQL` ORDER BY mv.amount_received DESC`
+        : filters.sortBy === 'name'
+        ? SQL` ORDER BY COALESCE(nft.name, w_p.name, e_p.name) ASC`
+        : SQL` ORDER BY mv.created_at DESC`
+    query.append(order).append(SQL` LIMIT ${first} OFFSET ${skip}`)
+
+    const result = await pg.query<ShopListingRow>(query)
+    const polygonChainId = getPolygonChainId()
+    const ethereumChainId = getEthereumChainId()
+    const total = result.rows[0] ? Number(result.rows[0].total) : 0
+
+    const data: ShopListing[] = []
+    for (const r of result.rows) {
+      const priceCredits = toCredits(r.price)
+      if (priceCredits === null) {
+        logger.warn('Dropping shop listing with non-positive or unparseable price', { tradeId: r.trade_id, price: r.price })
+        continue
+      }
+      const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
+      data.push({
+        tradeId: r.trade_id,
+        listingType: r.trade_type === 'public_item_order' ? 'primary' : 'secondary',
+        contractAddress: r.contract_address,
+        itemId: r.item_id,
+        tokenId: r.token_id,
+        name: r.name ?? '',
+        thumbnail: r.image ?? '',
+        rarity: (r.rarity ?? 'common').toLowerCase(),
+        category: topLevelCategory(r.item_type),
+        wearableCategory: r.wearable_category,
+        creator: r.creator ?? '',
+        priceCredits,
+        available: r.available ? Number(r.available) : 1,
+        network: isPolygon ? Network.MATIC : Network.ETHEREUM,
+        chainId: isPolygon ? polygonChainId : ethereumChainId,
+        createdAt: Number(r.created_at)
+      })
+    }
+
+    return { data, total }
+  }
+
+  // A seller's OPEN classic (ERC20-MANA) listings -- the "old liquidity" they can import into the
+  // Shop. Both primary (public_item_order) and secondary (public_nft_order). Price is returned raw
+  // (MANA wei); the client converts to credits via the oracle. USD-pegged ones are excluded (they're
+  // already in the Shop).
+  async function getImportableListings(seller: string): Promise<ImportableListing[]> {
+    const query = SQL`
+      SELECT
+        mv.id AS old_trade_id,
+        mv.type AS trade_type,
+        mv.sent_contract_address AS contract_address,
+        mv.sent_item_id AS item_id,
+        mv.sent_token_id AS token_id,
+        COALESCE(nft.name, w_p.name, e_p.name) AS name,
+        COALESCE(nft.image, item_p.image, item_s.image) AS image,
+        COALESCE(item_p.rarity, item_s.rarity, nft.search_wearable_rarity) AS rarity,
+        COALESCE(item_p.item_type, item_s.item_type, nft.item_type) AS item_type,
+        COALESCE(
+          item_p.search_wearable_category, item_p.search_emote_category,
+          item_s.search_wearable_category, item_s.search_emote_category
+        ) AS wearable_category,
+        mv.amount_received::text AS mana_wei,
+        mv.available::text AS available,
+        mv.network AS network
+      `
+      .append(metadataJoins())
+      .append(
+        SQL`
+      WHERE mv.status = 'open'
+        AND (mv.available IS NULL OR mv.available > 0)
+        AND lower(mv.signer) = ${seller.toLowerCase()}
+        AND EXISTS (
+          SELECT 1 FROM marketplace.trade_assets ta
+          WHERE ta.trade_id = mv.id AND ta.direction = 'received' AND ta.asset_type = ${ERC20_ASSET_TYPE}
+        )
+      ORDER BY mv.created_at DESC`
+      )
+
+    const result = await pg.query<ImportableListingRow>(query)
+    const polygonChainId = getPolygonChainId()
+    const ethereumChainId = getEthereumChainId()
+
+    return result.rows.map(r => {
+      const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
+      return {
+        oldTradeId: r.old_trade_id,
+        listingType: r.trade_type === 'public_item_order' ? 'primary' : 'secondary',
+        contractAddress: r.contract_address,
+        itemId: r.item_id,
+        tokenId: r.token_id,
+        name: r.name ?? '',
+        thumbnail: r.image ?? '',
+        rarity: (r.rarity ?? 'common').toLowerCase(),
+        category: topLevelCategory(r.item_type),
+        wearableCategory: r.wearable_category,
+        manaWei: r.mana_wei,
+        available: r.available ? Number(r.available) : 1,
+        network: isPolygon ? Network.MATIC : Network.ETHEREUM,
+        chainId: isPolygon ? polygonChainId : ethereumChainId
+      }
+    })
+  }
+
+  return { getShopListings, getImportableListings }
+}

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -1,0 +1,105 @@
+// The Shop's curated read model: only credit-buyable (USD-pegged) offchain listings, unified across
+// primary (public_item_order) and secondary (public_nft_order), with the tradeId included so the
+// client can buy/cancel without a second lookup. Lighter than /v2/catalog (no owners/picks/etc.).
+
+// Pagination bounds, shared by the handler (parses the request) and the component (clamps defensively).
+export const SHOP_DEFAULT_PAGE_SIZE = 48
+export const SHOP_MIN_PAGE_SIZE = 1
+export const SHOP_MAX_PAGE_SIZE = 1000
+
+export type ShopListingType = 'primary' | 'secondary'
+
+export type ShopListing = {
+  tradeId: string
+  listingType: ShopListingType
+  contractAddress: string
+  itemId: string | null // primary (mint) listings
+  tokenId: string | null // secondary (resale) listings
+  name: string
+  thumbnail: string
+  rarity: string
+  category: string // top-level: 'wearable' | 'emote'
+  wearableCategory: string | null // on-chain category (upper_body, hat, ...) when applicable
+  creator: string
+  priceCredits: number // USD -> fixed credits (1 credit = $0.10)
+  available: number
+  network: string
+  chainId: number
+  createdAt: number
+}
+
+export type ShopSortBy = 'newest' | 'cheapest' | 'most_expensive' | 'name'
+
+export type ShopCatalogFilters = {
+  first?: number
+  skip?: number
+  category?: string // 'wearable' | 'emote'
+  contractAddress?: string
+  itemId?: string
+  rarities?: string[]
+  wearableCategories?: string[] // on-chain categories (upper_body, hat, ...)
+  minPriceCredits?: number
+  maxPriceCredits?: number
+  search?: string
+  sortBy?: ShopSortBy
+}
+
+// A seller's OLD classic (ERC20-MANA) listing that can be re-listed into the Shop as credit-buyable.
+// Carries the raw MANA price (client converts to credits via the oracle) + the old trade id.
+export type ImportableListing = {
+  oldTradeId: string
+  listingType: ShopListingType
+  contractAddress: string
+  itemId: string | null
+  tokenId: string | null
+  name: string
+  thumbnail: string
+  rarity: string
+  category: string
+  wearableCategory: string | null
+  manaWei: string
+  available: number
+  network: string
+  chainId: number
+}
+
+export interface IShopCatalogComponent {
+  getShopListings(filters: ShopCatalogFilters): Promise<{ data: ShopListing[]; total: number }>
+  getImportableListings(seller: string): Promise<ImportableListing[]>
+}
+
+export type ImportableListingRow = {
+  old_trade_id: string
+  trade_type: string
+  contract_address: string
+  item_id: string | null
+  token_id: string | null
+  name: string | null
+  image: string | null
+  rarity: string | null
+  item_type: string | null
+  wearable_category: string | null
+  mana_wei: string
+  available: string | null
+  network: string | null
+}
+
+// Raw DB row (before mapping to ShopListing).
+export type ShopListingRow = {
+  trade_id: string
+  trade_type: string
+  contract_address: string
+  item_id: string | null
+  token_id: string | null
+  name: string | null
+  image: string | null
+  rarity: string | null
+  item_type: string | null
+  wearable_category: string | null
+  creator: string | null
+  price: string
+  available: string | null
+  network: string | null
+  created_at: string
+  total: string
+}

--- a/src/ports/trades/queries.ts
+++ b/src/ports/trades/queries.ts
@@ -70,6 +70,7 @@ export function getInsertTradeAssetValueByTypeQuery(asset: TradeAsset | TradeAss
           ${asset.tokenId}
         ) RETURNING *;`
     case TradeAssetType.ERC20:
+    case TradeAssetType.USD_PEGGED_MANA:
       return SQL`INSERT INTO marketplace.trade_assets_erc20 (
         asset_id,
         amount

--- a/src/ports/trades/schemas.ts
+++ b/src/ports/trades/schemas.ts
@@ -5,7 +5,7 @@ export const BaseTradeAssetSchema: JSONSchema<BaseTradeAsset> = {
   properties: {
     assetType: {
       type: 'integer',
-      enum: [TradeAssetType.ERC20, TradeAssetType.ERC721, TradeAssetType.COLLECTION_ITEM]
+      enum: [TradeAssetType.ERC20, TradeAssetType.USD_PEGGED_MANA, TradeAssetType.ERC721, TradeAssetType.COLLECTION_ITEM]
     },
     contractAddress: {
       type: 'string',
@@ -25,6 +25,14 @@ export const TradeCreationAssetSchema: JSONSchema<TradeAsset> = {
       properties: {
         ...BaseTradeAssetSchema.properties,
         assetType: { const: TradeAssetType.ERC20 },
+        amount: { type: 'string', pattern: '^(0|[1-9][0-9]*)$' }
+      },
+      required: [...BaseTradeAssetSchema.required, 'amount']
+    },
+    {
+      properties: {
+        ...BaseTradeAssetSchema.properties,
+        assetType: { const: TradeAssetType.USD_PEGGED_MANA },
         amount: { type: 'string', pattern: '^(0|[1-9][0-9]*)$' }
       },
       required: [...BaseTradeAssetSchema.required, 'amount']

--- a/src/ports/trades/utils.ts
+++ b/src/ports/trades/utils.ts
@@ -8,6 +8,7 @@ import {
   TradeAsset,
   ERC721TradeAsset,
   CollectionItemTradeAsset,
+  USDPeggedManaTradeAsset,
   ListingStatus,
   Event,
   ChainId
@@ -39,6 +40,15 @@ export function isERC721TradeAsset(asset: TradeAsset): asset is ERC721TradeAsset
 
 export function isCollectionItemTradeAsset(asset: TradeAsset): asset is CollectionItemTradeAsset {
   return asset.assetType === TradeAssetType.COLLECTION_ITEM
+}
+
+export function isUSDPeggedManaTradeAsset(asset: TradeAsset): asset is USDPeggedManaTradeAsset {
+  return asset.assetType === TradeAssetType.USD_PEGGED_MANA
+}
+
+// The price side of a listing/bid can be paid in MANA (ERC20) or as a USD-pegged amount settled in MANA at execution.
+export function isPriceTradeAsset(asset: TradeAsset): asset is ERC20TradeAsset | USDPeggedManaTradeAsset {
+  return isERC20TradeAsset(asset) || isUSDPeggedManaTradeAsset(asset)
 }
 
 function isBytesEmpty(bytes: string): boolean {
@@ -79,9 +89,9 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
       // validate bid structure
       const receivesERC721OrItemAsset =
         received.length === 1 && (isERC721TradeAsset(received[0]) || isCollectionItemTradeAsset(received[0]))
-      const sendsERC20Asset = sent.length === 1 && isERC20TradeAsset(sent[0])
+      const sendsPriceAsset = sent.length === 1 && isPriceTradeAsset(sent[0])
 
-      if (!receivesERC721OrItemAsset || !sendsERC20Asset) {
+      if (!receivesERC721OrItemAsset || !sendsPriceAsset) {
         throw new InvalidTradeStructureError(type)
       }
 
@@ -102,9 +112,9 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
 
     if (trade.type === TradeType.PUBLIC_NFT_ORDER) {
       const sendsERC721Asset = sent.length === 1 && isERC721TradeAsset(sent[0])
-      const receivesERC20Asset = received.length === 1 && isERC20TradeAsset(received[0])
+      const receivesPriceAsset = received.length === 1 && isPriceTradeAsset(received[0])
 
-      if (!sendsERC721Asset || !receivesERC20Asset) {
+      if (!sendsERC721Asset || !receivesPriceAsset) {
         throw new InvalidTradeStructureError(trade.type)
       }
 
@@ -123,9 +133,9 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
 
     if (trade.type === TradeType.PUBLIC_ITEM_ORDER) {
       const sendsCollectionItemAsset = sent.length === 1 && isCollectionItemTradeAsset(sent[0])
-      const receivesERC20Asset = received.length === 1 && isERC20TradeAsset(received[0])
+      const receivesPriceAsset = received.length === 1 && isPriceTradeAsset(received[0])
 
-      if (!sendsCollectionItemAsset || !receivesERC20Asset) {
+      if (!sendsCollectionItemAsset || !receivesPriceAsset) {
         throw new InvalidTradeStructureError(trade.type)
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ import { IPricesComponent } from './ports/prices'
 import { IItemsDayDataComponent } from './ports/rankings/types'
 import { IRentalsComponent } from './ports/rentals/types'
 import { ISalesComponent } from './ports/sales'
+import { IShopCatalogComponent } from './ports/shop-catalog/types'
 import { IStatsComponent } from './ports/stats/types'
 import { ITradesComponent } from './ports/trades/types'
 import { ITransakComponent } from './ports/transak/types'
@@ -52,6 +53,7 @@ export type BaseComponents = {
   dappsDatabase: IPgComponent
   dappsWriteDatabase: IPgComponent
   catalog: ICatalogComponent
+  shopCatalog: IShopCatalogComponent
   wertSigner: IWertSignerComponent
   wertApi: IWertApiComponent
   transak: ITransakComponent

--- a/test/components.ts
+++ b/test/components.ts
@@ -36,6 +36,7 @@ import { createPricesComponents } from '../src/ports/prices'
 import { createRankingsComponent } from '../src/ports/rankings/component'
 import { createRentalsComponent } from '../src/ports/rentals/components'
 import { createSalesComponents } from '../src/ports/sales'
+import { createShopCatalogComponent } from '../src/ports/shop-catalog/component'
 import { createStatsComponent } from '../src/ports/stats/component'
 import { createTradesComponent } from '../src/ports/trades'
 import { createTransakComponent } from '../src/ports/transak/component'
@@ -113,6 +114,7 @@ async function initComponents(): Promise<TestComponents> {
   const access = createAccessComponent({ favoritesDatabase, logs, lists })
   const picks = createPicksComponent({ favoritesDatabase, items, snapshot, logs, lists })
   const catalog = await createCatalogComponent({ dappsDatabase: dappsReadDatabase, dappsWriteDatabase, picks }, SEGMENT_WRITE_KEY)
+  const shopCatalog = createShopCatalogComponent({ dappsDatabase: dappsReadDatabase, logs })
   const schemaValidator = await createSchemaValidatorComponent()
   const trades = createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs })
   const bids = createBidsComponents({ dappsDatabase: dappsReadDatabase })
@@ -171,6 +173,7 @@ async function initComponents(): Promise<TestComponents> {
     dappsWriteDatabase,
     favoritesDatabase,
     catalog,
+    shopCatalog,
     wertSigner,
     wertApi,
     ens,

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -1,0 +1,195 @@
+import { createShopCatalogComponent } from '../../src/ports/shop-catalog/component'
+import { IShopCatalogComponent } from '../../src/ports/shop-catalog/types'
+
+// 1 credit = $0.10 = 1e17 USD wei.
+const WEI_PER_CREDIT = 100000000000000000n
+
+function shopRow(overrides: Record<string, unknown> = {}) {
+  return {
+    trade_id: 'trade-1',
+    trade_type: 'public_item_order',
+    contract_address: '0xcollection',
+    item_id: '3',
+    token_id: null,
+    name: 'Cool Hat',
+    image: 'ipfs://hat.png',
+    rarity: 'RARE',
+    item_type: 'wearable_v2',
+    wearable_category: 'hat',
+    creator: '0xcreator',
+    price: (5n * WEI_PER_CREDIT).toString(),
+    available: '10',
+    network: 'MATIC',
+    created_at: '1700000000000',
+    total: '1',
+    ...overrides
+  }
+}
+
+describe('Shop Catalog Component', () => {
+  let shopCatalog: IShopCatalogComponent
+  let query: jest.Mock
+  let warn: jest.Mock
+
+  beforeEach(() => {
+    query = jest.fn()
+    warn = jest.fn()
+    const components = {
+      dappsDatabase: { query },
+      logs: { getLogger: jest.fn().mockReturnValue({ warn, info: jest.fn(), error: jest.fn(), debug: jest.fn() }) }
+    } as any
+    shopCatalog = createShopCatalogComponent(components)
+  })
+
+  describe('when converting a listing price to credits', () => {
+    it('should map an exact whole-credit price straight through', async () => {
+      query.mockResolvedValueOnce({ rows: [shopRow({ price: (5n * WEI_PER_CREDIT).toString() })] })
+
+      const { data } = await shopCatalog.getShopListings({})
+
+      expect(data[0].priceCredits).toBe(5)
+    })
+
+    it('should round a fractional-credit price UP so it never under-states the settlement amount', async () => {
+      // $1.55 -> 1_550_000_000_000_000_000 wei -> 15.5 credits -> ceil 16.
+      query.mockResolvedValueOnce({ rows: [shopRow({ price: '1550000000000000000' })] })
+
+      const { data } = await shopCatalog.getShopListings({})
+
+      expect(data[0].priceCredits).toBe(16)
+    })
+
+    it('should drop listings with a non-positive or unparseable price instead of advertising a free item', async () => {
+      query.mockResolvedValueOnce({
+        rows: [
+          shopRow({ trade_id: 'ok', price: (2n * WEI_PER_CREDIT).toString(), total: '3' }),
+          shopRow({ trade_id: 'zero', price: '0', total: '3' }),
+          shopRow({ trade_id: 'nan', price: 'not-a-number', total: '3' })
+        ]
+      })
+
+      const { data, total } = await shopCatalog.getShopListings({})
+
+      expect(data).toHaveLength(1)
+      expect(data[0].tradeId).toBe('ok')
+      // total comes from COUNT(*) OVER() and is not reduced by dropped rows.
+      expect(total).toBe(3)
+      expect(warn).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('when mapping a listing row', () => {
+    it('should lowercase the rarity and tag primary/secondary from the trade type', async () => {
+      query.mockResolvedValueOnce({
+        rows: [shopRow({ rarity: 'MYTHIC', trade_type: 'public_nft_order', token_id: '99', item_id: null })]
+      })
+
+      const { data } = await shopCatalog.getShopListings({})
+
+      expect(data[0]).toMatchObject({ rarity: 'mythic', listingType: 'secondary', tokenId: '99' })
+    })
+  })
+
+  describe('when building the shop listings query', () => {
+    beforeEach(() => {
+      query.mockResolvedValue({ rows: [] })
+    })
+
+    it('should only include USD-pegged (asset_type = 2) received assets', async () => {
+      await shopCatalog.getShopListings({})
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain("ta.direction = 'received' AND ta.asset_type =")
+      expect(sql.values).toContain(2)
+    })
+
+    it('should clamp pagination to the default page size and a zero offset', async () => {
+      await shopCatalog.getShopListings({})
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('LIMIT')
+      expect(sql.text).toContain('OFFSET')
+      expect(sql.values).toEqual(expect.arrayContaining([48, 0]))
+    })
+
+    it('should clamp an oversized page size to the maximum and floor non-integers', async () => {
+      await shopCatalog.getShopListings({ first: 99999, skip: 10.7 })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.values).toEqual(expect.arrayContaining([1000, 10]))
+    })
+
+    it('should never place a user-supplied sort value into the SQL text', async () => {
+      await shopCatalog.getShopListings({ sortBy: 'cheapest' })
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY mv.amount_received ASC')
+
+      query.mockClear()
+      await shopCatalog.getShopListings({})
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY mv.created_at DESC')
+    })
+
+    it('should bind a name search as a parameterized ILIKE', async () => {
+      await shopCatalog.getShopListings({ search: 'Cool' })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('ILIKE')
+      expect(sql.values).toContain('%Cool%')
+    })
+
+    it('should lowercase rarities and bind them as an array', async () => {
+      await shopCatalog.getShopListings({ rarities: ['Rare', 'EPIC'] })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('lower(COALESCE(item_p.rarity, item_s.rarity, nft.search_wearable_rarity)) = ANY(')
+      expect(sql.values).toContainEqual(['rare', 'epic'])
+    })
+
+    it('should lowercase wearable categories on both sides of the comparison', async () => {
+      await shopCatalog.getShopListings({ wearableCategories: ['Upper_Body', 'HAT'] })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('lower(COALESCE(item_p.search_wearable_category')
+      expect(sql.values).toContainEqual(['upper_body', 'hat'])
+    })
+
+    it('should translate credit price bounds into USD wei', async () => {
+      await shopCatalog.getShopListings({ minPriceCredits: 3, maxPriceCredits: 10 })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.values).toContain((3n * WEI_PER_CREDIT).toString())
+      expect(sql.values).toContain((10n * WEI_PER_CREDIT).toString())
+    })
+  })
+
+  describe('when fetching a seller importable listings', () => {
+    it('should only include classic ERC20 (asset_type = 1) listings for the lowercased seller', async () => {
+      query.mockResolvedValueOnce({
+        rows: [
+          {
+            old_trade_id: 'old-1',
+            trade_type: 'public_item_order',
+            contract_address: '0xcollection',
+            item_id: '3',
+            token_id: null,
+            name: 'Legacy Hat',
+            image: 'ipfs://hat.png',
+            rarity: 'rare',
+            item_type: 'wearable_v2',
+            wearable_category: 'hat',
+            mana_wei: '1000000000000000000',
+            available: '1',
+            network: 'MATIC'
+          }
+        ]
+      })
+
+      const data = await shopCatalog.getImportableListings('0xABCDEF')
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('lower(mv.signer) =')
+      expect(sql.values).toContain('0xabcdef')
+      expect(sql.values).toContain(1)
+      expect(data[0]).toMatchObject({ oldTradeId: 'old-1', manaWei: '1000000000000000000', listingType: 'primary' })
+    })
+  })
+})

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -159,6 +159,22 @@ describe('Shop Catalog Component', () => {
       expect(sql.values).toContain((3n * WEI_PER_CREDIT).toString())
       expect(sql.values).toContain((10n * WEI_PER_CREDIT).toString())
     })
+
+    it('should ignore a non-finite price bound instead of throwing on BigInt(Infinity)', async () => {
+      await expect(shopCatalog.getShopListings({ minPriceCredits: Infinity, maxPriceCredits: Infinity })).resolves.toBeDefined()
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).not.toContain('mv.amount_received >=')
+      expect(sql.text).not.toContain('mv.amount_received <=')
+    })
+
+    it('should escape ILIKE wildcards in the search term', async () => {
+      await shopCatalog.getShopListings({ search: '50%_off' })
+
+      const sql = query.mock.calls[0][0]
+      // % and _ are escaped so they match literally instead of acting as wildcards.
+      expect(sql.values).toContain('%50\\%\\_off%')
+    })
   })
 
   describe('when fetching a seller importable listings', () => {
@@ -187,6 +203,7 @@ describe('Shop Catalog Component', () => {
 
       const sql = query.mock.calls[0][0]
       expect(sql.text).toContain('lower(mv.signer) =')
+      expect(sql.text).toContain('LIMIT')
       expect(sql.values).toContain('0xabcdef')
       expect(sql.values).toContain(1)
       expect(data[0]).toMatchObject({ oldTradeId: 'old-1', manaWei: '1000000000000000000', listingType: 'primary' })

--- a/test/unit/trades-logic.spec.ts
+++ b/test/unit/trades-logic.spec.ts
@@ -208,3 +208,18 @@ describe('when validating the estate signature', () => {
     })
   })
 })
+
+describe('when getting the value from a trade asset', () => {
+  describe('and the asset is a USD-pegged MANA asset', () => {
+    it('should return the amount', () => {
+      expect(
+        getValueFromTradeAsset({
+          assetType: TradeAssetType.USD_PEGGED_MANA,
+          contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+          amount: '1000000000000000000',
+          extra: '0x'
+        })
+      ).toBe('1000000000000000000')
+    })
+  })
+})

--- a/test/unit/trades-utils.spec.ts
+++ b/test/unit/trades-utils.spec.ts
@@ -652,6 +652,33 @@ describe('when validating trade by type', () => {
         return expect(validateTradeByType(trade, pgClient)).resolves.toBe(true)
       })
     })
+
+    describe('and the received asset is a USD-pegged MANA asset', () => {
+      beforeEach(() => {
+        trade.received = [
+          {
+            assetType: TradeAssetType.USD_PEGGED_MANA,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
+            amount: '100',
+            extra: '0x',
+            beneficiary: '0x123'
+          }
+        ]
+
+        trade.sent = [
+          {
+            assetType: TradeAssetType.ERC721,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            tokenId: '100',
+            extra: '0x'
+          }
+        ]
+      })
+
+      it('should return true', () => {
+        return expect(validateTradeByType(trade, pgClient)).resolves.toBe(true)
+      })
+    })
   })
 
   describe('when trade is a public item order', () => {
@@ -747,6 +774,33 @@ describe('when validating trade by type', () => {
         trade.received = [
           {
             assetType: TradeAssetType.ERC20,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
+            amount: '100',
+            extra: '0x',
+            beneficiary: '0x123'
+          }
+        ]
+
+        trade.sent = [
+          {
+            assetType: TradeAssetType.COLLECTION_ITEM,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            itemId: '1',
+            extra: '0x'
+          }
+        ]
+      })
+
+      it('should return true', () => {
+        return expect(validateTradeByType(trade, pgClient)).resolves.toBe(true)
+      })
+    })
+
+    describe('and the received asset is a USD-pegged MANA asset', () => {
+      beforeEach(() => {
+        trade.received = [
+          {
+            assetType: TradeAssetType.USD_PEGGED_MANA,
             contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
             amount: '100',
             extra: '0x',


### PR DESCRIPTION
## What

Adds the marketplace-server backend the new **Shop** storefront needs:

1. **USD-pegged MANA trade assets** — trades can now carry a received asset of type `USD_PEGGED_MANA` (`asset_type = 2`) in addition to classic `ERC20` MANA (`asset_type = 1`). The schema, type guards, price-asset helpers and insert/value paths route a USD-pegged price through the same code as an ERC20 price (both are `{ amount: string }`), so the existing offchain-trade machinery keeps working unchanged.

2. **Two v3 catalog endpoints** consumed by the Shop:
   - `GET /v3/catalog/shop` — the curated feed of credit-buyable (USD-pegged) listings, unified across primary (`public_item_order`) and secondary (`public_nft_order`) offers, each with its `tradeId` so the client can buy/cancel without a second lookup. Supports the storefront filters (category, rarity, wearable category, price range in credits, text search) and sorts (newest, cheapest, most expensive, name).
   - `GET /v3/catalog/importable?seller=0x…` — a seller's OPEN classic (ERC20-MANA) listings, used by the Shop's migration tool to re-list "old liquidity" as credit-buyable. USD-pegged listings are excluded (already in the Shop).

Prices are exposed in **credits** (1 credit = $0.10 = 1e17 USD wei).

## Why

The Shop prices items in fixed USD credits with MANA settled underneath. That requires (a) the trades layer to understand a USD-pegged price asset and (b) a lean read model over `marketplace.mv_trades` that returns only credit-buyable listings plus the seller's importable legacy listings. `/v2/catalog` is heavier than the Shop needs (owners/picks/etc.), hence a dedicated `/v3/catalog/shop`.

## Notes for review

- **SQL safety** — every user-supplied value (seller, contract, item id, rarities, wearable categories, price bounds, search, pagination) is bound as a parameter or clamped to a fixed set. `sortBy` maps to fixed `ORDER BY` fragments and is never interpolated. `seller` is validated via `Params.getAddress` and lowercased; pagination is floored and clamped to `[1, 1000]`.
- **Money math** — MANA-wei → credits uses BigInt and rounds **up** so a listing can never be advertised for less than it would settle at on-chain; a non-positive/unparseable price is dropped (never advertised as free) and logged.
- **Environment-agnostic** — chain ids come from `getPolygonChainId()` / `getEthereumChainId()` (env-driven), the squid schema from `MARKETPLACE_SQUID_SCHEMA`. No mainnet assumptions; runs against `.zone` / Amoy for testing.
- **Consistency** — the new port/handler follow the sibling `catalog` patterns; asset-type constants come from `@dcl/schemas` `TradeAssetType` rather than being redeclared.

## Testing

- `yarn build` (tsc) — clean.
- `eslint` — clean.
- Unit tests: added `test/unit/shop-catalog-component.spec.ts` (13 cases covering the credits conversion, the price-drop edge cases, and the generated SQL for every filter/sort), plus the new USD-pegged cases in `trades-utils` / `trades-logic`. All green.
- The integration suite (needs a live Postgres) was not run locally; CI covers it.
