### PR TITLE
fix: log unhandled errors in asJSON (500s were invisible in the logs)

### DIFF
--- a/src/logic/http/response.ts
+++ b/src/logic/http/response.ts
@@ -29,14 +29,20 @@ export async function asJSON(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     if (error instanceof HttpError) {
+      // Explicitly-thrown, expected errors. Log 5xx (a real server fault); 4xx are normal control flow.
+      if (error.code >= 500) console.error(`[asJSON] HttpError ${error.code}:`, error)
       return {
         status: error.code,
         body: error.message
       }
     } else {
+      // Unexpected error → 500. Log the FULL error (message + stack) so failures are debuggable from
+      // the server logs, not just a bare 500 in the access log. (The message is also returned in the
+      // body, but server logs are what you read when a request 500s.)
+      console.error('[asJSON] unhandled error → 500:', error)
       return {
         status: 500,
-        body: error.message
+        body: error?.message ?? 'Internal server error'
       }
     }
   }

--- a/test/unit/response.spec.ts
+++ b/test/unit/response.spec.ts
@@ -1,0 +1,53 @@
+import { asJSON, HttpError } from '../../src/logic/http/response'
+
+describe('asJSON', () => {
+  let errSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    errSpy.mockRestore()
+  })
+
+  it('returns 200 with the handler result and does not log', async () => {
+    const res = await asJSON(async () => ({ ok: true }))
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true })
+    expect(errSpy).not.toHaveBeenCalled()
+  })
+
+  it('maps an HttpError to its status, without logging a 4xx (normal control flow)', async () => {
+    const res = await asJSON(async () => {
+      throw new HttpError('bad request', 400)
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toBe('bad request')
+    expect(errSpy).not.toHaveBeenCalled()
+  })
+
+  it('logs a 5xx HttpError (a real server fault)', async () => {
+    const res = await asJSON(async () => {
+      throw new HttpError('upstream down', 503)
+    })
+
+    expect(res.status).toBe(503)
+    expect(errSpy).toHaveBeenCalled()
+  })
+
+  it('maps an unexpected error to 500 AND logs the real error (so 500s are debuggable)', async () => {
+    const boom = new Error('relation "marketplace.mv_trades" does not exist')
+    const res = await asJSON(async () => {
+      throw boom
+    })
+
+    expect(res.status).toBe(500)
+    expect(res.body).toBe(boom.message)
+    // The actual error object (message + stack) must reach the logs — the whole point of the fix.
+    expect(errSpy).toHaveBeenCalled()
+    expect(errSpy.mock.calls.some(call => call.includes(boom))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem

`asJSON` (used by ~every handler) caught the handler error and returned a bare **500 with only `error.message` in the response body** — **nothing was logged**. So a failing request (e.g. `GET /v3/catalog/shop`) showed up in the server logs as just `[500]` with no cause, making it undebuggable from logs.

## Fix

`asJSON` now `console.error`s the **full error (message + stack)** for unexpected 500s and 5xx `HttpError`s. 4xx `HttpError`s stay quiet (normal control flow). The response body is unchanged.

## Test

Adds `test/unit/response.spec.ts` (the util had **no tests**): 200 passthrough, 4xx maps quietly, 5xx logs, unexpected→500 **and asserts the real error reaches the logs**.

## Note on why a live 500 slips past unit tests

Handler/component tests mock the DB (`query = jest.fn()` returning canned rows), so a real SQL/data error (missing/unrefreshed MV, schema drift) never runs in tests. This fix at least makes such errors visible at runtime. A DB-backed integration test for `/v3/catalog/shop` is a good follow-up.