### PR TITLE
feat: add v3 legacy catalog endpoint for credit-buyable classic listings

### DIFF
--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -60,6 +60,39 @@ export function createShopCatalogHandler(
   }
 }
 
+// GET /v3/catalog/legacy -- paginated feed of classic MANA-priced PRIMARY listings (the "old
+// liquidity") so the Shop can offer them for purchase with credits. Returns the raw MANA price
+// (manaWei); the client converts to credits via the oracle. No price-range filter in v1.
+export function createShopLegacyHandler(
+  components: Pick<AppComponents, 'shopCatalog'>
+): IHttpServerComponent.IRequestHandler<Context<'/v3/catalog/legacy'>> {
+  const { shopCatalog } = components
+
+  return async context => {
+    const params = new Params(context.url.searchParams)
+    const first = Math.min(params.getNumber('first', SHOP_DEFAULT_PAGE_SIZE) ?? SHOP_DEFAULT_PAGE_SIZE, SHOP_MAX_PAGE_SIZE)
+    const skip = params.getNumber('skip', 0) ?? 0
+    const category = params.getString('category')
+    const rarities = csv(params.getString('rarity'))
+    const wearableCategories = csv(params.getString('wearableCategory'))
+    const search = params.getString('search')
+    const sortBy = params.getValue<ShopSortBy>('sortBy', SORT_VALUES)
+
+    return asJSON(async () => {
+      const { data, total } = await shopCatalog.getLegacyListings({
+        first,
+        skip,
+        category,
+        rarities,
+        wearableCategories,
+        search,
+        sortBy
+      })
+      return { data, total }
+    })
+  }
+}
+
 // GET /v3/catalog/importable?seller=0x... -- a seller's OLD classic (MANA-priced) listings they can
 // import into the Shop. Public read (open orders are already public).
 export function createShopImportableHandler(

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -21,7 +21,7 @@ import { pingHandler } from './handlers/ping-handler'
 import { getPricesHandler } from './handlers/prices-handler'
 import { getRankingsHandler } from './handlers/rankings-handler'
 import { getSalesHandler } from './handlers/sales-handler'
-import { createShopCatalogHandler, createShopImportableHandler } from './handlers/shop-catalog-handler'
+import { createShopCatalogHandler, createShopImportableHandler, createShopLegacyHandler } from './handlers/shop-catalog-handler'
 import { getStatsHandler } from './handlers/stats-handler'
 import {
   addTradeHandler,
@@ -98,6 +98,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   router.get('/v1/ens/generate', createENSImageGeratorHandler)
 
   router.get('/v3/catalog/shop', createShopCatalogHandler(components))
+  router.get('/v3/catalog/legacy', createShopLegacyHandler(components))
   router.get('/v3/catalog/importable', createShopImportableHandler(components))
 
   router.get('/v1/trades', getTradesHandler)

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -7,6 +7,9 @@ import {
   IShopCatalogComponent,
   ImportableListing,
   ImportableListingRow,
+  LegacyCatalogFilters,
+  LegacyListing,
+  LegacyListingRow,
   ShopCatalogFilters,
   ShopListing,
   ShopListingRow,
@@ -284,5 +287,98 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
     })
   }
 
-  return { getShopListings, getImportableListings }
+  // The classic (ERC20-MANA) PRIMARY listings -- the "old liquidity" the Shop can offer for purchase
+  // with credits. Mirrors getShopListings but filters classic ERC20 received assets (asset_type = 1)
+  // instead of USD-pegged (asset_type = 2), restricts to primaries (public_item_order) since
+  // secondary-with-credits is disabled, and returns the RAW MANA price (the client converts to credits
+  // via the oracle). Paginated public browse feed; no price-range filter in v1 (that needs a live rate).
+  async function getLegacyListings(filters: LegacyCatalogFilters): Promise<{ data: LegacyListing[]; total: number }> {
+    const first = clampCount(filters.first, SHOP_DEFAULT_PAGE_SIZE, SHOP_MIN_PAGE_SIZE, SHOP_MAX_PAGE_SIZE)
+    const skip = clampCount(filters.skip, 0, 0, Number.MAX_SAFE_INTEGER)
+
+    const query = SQL`
+      SELECT
+        mv.id AS trade_id,
+        mv.sent_contract_address AS contract_address,
+        mv.sent_item_id AS item_id,
+        COALESCE(w_p.name, e_p.name) AS name,
+        item_p.image AS image,
+        item_p.rarity AS rarity,
+        item_p.item_type AS item_type,
+        COALESCE(item_p.search_wearable_category, item_p.search_emote_category) AS wearable_category,
+        COALESCE(item_p.creator, '') AS creator,
+        mv.amount_received::text AS mana_wei,
+        mv.available::text AS available,
+        mv.network AS network,
+        EXTRACT(EPOCH FROM mv.created_at)::bigint * 1000 AS created_at,
+        COUNT(*) OVER() AS total
+      `.append(metadataJoins()).append(SQL`
+      WHERE mv.status = 'open'
+        AND mv.type = 'public_item_order'
+        AND (mv.available IS NULL OR mv.available > 0)
+        AND EXISTS (
+          SELECT 1 FROM marketplace.trade_assets ta
+          WHERE ta.trade_id = mv.id AND ta.direction = 'received' AND ta.asset_type = ${ERC20_ASSET_TYPE}
+        )`)
+
+    if (filters.category === 'emote') {
+      query.append(SQL` AND item_p.item_type ILIKE 'emote%'`)
+    } else if (filters.category === 'wearable') {
+      query.append(SQL` AND item_p.item_type NOT ILIKE 'emote%'`)
+    }
+    if (filters.rarities?.length) {
+      query.append(SQL` AND lower(item_p.rarity) = ANY(${filters.rarities.map(r => r.toLowerCase())})`)
+    }
+    if (filters.wearableCategories?.length) {
+      query.append(
+        SQL` AND lower(COALESCE(item_p.search_wearable_category, item_p.search_emote_category)) = ANY(${filters.wearableCategories.map(c =>
+          c.toLowerCase()
+        )})`
+      )
+    }
+    if (filters.search) {
+      query.append(SQL` AND COALESCE(w_p.name, e_p.name) ILIKE ${'%' + escapeLike(filters.search) + '%'}`)
+    }
+
+    // Sort (fixed expressions only -- never interpolate user input into ORDER BY).
+    const order =
+      filters.sortBy === 'cheapest'
+        ? SQL` ORDER BY mv.amount_received ASC`
+        : filters.sortBy === 'most_expensive'
+        ? SQL` ORDER BY mv.amount_received DESC`
+        : filters.sortBy === 'name'
+        ? SQL` ORDER BY COALESCE(w_p.name, e_p.name) ASC`
+        : SQL` ORDER BY mv.created_at DESC`
+    query.append(order).append(SQL` LIMIT ${first} OFFSET ${skip}`)
+
+    const result = await pg.query<LegacyListingRow>(query)
+    const polygonChainId = getPolygonChainId()
+    const ethereumChainId = getEthereumChainId()
+    const total = result.rows[0] ? Number(result.rows[0].total) : 0
+
+    const data: LegacyListing[] = result.rows.map(r => {
+      const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
+      return {
+        tradeId: r.trade_id,
+        listingType: 'primary',
+        contractAddress: r.contract_address,
+        itemId: r.item_id,
+        name: r.name ?? '',
+        thumbnail: r.image ?? '',
+        rarity: (r.rarity ?? 'common').toLowerCase(),
+        category: topLevelCategory(r.item_type),
+        wearableCategory: r.wearable_category,
+        creator: r.creator ?? '',
+        manaWei: r.mana_wei,
+        available: r.available ? Number(r.available) : 1,
+        network: isPolygon ? Network.MATIC : Network.ETHEREUM,
+        chainId: isPolygon ? polygonChainId : ethereumChainId,
+        createdAt: Number(r.created_at)
+      }
+    })
+
+    return { data, total }
+  }
+
+  return { getShopListings, getImportableListings, getLegacyListings }
 }

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -63,9 +63,44 @@ export type ImportableListing = {
   chainId: number
 }
 
+// A classic (ERC20-MANA) PRIMARY listing surfaced as a paginated browse feed so the Shop can offer
+// the "old liquidity" for purchase with credits. Like ImportableListing it carries the raw MANA price
+// (the client converts to credits via the oracle), but this is a public catalog feed, not per-seller.
+// Primaries only: secondary-with-credits is disabled, so public_nft_order rows are excluded entirely.
+export type LegacyListing = {
+  tradeId: string
+  listingType: 'primary'
+  contractAddress: string
+  itemId: string | null
+  name: string
+  thumbnail: string
+  rarity: string
+  category: string // top-level: 'wearable' | 'emote'
+  wearableCategory: string | null // on-chain category (upper_body, hat, ...) when applicable
+  creator: string
+  manaWei: string // raw MANA price; the client converts to credits via the oracle
+  available: number
+  network: string
+  chainId: number
+  createdAt: number
+}
+
+// Filters accepted by getLegacyListings. Same shape as ShopCatalogFilters minus the price-range
+// bounds, which would need a live MANA/credit rate on the server and are out of scope for v1.
+export type LegacyCatalogFilters = {
+  first?: number
+  skip?: number
+  category?: string // 'wearable' | 'emote'
+  rarities?: string[]
+  wearableCategories?: string[] // on-chain categories (upper_body, hat, ...)
+  search?: string
+  sortBy?: ShopSortBy
+}
+
 export interface IShopCatalogComponent {
   getShopListings(filters: ShopCatalogFilters): Promise<{ data: ShopListing[]; total: number }>
   getImportableListings(seller: string): Promise<ImportableListing[]>
+  getLegacyListings(filters: LegacyCatalogFilters): Promise<{ data: LegacyListing[]; total: number }>
 }
 
 export type ImportableListingRow = {
@@ -98,6 +133,24 @@ export type ShopListingRow = {
   wearable_category: string | null
   creator: string | null
   price: string
+  available: string | null
+  network: string | null
+  created_at: string
+  total: string
+}
+
+// Raw DB row for the legacy (classic MANA) primary feed, before mapping to LegacyListing.
+export type LegacyListingRow = {
+  trade_id: string
+  contract_address: string
+  item_id: string | null
+  name: string | null
+  image: string | null
+  rarity: string | null
+  item_type: string | null
+  wearable_category: string | null
+  creator: string | null
+  mana_wei: string
   available: string | null
   network: string | null
   created_at: string

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -26,6 +26,26 @@ function shopRow(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function legacyRow(overrides: Record<string, unknown> = {}) {
+  return {
+    trade_id: 'legacy-1',
+    contract_address: '0xcollection',
+    item_id: '3',
+    name: 'Legacy Hat',
+    image: 'ipfs://hat.png',
+    rarity: 'RARE',
+    item_type: 'wearable_v2',
+    wearable_category: 'hat',
+    creator: '0xcreator',
+    mana_wei: '1000000000000000000',
+    available: '10',
+    network: 'MATIC',
+    created_at: '1700000000000',
+    total: '1',
+    ...overrides
+  }
+}
+
 describe('Shop Catalog Component', () => {
   let shopCatalog: IShopCatalogComponent
   let query: jest.Mock
@@ -207,6 +227,113 @@ describe('Shop Catalog Component', () => {
       expect(sql.values).toContain('0xabcdef')
       expect(sql.values).toContain(1)
       expect(data[0]).toMatchObject({ oldTradeId: 'old-1', manaWei: '1000000000000000000', listingType: 'primary' })
+    })
+  })
+
+  describe('when building the legacy listings query', () => {
+    beforeEach(() => {
+      query.mockResolvedValue({ rows: [] })
+    })
+
+    it('should only include classic ERC20 (asset_type = 1) primary listings', async () => {
+      await shopCatalog.getLegacyListings({})
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain("ta.direction = 'received' AND ta.asset_type =")
+      expect(sql.values).toContain(1)
+    })
+
+    it('should restrict to primaries via the WHERE guard so secondaries are excluded', async () => {
+      await shopCatalog.getLegacyListings({})
+
+      const sql = query.mock.calls[0][0]
+      // The primary-only guard lives in the WHERE clause (the shared metadataJoins keeps the
+      // public_nft_order LEFT JOINs, but no secondary row can satisfy mv.type = 'public_item_order').
+      expect(sql.text).toContain("WHERE mv.status = 'open'\n        AND mv.type = 'public_item_order'")
+    })
+
+    it('should apply the same open and available guards as the shop feed', async () => {
+      await shopCatalog.getLegacyListings({})
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain("mv.status = 'open'")
+      expect(sql.text).toContain('mv.available IS NULL OR mv.available > 0')
+    })
+
+    it('should not apply any price-range filter', async () => {
+      await shopCatalog.getLegacyListings({})
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).not.toContain('mv.amount_received >=')
+      expect(sql.text).not.toContain('mv.amount_received <=')
+    })
+
+    it('should clamp pagination and bind LIMIT/OFFSET as params', async () => {
+      await shopCatalog.getLegacyListings({ first: 99999, skip: 10.7 })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('LIMIT')
+      expect(sql.text).toContain('OFFSET')
+      expect(sql.values).toEqual(expect.arrayContaining([1000, 10]))
+    })
+
+    it('should never place a user-supplied sort value into the SQL text', async () => {
+      await shopCatalog.getLegacyListings({ sortBy: 'cheapest' })
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY mv.amount_received ASC')
+
+      query.mockClear()
+      await shopCatalog.getLegacyListings({})
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY mv.created_at DESC')
+    })
+
+    it('should bind a name search as a parameterized ILIKE with escaped wildcards', async () => {
+      await shopCatalog.getLegacyListings({ search: '50%_off' })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('ILIKE')
+      expect(sql.values).toContain('%50\\%\\_off%')
+    })
+
+    it('should lowercase rarities and bind them as an array param', async () => {
+      await shopCatalog.getLegacyListings({ rarities: ['Rare', 'EPIC'] })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('lower(item_p.rarity) = ANY(')
+      expect(sql.values).toContainEqual(['rare', 'epic'])
+    })
+
+    it('should lowercase wearable categories and bind them as an array param', async () => {
+      await shopCatalog.getLegacyListings({ wearableCategories: ['Upper_Body', 'HAT'] })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('lower(COALESCE(item_p.search_wearable_category')
+      expect(sql.values).toContainEqual(['upper_body', 'hat'])
+    })
+  })
+
+  describe('when mapping a legacy listing row', () => {
+    it('should pass the raw MANA price through and tag the listing as primary', async () => {
+      query.mockResolvedValueOnce({ rows: [legacyRow({ rarity: 'MYTHIC', mana_wei: '2500000000000000000', total: '1' })] })
+
+      const { data, total } = await shopCatalog.getLegacyListings({})
+
+      expect(total).toBe(1)
+      expect(data[0]).toMatchObject({
+        tradeId: 'legacy-1',
+        listingType: 'primary',
+        contractAddress: '0xcollection',
+        itemId: '3',
+        name: 'Legacy Hat',
+        thumbnail: 'ipfs://hat.png',
+        rarity: 'mythic',
+        category: 'wearable',
+        wearableCategory: 'hat',
+        creator: '0xcreator',
+        manaWei: '2500000000000000000',
+        available: 10,
+        network: 'MATIC',
+        createdAt: 1700000000000
+      })
     })
   })
 })


### PR DESCRIPTION
## What

Adds `GET /v3/catalog/legacy`: a paginated, read-only feed of the classic MANA-priced **primary** listings (the "old liquidity") so the Shop can offer them for purchase with credits.

It mirrors `getShopListings` but:
- Filters classic ERC20 received assets (`trade_assets.asset_type = 1`, `TradeAssetType.ERC20`) instead of USD-pegged (`= 2`).
- **Primaries only**: `mv.type = 'public_item_order'` (secondaries are excluded by the WHERE guard, since secondary-with-credits is disabled).
- Same open/available guards (`status = 'open'`, `available IS NULL OR > 0`) and the shared `metadataJoins()` helper.
- Returns the **raw MANA price** as `manaWei` (`amount_received::text`). No credit conversion server-side; the client converts via the oracle.
- No price-range filter in v1 (would need a live MANA/credit rate on the server).

## Response contract

`{ data: LegacyListing[], total }` where:

```ts
LegacyListing = {
  tradeId: string
  listingType: 'primary'
  contractAddress: string
  itemId: string | null
  name: string
  thumbnail: string
  rarity: string
  category: string           // 'wearable' | 'emote'
  wearableCategory: string | null
  creator: string
  manaWei: string            // raw MANA price; client converts to credits via the oracle
  available: number
  network: string
  chainId: number
  createdAt: number
}
```

## Query params

Same subset as `/v3/catalog/shop` (minus price-range): `first`, `skip`, `category` (`wearable`|`emote`), `rarity` (csv), `wearableCategory` (csv), `search`, `sortBy` (`newest`|`cheapest`|`most_expensive`|`name`). All user input is bound as SQL params (no interpolation); ORDER BY uses fixed expressions only.

## Verification

- `tsc --noEmit`: clean
- `eslint`: clean (only the pre-existing `as any` warning in the spec)
- `jest test/unit/shop-catalog-component.spec.ts`: 25/25 green

## Note

Stacked on #359 (`feat/support-usd-pegged-trades`) — this PR is based on that branch and should merge **after** it. The diff here is just the new endpoint.
