### PR TITLE
feat: server-side credit pricing for shop catalog feeds

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -63,3 +63,13 @@ SIGNATURES_SERVER_URL=https://signatures-api.zone
 # Redis
 REDIS_URL=
 MARKETPLACE_BASE_URL=https://decentraland.org/marketplace
+
+# MANA/USD rate (used to convert legacy MANA-priced listings into credits for the unified shop catalog).
+# Sources the SAME on-chain Chainlink-style MANA/USD aggregator that the credits-server oracle reads.
+# When RPC_ENDPOINT_POLYGON / MANA_USD_ORACLE_ADDRESS are unset (e.g. dev/testnet) the rate component
+# fails safe to MANA_USD_FALLBACK_RATE. The cached rate refreshes every MANA_RATE_REFRESH_INTERVAL_MS.
+RPC_ENDPOINT_POLYGON=
+MANA_USD_ORACLE_ADDRESS=
+MANA_RATE_REFRESH_INTERVAL_MS=90000
+MANA_USD_FALLBACK_RATE=0.02
+MANA_ORACLE_MAX_STALENESS_SECONDS=86400

--- a/src/components.ts
+++ b/src/components.ts
@@ -27,6 +27,7 @@ import { createPicksComponent } from './ports/favorites/picks'
 import { createSnapshotComponent } from './ports/favorites/snapshot'
 import { createItemsComponent } from './ports/items'
 import { createJobComponent } from './ports/job'
+import { createManaUsdRateComponent } from './ports/mana-rate/component'
 import { createNFTsComponent } from './ports/nfts/component'
 import { createOrdersComponent } from './ports/orders/component'
 import { createOwnersComponent } from './ports/owners/component'
@@ -146,6 +147,7 @@ export async function initComponents(): Promise<AppComponents> {
   // catalog
   const catalog = await createCatalogComponent({ dappsDatabase: dappsReadDatabase, dappsWriteDatabase, picks }, SEGMENT_WRITE_KEY)
   const shopCatalog = createShopCatalogComponent({ dappsDatabase: dappsReadDatabase, logs })
+  const manaUsdRate = await createManaUsdRateComponent({ config, logs })
   const trades = await createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs })
   const bids = await createBidsComponents({ dappsDatabase: dappsReadDatabase })
   const nfts = await createNFTsComponent({ dappsDatabase: dappsReadDatabase, config, rentals })
@@ -200,6 +202,7 @@ export async function initComponents(): Promise<AppComponents> {
     dappsWriteDatabase,
     catalog,
     shopCatalog,
+    manaUsdRate,
     wertSigner,
     wertApi,
     ens,

--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -3,6 +3,7 @@ import { Params } from '../../logic/http/params'
 import { asJSON } from '../../logic/http/response'
 import { ShopSortBy, UnifiedListingSource, SHOP_DEFAULT_PAGE_SIZE, SHOP_MAX_PAGE_SIZE } from '../../ports/shop-catalog/types'
 import { AppComponents, Context } from '../../types'
+import { getItemsParams } from './utils'
 
 // Valid sort values, as a map so Params.getValue can validate the query param against them (mirrors
 // how the catalog handler validates CatalogSortBy) and return undefined for anything unexpected.
@@ -143,6 +144,28 @@ export function createShopUnifiedHandler(
         },
         rate
       )
+      return { data, total }
+    })
+  }
+}
+
+// GET /v3/catalog/items -- the credit-aware CATALOG-ITEMS feed. Same data source and full-catalog
+// semantics as GET /v1/items (ALL items incl. not-on-sale, keyed by item, filterable by creator,
+// contractAddress, category, rarity, search, ...) but every item carries a server-computed,
+// asset-type-aware priceCredits (USD-pegged items pass through; MANA-priced ones are converted with the
+// live MANA/USD rate). Returns { data, total } where each item is the /v1/items shape plus priceCredits.
+export function createCatalogItemsHandler(
+  components: Pick<AppComponents, 'items' | 'manaUsdRate'>
+): IHttpServerComponent.IRequestHandler<Context<'/v3/catalog/items'>> {
+  const { items, manaUsdRate } = components
+
+  return async context => {
+    const params = new Params(context.url.searchParams)
+    const filters = getItemsParams(params)
+
+    return asJSON(async () => {
+      const rate = manaUsdRate.getRate()
+      const { data, total } = await items.getCatalogItems(filters, rate)
       return { data, total }
     })
   }

--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -1,7 +1,7 @@
 import { IHttpServerComponent } from '@dcl/core-commons'
 import { Params } from '../../logic/http/params'
 import { asJSON } from '../../logic/http/response'
-import { ShopSortBy, SHOP_DEFAULT_PAGE_SIZE, SHOP_MAX_PAGE_SIZE } from '../../ports/shop-catalog/types'
+import { ShopSortBy, UnifiedListingSource, SHOP_DEFAULT_PAGE_SIZE, SHOP_MAX_PAGE_SIZE } from '../../ports/shop-catalog/types'
 import { AppComponents, Context } from '../../types'
 
 // Valid sort values, as a map so Params.getValue can validate the query param against them (mirrors
@@ -11,6 +11,12 @@ const SORT_VALUES: Record<ShopSortBy, ShopSortBy> = {
   cheapest: 'cheapest',
   most_expensive: 'most_expensive',
   name: 'name'
+}
+
+// Valid `source` values for the unified feed (validated the same way as sortBy).
+const SOURCE_VALUES: Record<UnifiedListingSource, UnifiedListingSource> = {
+  native: 'native',
+  legacy: 'legacy'
 }
 
 function csv(value?: string): string[] | undefined {
@@ -88,6 +94,55 @@ export function createShopLegacyHandler(
         search,
         sortBy
       })
+      return { data, total }
+    })
+  }
+}
+
+// GET /v3/catalog/unified -- the UNIFIED shop feed: native (USD-pegged) + legacy (classic MANA)
+// listings in ONE credit-priced feed. Every item carries a server-computed priceCredits (legacy
+// converted MANA->credits with the live rate) and a `source` discriminator. Same query params as
+// /v3/catalog/shop plus optional `source` (native|legacy). Sorting and minPriceCredits/maxPriceCredits
+// work across BOTH sources.
+export function createShopUnifiedHandler(
+  components: Pick<AppComponents, 'shopCatalog' | 'manaUsdRate'>
+): IHttpServerComponent.IRequestHandler<Context<'/v3/catalog/unified'>> {
+  const { shopCatalog, manaUsdRate } = components
+
+  return async context => {
+    const params = new Params(context.url.searchParams)
+    const first = Math.min(params.getNumber('first', SHOP_DEFAULT_PAGE_SIZE) ?? SHOP_DEFAULT_PAGE_SIZE, SHOP_MAX_PAGE_SIZE)
+    const skip = params.getNumber('skip', 0) ?? 0
+    const category = params.getString('category')
+    const contractAddress = params.getString('contractAddress')
+    const itemId = params.getString('itemId')
+    const rarities = csv(params.getString('rarity'))
+    const wearableCategories = csv(params.getString('wearableCategory'))
+    const minPriceCredits = params.getNumber('minPriceCredits')
+    const maxPriceCredits = params.getNumber('maxPriceCredits')
+    const search = params.getString('search')
+    const sortBy = params.getValue<ShopSortBy>('sortBy', SORT_VALUES)
+    const source = params.getValue<UnifiedListingSource>('source', SOURCE_VALUES)
+
+    return asJSON(async () => {
+      const rate = manaUsdRate.getRate()
+      const { data, total } = await shopCatalog.getUnifiedListings(
+        {
+          first,
+          skip,
+          category,
+          contractAddress,
+          itemId,
+          rarities,
+          wearableCategories,
+          minPriceCredits,
+          maxPriceCredits,
+          search,
+          sortBy,
+          source
+        },
+        rate
+      )
       return { data, total }
     })
   }

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -21,7 +21,12 @@ import { pingHandler } from './handlers/ping-handler'
 import { getPricesHandler } from './handlers/prices-handler'
 import { getRankingsHandler } from './handlers/rankings-handler'
 import { getSalesHandler } from './handlers/sales-handler'
-import { createShopCatalogHandler, createShopImportableHandler, createShopLegacyHandler } from './handlers/shop-catalog-handler'
+import {
+  createShopCatalogHandler,
+  createShopImportableHandler,
+  createShopLegacyHandler,
+  createShopUnifiedHandler
+} from './handlers/shop-catalog-handler'
 import { getStatsHandler } from './handlers/stats-handler'
 import {
   addTradeHandler,
@@ -99,6 +104,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
 
   router.get('/v3/catalog/shop', createShopCatalogHandler(components))
   router.get('/v3/catalog/legacy', createShopLegacyHandler(components))
+  router.get('/v3/catalog/unified', createShopUnifiedHandler(components))
   router.get('/v3/catalog/importable', createShopImportableHandler(components))
 
   router.get('/v1/trades', getTradesHandler)

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -22,6 +22,7 @@ import { getPricesHandler } from './handlers/prices-handler'
 import { getRankingsHandler } from './handlers/rankings-handler'
 import { getSalesHandler } from './handlers/sales-handler'
 import {
+  createCatalogItemsHandler,
   createShopCatalogHandler,
   createShopImportableHandler,
   createShopLegacyHandler,
@@ -105,6 +106,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   router.get('/v3/catalog/shop', createShopCatalogHandler(components))
   router.get('/v3/catalog/legacy', createShopLegacyHandler(components))
   router.get('/v3/catalog/unified', createShopUnifiedHandler(components))
+  router.get('/v3/catalog/items', createCatalogItemsHandler(components))
   router.get('/v3/catalog/importable', createShopImportableHandler(components))
 
   router.get('/v1/trades', getTradesHandler)

--- a/src/ports/items/component.ts
+++ b/src/ports/items/component.ts
@@ -3,8 +3,16 @@ import { isErrorWithMessage } from '../../logic/errors'
 import { AppComponents } from '../../types'
 import { QueryFailure } from '../favorites/lists/errors'
 import { ItemNotFoundError } from './errors'
-import { getItemById, getItemsQuery, getUtilityByItem } from './queries'
-import { DBItem, IItemsComponent, ItemQueryFilters } from './types'
+import { getCatalogItemsQuery, getItemById, getItemsQuery, getUtilityByItem } from './queries'
+import { CatalogDBItem, DBItem, IItemsComponent, ItemQueryFilters } from './types'
+
+// Format a MANA/USD rate (USD per MANA) as a bounded-precision decimal literal for the SQL numeric math.
+// A non-positive/non-finite rate yields '0' (a MANA-priced item then converts to 0 credits) rather than
+// pricing off a broken rate. Mirrors the shop-catalog component's rate handling.
+function rateToNumericString(rate: number): string {
+  if (!Number.isFinite(rate) || rate <= 0) return '0'
+  return rate.toFixed(18)
+}
 
 export function createItemsComponent(components: Pick<AppComponents, 'dappsDatabase' | 'logs'>): IItemsComponent {
   const { dappsDatabase: database, logs } = components
@@ -46,5 +54,16 @@ export function createItemsComponent(components: Pick<AppComponents, 'dappsDatab
     }
   }
 
-  return { validateItemExists, getItems }
+  async function getCatalogItems(filters: ItemQueryFilters, manaUsdRate: number) {
+    const query = getCatalogItemsQuery(filters, rateToNumericString(manaUsdRate))
+    const result = await database.query<CatalogDBItem>(query)
+    const items = result.rows
+
+    return {
+      data: items.map(item => ({ ...fromDBItemToItem(item), priceCredits: Number(item.price_credits ?? 0) })),
+      total: result.rowCount > 0 ? Number(items[0].count) : 0
+    }
+  }
+
+  return { validateItemExists, getItems, getCatalogItems }
 }

--- a/src/ports/items/queries.ts
+++ b/src/ports/items/queries.ts
@@ -1,5 +1,5 @@
 import SQL, { SQLStatement } from 'sql-template-strings'
-import { EmotePlayMode, GenderFilterOption, ItemFilters, ListingStatus, TradeType, WearableGender } from '@dcl/schemas'
+import { EmotePlayMode, GenderFilterOption, ItemFilters, ListingStatus, TradeAssetType, TradeType, WearableGender } from '@dcl/schemas'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getDBNetworks } from '../../utils'
 import { getTradesCTE } from '../catalog/queries'
@@ -206,6 +206,125 @@ export function getItemsQuery(filters: ItemQueryFilters = {}) {
           )
       )
   )
+}
+
+// 1 credit = $0.10; $1 = 1e18 USD wei = 10 credits, so 1 credit = 1e17 USD wei. Kept as a literal
+// string so the SQL numeric math stays exact (no float precision loss).
+const USD_WEI_PER_CREDIT = '100000000000000000'
+
+// The asset-type-aware `price_credits` column for the catalog-items feed. Unlike the mixed-unit
+// `/v1/items` `price`, this normalizes every item to whole credits, CEIL-consistent with the native
+// Shop path ("Model B"):
+//   - a v3 trade priced in USD-pegged MANA (asset_type = USD_PEGGED_MANA) is already USD wei -> no rate;
+//   - a v3 trade priced in classic MANA/ERC20, or a classic store-minter `item.price` (MANA wei), is
+//     multiplied by the MANA/USD rate to reach USD wei;
+//   - anything not currently for sale (available = 0, no open minter) -> 0.
+// The trade branch mirrors fromDBItemToItem's precedence (open v3 trade wins over the store minter).
+function getPriceCreditsSelect(rateNumericString: string): SQLStatement {
+  return SQL`
+      CASE
+        WHEN item.available > 0 AND unified_trades.id IS NOT NULL AND item.search_is_marketplace_v3_minter = true THEN
+          CASE
+            WHEN EXISTS (
+              SELECT 1 FROM marketplace.trade_assets ta
+              WHERE ta.trade_id = unified_trades.id
+                AND ta.direction = 'received'
+                AND ta.asset_type = ${TradeAssetType.USD_PEGGED_MANA}
+            )
+            THEN CEIL((unified_trades.assets -> 'received' ->> 'amount')::numeric / ${USD_WEI_PER_CREDIT}::numeric)
+            ELSE CEIL((unified_trades.assets -> 'received' ->> 'amount')::numeric * ${rateNumericString}::numeric / ${USD_WEI_PER_CREDIT}::numeric)
+          END
+        WHEN item.available > 0 AND item.search_is_store_minter = true THEN
+          CEIL(item.price::numeric * ${rateNumericString}::numeric / ${USD_WEI_PER_CREDIT}::numeric)
+        ELSE 0
+      END::bigint AS price_credits`
+}
+
+// The credit-aware catalog-items feed backing GET /v3/catalog/items. Same data source and full-catalog
+// semantics as getItemsQuery (ALL items incl. not-on-sale, keyed by item, filterable by creator/contract
+// address/category/rarity/search) but with a server-computed, asset-type-aware `price_credits` per item.
+// Mirrors getItemsQuery's SELECT/joins so the row maps through fromDBItemToItem unchanged, plus the one
+// extra column. `rateNumericString` is the MANA/USD rate as a fixed-precision numeric literal.
+export function getCatalogItemsQuery(filters: ItemQueryFilters = {}, rateNumericString = '0') {
+  return getTradesCTE({
+    category: filters.category,
+    first: filters.first,
+    skip: filters.skip
+  })
+    .append(
+      SQL`
+    SELECT
+      COUNT(*) OVER() as count,
+      item.id,
+      item.image,
+      item.uri,
+      item.blockchain_id as item_id,
+      item.collection_id as contract_address,
+      coalesce(wearable.rarity, emote.rarity) as rarity,
+      item.price,
+      item.available,
+      item.creator,
+      item.beneficiary,
+      item.created_at,
+      item.updated_at,
+      item.reviewed_at,
+      item.sold_at,
+      item.urn,
+      item.network,
+      item.search_is_store_minter,
+      item.search_is_marketplace_v3_minter,
+      unified_trades.id as trade_id,
+	    coalesce(wearable.name, emote.name) as name,
+      wearable.body_shapes as wearable_body_shapes,
+      emote.body_shapes as emote_body_shapes,
+      wearable.category as wearable_category,
+      emote.category as emote_category,
+      item.item_type,
+      emote.loop,
+      emote.has_sound,
+      emote.has_geometry,
+      emote.outcome_type as emote_outcome_type,
+      coalesce (wearable.description, emote.description) as description,
+      coalesce (to_timestamp(item.first_listed_at) AT TIME ZONE 'UTC', unified_trades.created_at) as first_listed_at,
+      unified_trades.assets -> 'received' ->> 'beneficiary' as trade_beneficiary,
+      unified_trades.expires_at as trade_expires_at,
+      unified_trades.trade_contract as trade_contract,
+      unified_trades.assets -> 'received' ->> 'amount' as trade_price,`
+    )
+    .append(getPriceCreditsSelect(rateNumericString))
+    .append(
+      SQL`
+    FROM
+      `
+        .append(MARKETPLACE_SQUID_SCHEMA)
+        .append(
+          SQL`.item item
+    LEFT JOIN `
+            .append(MARKETPLACE_SQUID_SCHEMA)
+            .append(
+              SQL`.metadata metadata on
+      item.metadata_id = metadata.id
+    LEFT JOIN `
+                .append(MARKETPLACE_SQUID_SCHEMA)
+                .append(
+                  SQL`.wearable wearable on
+      metadata.wearable_id = wearable.id
+    LEFT JOIN `
+                    .append(MARKETPLACE_SQUID_SCHEMA)
+                    .append(
+                      SQL`.emote emote on
+      metadata.emote_id = emote.id
+  `
+                        .append(
+                          ` LEFT JOIN unified_trades ON sent_item_id = item.blockchain_id::text AND sent_contract_address = item.collection_id AND type = '${TradeType.PUBLIC_ITEM_ORDER}' AND status = '${ListingStatus.OPEN}' `
+                        )
+                        .append(getItemsWhereStatement(filters))
+                        .append(getItemsLimitAndOffsetStatement(filters))
+                    )
+                )
+            )
+        )
+    )
 }
 
 export function getUtilityByItem(contractAddress: string, itemId: string) {

--- a/src/ports/items/types.ts
+++ b/src/ports/items/types.ts
@@ -6,10 +6,23 @@ export type ItemQueryFilters = ItemFilters & { includeSocialEmotes?: boolean }
 export interface IItemsComponent {
   validateItemExists(itemId: string): Promise<void>
   getItems(filters?: ItemQueryFilters): Promise<GetItemsResponse>
+  // The credit-aware catalog-items feed: same items as getItems (full catalog, incl. not-on-sale) but
+  // each item carries a server-computed, asset-type-aware priceCredits. `manaUsdRate` is USD per MANA,
+  // used to convert MANA-priced items (classic store minter / ERC20 trades) to credits; USD-pegged
+  // items are already in USD and are NOT rate-adjusted.
+  getCatalogItems(filters: ItemQueryFilters, manaUsdRate: number): Promise<GetCatalogItemsResponse>
 }
 
 export type GetItemsResponse = {
   data: Item[]
+  total: number
+}
+
+// A catalog item is the same shape /v1/items returns plus a server-computed whole-credit price.
+export type CatalogItem = Item & { priceCredits: number }
+
+export type GetCatalogItemsResponse = {
+  data: CatalogItem[]
   total: number
 }
 
@@ -60,3 +73,7 @@ export type DBItem = {
   trade_price: string
   utility?: string
 }
+
+// A DBItem row from the catalog-items query: the same columns as DBItem plus the SQL-computed whole-credit
+// price (CEIL of the USD-wei-equivalent). Nullable because the CASE yields 0 for not-for-sale items.
+export type CatalogDBItem = DBItem & { price_credits: string | null }

--- a/src/ports/mana-rate/component.ts
+++ b/src/ports/mana-rate/component.ts
@@ -15,6 +15,9 @@ const AGGREGATOR_ABI = [
 const DEFAULT_REFRESH_INTERVAL_MS = 90_000
 const DEFAULT_FALLBACK_RATE = 0.02 // USD per MANA
 const DEFAULT_MAX_STALENESS_SECONDS = 86_400
+// Upper bound on how long the initial refresh in start() may block. A slow/unreachable RPC must not
+// wedge component startup: after this the server boots on the fallback and the interval keeps trying.
+const DEFAULT_STARTUP_REFRESH_TIMEOUT_MS = 5_000
 
 export async function createManaUsdRateComponent(components: Pick<AppComponents, 'config' | 'logs'>): Promise<IManaUsdRateComponent> {
   const { config, logs } = components
@@ -23,12 +26,14 @@ export async function createManaUsdRateComponent(components: Pick<AppComponents,
   const refreshIntervalMs = (await config.getNumber('MANA_RATE_REFRESH_INTERVAL_MS')) ?? DEFAULT_REFRESH_INTERVAL_MS
   const fallbackRate = (await config.getNumber('MANA_USD_FALLBACK_RATE')) ?? DEFAULT_FALLBACK_RATE
   const maxStalenessSeconds = (await config.getNumber('MANA_ORACLE_MAX_STALENESS_SECONDS')) ?? DEFAULT_MAX_STALENESS_SECONDS
+  const startupRefreshTimeoutMs = (await config.getNumber('MANA_RATE_STARTUP_TIMEOUT_MS')) ?? DEFAULT_STARTUP_REFRESH_TIMEOUT_MS
 
   // Last successfully-fetched rate; `undefined` until the first success, in which case getRate() falls
   // back to the configured value.
   let cachedRate: number | undefined
   let interval: ReturnType<typeof setInterval> | undefined
 
+  let provider: ethers.JsonRpcProvider | undefined
   let aggregator: ethers.Contract | undefined
   let decimalsCache: number | undefined
 
@@ -40,7 +45,8 @@ export async function createManaUsdRateComponent(components: Pick<AppComponents,
       if (!rpcUrl || !oracleAddress) {
         return undefined
       }
-      aggregator = new ethers.Contract(oracleAddress, AGGREGATOR_ABI, new ethers.JsonRpcProvider(rpcUrl))
+      provider = new ethers.JsonRpcProvider(rpcUrl)
+      aggregator = new ethers.Contract(oracleAddress, AGGREGATOR_ABI, provider)
     }
     return aggregator
   }
@@ -92,7 +98,15 @@ export async function createManaUsdRateComponent(components: Pick<AppComponents,
   }
 
   async function start(): Promise<void> {
-    await refresh()
+    // Bound the initial refresh: a slow/unreachable RPC must not wedge startup. If it wins we boot with
+    // a live rate; if the timeout wins we boot on the fallback and the still-running refresh (plus the
+    // interval below) updates the cache as soon as the oracle answers. refresh() never rejects.
+    let startupTimer: ReturnType<typeof setTimeout> | undefined
+    const bound = new Promise<void>(resolve => {
+      startupTimer = setTimeout(resolve, startupRefreshTimeoutMs)
+      startupTimer.unref?.()
+    })
+    await Promise.race([refresh().finally(() => startupTimer && clearTimeout(startupTimer)), bound])
     interval = setInterval(() => {
       refresh().catch(() => undefined)
     }, refreshIntervalMs)
@@ -105,6 +119,10 @@ export async function createManaUsdRateComponent(components: Pick<AppComponents,
       clearInterval(interval)
       interval = undefined
     }
+    // Release the RPC provider's sockets/timers so the process can exit cleanly.
+    provider?.destroy()
+    provider = undefined
+    aggregator = undefined
   }
 
   return { getRate, refresh, start, stop }

--- a/src/ports/mana-rate/component.ts
+++ b/src/ports/mana-rate/component.ts
@@ -1,0 +1,111 @@
+import { ethers } from 'ethers'
+import { isErrorWithMessage } from '../../logic/errors'
+import { AppComponents } from '../../types'
+import { IManaUsdRateComponent } from './types'
+
+// Minimal Chainlink aggregator ABI -- the exact interface the credits-server oracle reads. Sourcing
+// the SAME feed keeps the credit price we advertise coherent with the amount a purchase settles at.
+const AGGREGATOR_ABI = [
+  'function decimals() view returns (uint8)',
+  'function latestRoundData() view returns (uint80, int256, uint256, uint256, uint80)'
+]
+
+// Refresh cadence (~90s) and a dev/testnet fallback rate, both config-overridable. The fallback is
+// only used before the first successful fetch; after that the last-known value is kept on failure.
+const DEFAULT_REFRESH_INTERVAL_MS = 90_000
+const DEFAULT_FALLBACK_RATE = 0.02 // USD per MANA
+const DEFAULT_MAX_STALENESS_SECONDS = 86_400
+
+export async function createManaUsdRateComponent(components: Pick<AppComponents, 'config' | 'logs'>): Promise<IManaUsdRateComponent> {
+  const { config, logs } = components
+  const logger = logs.getLogger('mana-usd-rate')
+
+  const refreshIntervalMs = (await config.getNumber('MANA_RATE_REFRESH_INTERVAL_MS')) ?? DEFAULT_REFRESH_INTERVAL_MS
+  const fallbackRate = (await config.getNumber('MANA_USD_FALLBACK_RATE')) ?? DEFAULT_FALLBACK_RATE
+  const maxStalenessSeconds = (await config.getNumber('MANA_ORACLE_MAX_STALENESS_SECONDS')) ?? DEFAULT_MAX_STALENESS_SECONDS
+
+  // Last successfully-fetched rate; `undefined` until the first success, in which case getRate() falls
+  // back to the configured value.
+  let cachedRate: number | undefined
+  let interval: ReturnType<typeof setInterval> | undefined
+
+  let aggregator: ethers.Contract | undefined
+  let decimalsCache: number | undefined
+
+  // Built on first use so a missing RPC/oracle address only degrades to the fallback rate, never crashes.
+  async function getAggregator(): Promise<ethers.Contract | undefined> {
+    if (!aggregator) {
+      const rpcUrl = await config.getString('RPC_ENDPOINT_POLYGON')
+      const oracleAddress = await config.getString('MANA_USD_ORACLE_ADDRESS')
+      if (!rpcUrl || !oracleAddress) {
+        return undefined
+      }
+      aggregator = new ethers.Contract(oracleAddress, AGGREGATOR_ABI, new ethers.JsonRpcProvider(rpcUrl))
+    }
+    return aggregator
+  }
+
+  // Reads the aggregator and returns USD per MANA as a decimal. Applies the same completeness and
+  // staleness guards as the credits-server oracle so we never advertise a price off a bad round.
+  async function fetchRate(): Promise<number> {
+    const agg = await getAggregator()
+    if (!agg) {
+      throw new Error('MANA/USD oracle not configured (RPC_ENDPOINT_POLYGON, MANA_USD_ORACLE_ADDRESS)')
+    }
+    if (decimalsCache === undefined) {
+      decimalsCache = Number(await agg.decimals())
+    }
+    const roundData = await agg.latestRoundData()
+    const answer = BigInt(roundData[1]) // USD per MANA, scaled by 10^decimals
+    if (answer <= 0n) {
+      throw new Error('Oracle returned a non-positive MANA/USD rate')
+    }
+    const roundId = BigInt(roundData[0])
+    const answeredInRound = BigInt(roundData[4])
+    if (answeredInRound < roundId) {
+      throw new Error('Oracle round is incomplete (answeredInRound < roundId)')
+    }
+    const updatedAt = Number(roundData[3])
+    const ageSeconds = Math.floor(Date.now() / 1000) - updatedAt
+    if (!Number.isFinite(updatedAt) || updatedAt <= 0 || ageSeconds > maxStalenessSeconds) {
+      throw new Error(`Oracle rate is stale (age ${ageSeconds}s > ${maxStalenessSeconds}s)`)
+    }
+    return Number(answer) / 10 ** decimalsCache
+  }
+
+  async function refresh(): Promise<void> {
+    try {
+      const rate = await fetchRate()
+      cachedRate = rate
+      logger.debug('MANA/USD rate refreshed', { rate })
+    } catch (error) {
+      logger.warn(
+        `Failed to refresh MANA/USD rate, keeping last-known/fallback (${getRate()}): ${
+          isErrorWithMessage(error) ? error.message : 'unknown error'
+        }`
+      )
+    }
+  }
+
+  function getRate(): number {
+    return cachedRate ?? fallbackRate
+  }
+
+  async function start(): Promise<void> {
+    await refresh()
+    interval = setInterval(() => {
+      refresh().catch(() => undefined)
+    }, refreshIntervalMs)
+    // Don't keep the process alive just for the refresh timer.
+    interval.unref?.()
+  }
+
+  async function stop(): Promise<void> {
+    if (interval) {
+      clearInterval(interval)
+      interval = undefined
+    }
+  }
+
+  return { getRate, refresh, start, stop }
+}

--- a/src/ports/mana-rate/index.ts
+++ b/src/ports/mana-rate/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './component'

--- a/src/ports/mana-rate/types.ts
+++ b/src/ports/mana-rate/types.ts
@@ -1,0 +1,18 @@
+import { IBaseComponent } from '@well-known-components/interfaces'
+
+// A small, fail-safe MANA/USD rate cache. It sources the SAME on-chain Chainlink-style MANA/USD
+// aggregator that the credits-server oracle reads (latestRoundData -> USD per MANA, scaled by
+// 10^decimals), so a price shown in the catalog stays coherent with what a purchase settles at.
+// It caches the last-known rate and refreshes on an interval; reads never throw.
+export interface IManaUsdRateComponent extends IBaseComponent {
+  /**
+   * Current MANA price in USD (USD per MANA, e.g. 0.025). Never throws: returns the last successfully
+   * fetched rate, or the configured fallback if the oracle has not answered yet.
+   */
+  getRate(): number
+  /**
+   * Fetch the rate from the on-chain oracle and update the cache. Never throws: on failure it logs and
+   * keeps the last-known value so the catalog is never crashed by a momentarily-unavailable rate.
+   */
+  refresh(): Promise<void>
+}

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -184,9 +184,12 @@ function unifiedBranch(opts: {
       SQL` AS usd_wei,
         mv.available::text AS available,
         mv.network AS network,
-        EXTRACT(EPOCH FROM mv.created_at)::bigint * 1000 AS created_at
-      `
+        EXTRACT(EPOCH FROM mv.created_at)::bigint * 1000 AS created_at,
+        `
     )
+    // Raw MANA price, exposed only for legacy (MANA-priced) items so the client can size the purchase
+    // at the LIVE rate at checkout; native (USD-pegged) items carry no MANA price.
+    .append(applyRate ? SQL`mv.amount_received::text AS mana_wei` : SQL`NULL::text AS mana_wei`)
     .append(metadataJoins()).append(SQL`
       WHERE mv.status = 'open'
         AND (mv.available IS NULL OR mv.available > 0)`)
@@ -583,6 +586,7 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
         wearableCategory: r.wearable_category,
         creator: r.creator ?? '',
         priceCredits: Number(r.price_credits),
+        manaWei: r.mana_wei ?? null,
         available: r.available ? Number(r.available) : 1,
         network: isPolygon ? Network.MATIC : Network.ETHEREUM,
         chainId: isPolygon ? polygonChainId : ethereumChainId,

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -189,7 +189,7 @@ function unifiedBranch(opts: {
     )
     // Raw MANA price, exposed only for legacy (MANA-priced) items so the client can size the purchase
     // at the LIVE rate at checkout; native (USD-pegged) items carry no MANA price.
-    .append(applyRate ? SQL`mv.amount_received::text AS mana_wei` : SQL`NULL::text AS mana_wei`)
+    .append(applyRate ? SQL`mv.amount_received::text AS mana_wei ` : SQL`NULL::text AS mana_wei `)
     .append(metadataJoins()).append(SQL`
       WHERE mv.status = 'open'
         AND (mv.available IS NULL OR mv.available > 0)`)

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -1,4 +1,4 @@
-import SQL from 'sql-template-strings'
+import SQL, { SQLStatement } from 'sql-template-strings'
 import { Network, TradeAssetType } from '@dcl/schemas'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getEthereumChainId, getPolygonChainId } from '../../logic/chainIds'
@@ -13,6 +13,9 @@ import {
   ShopCatalogFilters,
   ShopListing,
   ShopListingRow,
+  UnifiedCatalogFilters,
+  UnifiedListing,
+  UnifiedListingRow,
   SHOP_DEFAULT_PAGE_SIZE,
   SHOP_MAX_PAGE_SIZE,
   SHOP_MIN_PAGE_SIZE
@@ -101,6 +104,104 @@ function escapeLike(value: string): string {
 function clampCount(value: number | undefined, fallback: number, min: number, max: number): number {
   const n = Number.isFinite(value) ? Math.floor(value as number) : fallback
   return Math.min(Math.max(n, min), max)
+}
+
+// Format a MANA/USD rate (USD per MANA) as a bounded-precision decimal literal for Postgres numeric
+// math. A non-positive/non-finite rate yields '0' so the caller's `usd_wei > 0` guard drops the rows
+// rather than advertising a free item off a broken rate.
+function rateToNumericString(rate: number): string {
+  if (!Number.isFinite(rate) || rate <= 0) return '0'
+  return rate.toFixed(18)
+}
+
+// The shared browse filters (category, contract/item, rarity, category, search) applied identically to
+// each branch of the unified feed. Mirrors the expressions used by getShopListings.
+function appendUnifiedFilters(query: SQLStatement, filters: UnifiedCatalogFilters): void {
+  if (filters.contractAddress) {
+    query.append(SQL` AND mv.sent_contract_address = ${filters.contractAddress.toLowerCase()}`)
+  }
+  if (filters.itemId != null) {
+    query.append(SQL` AND mv.sent_item_id = ${filters.itemId}`)
+  }
+  if (filters.category === 'emote') {
+    query.append(SQL` AND COALESCE(item_p.item_type, item_s.item_type, nft.item_type) ILIKE 'emote%'`)
+  } else if (filters.category === 'wearable') {
+    query.append(SQL` AND COALESCE(item_p.item_type, item_s.item_type, nft.item_type) NOT ILIKE 'emote%'`)
+  }
+  if (filters.rarities?.length) {
+    query.append(
+      SQL` AND lower(COALESCE(item_p.rarity, item_s.rarity, nft.search_wearable_rarity)) = ANY(${filters.rarities.map(r =>
+        r.toLowerCase()
+      )})`
+    )
+  }
+  if (filters.wearableCategories?.length) {
+    query.append(
+      SQL` AND lower(COALESCE(item_p.search_wearable_category, item_s.search_wearable_category, item_p.search_emote_category, item_s.search_emote_category)) = ANY(${filters.wearableCategories.map(
+        c => c.toLowerCase()
+      )})`
+    )
+  }
+  if (filters.search) {
+    query.append(SQL` AND COALESCE(nft.name, w_p.name, e_p.name) ILIKE ${'%' + escapeLike(filters.search) + '%'}`)
+  }
+}
+
+// One branch of the unified UNION. `usdWei` is the USD-wei-equivalent expression: native listings are
+// already USD-pegged (amount_received IS USD wei); legacy listings are MANA wei, so usdWei = amount *
+// rate. Columns are identical across branches so the two can be UNIONed and sorted/paginated as one.
+function unifiedBranch(opts: {
+  source: 'native' | 'legacy'
+  assetType: number
+  primaryOnly: boolean
+  applyRate: boolean
+  rateNumericString: string
+  filters: UnifiedCatalogFilters
+}): SQLStatement {
+  const { source, assetType, primaryOnly, applyRate, rateNumericString, filters } = opts
+  const usdWei = applyRate ? SQL`(mv.amount_received::numeric * ${rateNumericString}::numeric)` : SQL`mv.amount_received::numeric`
+
+  const query = SQL`
+      SELECT
+        ${source} AS source,
+        mv.id AS trade_id,
+        mv.type AS trade_type,
+        mv.sent_contract_address AS contract_address,
+        mv.sent_item_id AS item_id,
+        mv.sent_token_id AS token_id,
+        COALESCE(nft.name, w_p.name, e_p.name) AS name,
+        COALESCE(nft.image, item_p.image, item_s.image) AS image,
+        COALESCE(item_p.rarity, item_s.rarity, nft.search_wearable_rarity) AS rarity,
+        COALESCE(item_p.item_type, item_s.item_type, nft.item_type) AS item_type,
+        COALESCE(
+          item_p.search_wearable_category, item_p.search_emote_category,
+          item_s.search_wearable_category, item_s.search_emote_category
+        ) AS wearable_category,
+        COALESCE(item_p.creator, item_s.creator, '') AS creator,
+        `
+    .append(usdWei)
+    .append(
+      SQL` AS usd_wei,
+        mv.available::text AS available,
+        mv.network AS network,
+        EXTRACT(EPOCH FROM mv.created_at)::bigint * 1000 AS created_at
+      `
+    )
+    .append(metadataJoins()).append(SQL`
+      WHERE mv.status = 'open'
+        AND (mv.available IS NULL OR mv.available > 0)`)
+
+  if (primaryOnly) {
+    query.append(SQL` AND mv.type = 'public_item_order'`)
+  }
+  query.append(SQL`
+        AND EXISTS (
+          SELECT 1 FROM marketplace.trade_assets ta
+          WHERE ta.trade_id = mv.id AND ta.direction = 'received' AND ta.asset_type = ${assetType}
+        )`)
+
+  appendUnifiedFilters(query, filters)
+  return query
 }
 
 export function createShopCatalogComponent(components: Pick<AppComponents, 'dappsDatabase' | 'logs'>): IShopCatalogComponent {
@@ -380,5 +481,109 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
     return { data, total }
   }
 
-  return { getShopListings, getImportableListings, getLegacyListings }
+  // The UNIFIED feed: native (USD-pegged) + legacy (classic MANA) primaries in ONE credit-priced set.
+  // Legacy MANA prices are converted to a USD-wei-equivalent (amount * rate) so priceCredits, the
+  // price-range filter and the sort are all computed uniformly across both sources. priceCredits is
+  // CEIL(usd_wei / USD_WEI_PER_CREDIT) -- whole credits rounded UP, same "Model B" as the native path.
+  async function getUnifiedListings(
+    filters: UnifiedCatalogFilters,
+    manaUsdRate: number
+  ): Promise<{ data: UnifiedListing[]; total: number }> {
+    const first = clampCount(filters.first, SHOP_DEFAULT_PAGE_SIZE, SHOP_MIN_PAGE_SIZE, SHOP_MAX_PAGE_SIZE)
+    const skip = clampCount(filters.skip, 0, 0, Number.MAX_SAFE_INTEGER)
+    const rateNumericString = rateToNumericString(manaUsdRate)
+
+    // Build only the requested branch(es); default is both. `parts` are UNION ALL-ed together.
+    const parts: SQLStatement[] = []
+    if (filters.source !== 'legacy') {
+      parts.push(
+        unifiedBranch({
+          source: 'native',
+          assetType: USD_PEGGED_ASSET_TYPE,
+          primaryOnly: false,
+          applyRate: false,
+          rateNumericString,
+          filters
+        })
+      )
+    }
+    if (filters.source !== 'native') {
+      parts.push(
+        unifiedBranch({
+          source: 'legacy',
+          assetType: ERC20_ASSET_TYPE,
+          primaryOnly: true,
+          applyRate: true,
+          rateNumericString,
+          filters
+        })
+      )
+    }
+
+    const inner = parts[0]
+    for (let i = 1; i < parts.length; i++) {
+      inner.append(SQL` UNION ALL `).append(parts[i])
+    }
+
+    // Wrap the union so priceCredits, the price-range filter and the sort operate on the merged set.
+    const query = SQL`
+      SELECT
+        sub.*,
+        CEIL(sub.usd_wei / ${USD_WEI_PER_CREDIT.toString()}::numeric)::bigint AS price_credits,
+        COUNT(*) OVER() AS total
+      FROM (`.append(inner).append(SQL`) sub
+      WHERE sub.usd_wei > 0`)
+
+    if (filters.minPriceCredits != null) {
+      const minWei = creditsToWei(filters.minPriceCredits)
+      if (minWei != null) query.append(SQL` AND sub.usd_wei >= ${minWei.toString()}`)
+    }
+    if (filters.maxPriceCredits != null) {
+      const maxWei = creditsToWei(filters.maxPriceCredits)
+      if (maxWei != null) query.append(SQL` AND sub.usd_wei <= ${maxWei.toString()}`)
+    }
+
+    // Sort (fixed expressions only -- never interpolate user input into ORDER BY).
+    const order =
+      filters.sortBy === 'cheapest'
+        ? SQL` ORDER BY sub.usd_wei ASC`
+        : filters.sortBy === 'most_expensive'
+        ? SQL` ORDER BY sub.usd_wei DESC`
+        : filters.sortBy === 'name'
+        ? SQL` ORDER BY sub.name ASC`
+        : SQL` ORDER BY sub.created_at DESC`
+    query.append(order).append(SQL` LIMIT ${first} OFFSET ${skip}`)
+
+    const result = await pg.query<UnifiedListingRow>(query)
+    const polygonChainId = getPolygonChainId()
+    const ethereumChainId = getEthereumChainId()
+    const total = result.rows[0] ? Number(result.rows[0].total) : 0
+
+    const data: UnifiedListing[] = result.rows.map(r => {
+      const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
+      return {
+        source: r.source,
+        tradeId: r.trade_id,
+        listingType: r.trade_type === 'public_item_order' ? 'primary' : 'secondary',
+        contractAddress: r.contract_address,
+        itemId: r.item_id,
+        tokenId: r.token_id,
+        name: r.name ?? '',
+        thumbnail: r.image ?? '',
+        rarity: (r.rarity ?? 'common').toLowerCase(),
+        category: topLevelCategory(r.item_type),
+        wearableCategory: r.wearable_category,
+        creator: r.creator ?? '',
+        priceCredits: Number(r.price_credits),
+        available: r.available ? Number(r.available) : 1,
+        network: isPolygon ? Network.MATIC : Network.ETHEREUM,
+        chainId: isPolygon ? polygonChainId : ethereumChainId,
+        createdAt: Number(r.created_at)
+      }
+    })
+
+    return { data, total }
+  }
+
+  return { getShopListings, getImportableListings, getLegacyListings, getUnifiedListings }
 }

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -534,24 +534,32 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
       FROM (`.append(inner).append(SQL`) sub
       WHERE sub.usd_wei > 0`)
 
+    // minPriceCredits is a floor on the DISPLAYED price, which is CEIL(usd_wei / USD_WEI_PER_CREDIT).
+    // CEIL(x / C) >= m  <=>  x > (m - 1) * C, so the correct bound on usd_wei is (minWei - USD_WEI_PER_CREDIT).
+    // A plain `usd_wei >= minWei` (minWei = m * C) wrongly drops fractional-priced legacy items whose CEIL
+    // equals m but whose usd_wei sits just below m * C. Skip the filter when the bound would go negative
+    // (m <= 0), where every priced item (usd_wei > 0) already qualifies.
     if (filters.minPriceCredits != null) {
       const minWei = creditsToWei(filters.minPriceCredits)
-      if (minWei != null) query.append(SQL` AND sub.usd_wei >= ${minWei.toString()}`)
+      if (minWei != null && minWei > 0n) {
+        query.append(SQL` AND sub.usd_wei > ${(minWei - USD_WEI_PER_CREDIT).toString()}`)
+      }
     }
     if (filters.maxPriceCredits != null) {
       const maxWei = creditsToWei(filters.maxPriceCredits)
       if (maxWei != null) query.append(SQL` AND sub.usd_wei <= ${maxWei.toString()}`)
     }
 
-    // Sort (fixed expressions only -- never interpolate user input into ORDER BY).
+    // Sort (fixed expressions only -- never interpolate user input into ORDER BY). A `sub.trade_id`
+    // tiebreaker makes the order total so pagination is stable when many rows share a usd_wei/name.
     const order =
       filters.sortBy === 'cheapest'
-        ? SQL` ORDER BY sub.usd_wei ASC`
+        ? SQL` ORDER BY sub.usd_wei ASC, sub.trade_id`
         : filters.sortBy === 'most_expensive'
-        ? SQL` ORDER BY sub.usd_wei DESC`
+        ? SQL` ORDER BY sub.usd_wei DESC, sub.trade_id`
         : filters.sortBy === 'name'
-        ? SQL` ORDER BY sub.name ASC`
-        : SQL` ORDER BY sub.created_at DESC`
+        ? SQL` ORDER BY sub.name ASC, sub.trade_id`
+        : SQL` ORDER BY sub.created_at DESC, sub.trade_id`
     query.append(order).append(SQL` LIMIT ${first} OFFSET ${skip}`)
 
     const result = await pg.query<UnifiedListingRow>(query)

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -97,10 +97,31 @@ export type LegacyCatalogFilters = {
   sortBy?: ShopSortBy
 }
 
+// Which liquidity pool a unified item comes from: 'native' = credit-buyable (USD-pegged) Shop listing,
+// 'legacy' = classic MANA-priced primary converted to credits server-side via the live MANA/USD rate.
+export type UnifiedListingSource = 'native' | 'legacy'
+
+// A unified feed item: the same shape as a ShopListing (so the frontend consumes both uniformly) plus
+// the source discriminator. Legacy items always carry a server-computed priceCredits, converted from
+// their raw MANA price with the live rate and rounded UP to whole credits (same "Model B" as native).
+export type UnifiedListing = ShopListing & {
+  source: UnifiedListingSource
+}
+
+// Filters for the unified feed: the full ShopCatalogFilters (price-range works across BOTH sources now
+// that the server has a MANA/USD rate) plus an optional source filter to restrict to one pool.
+export type UnifiedCatalogFilters = ShopCatalogFilters & {
+  source?: UnifiedListingSource
+}
+
 export interface IShopCatalogComponent {
   getShopListings(filters: ShopCatalogFilters): Promise<{ data: ShopListing[]; total: number }>
   getImportableListings(seller: string): Promise<ImportableListing[]>
   getLegacyListings(filters: LegacyCatalogFilters): Promise<{ data: LegacyListing[]; total: number }>
+  // Merges native (USD-pegged) and legacy (classic MANA) listings into ONE credit-priced feed. The
+  // caller supplies the current MANA/USD rate (USD per MANA) used to convert legacy prices to credits
+  // and to make the price-range filter + sort comparable across both sources.
+  getUnifiedListings(filters: UnifiedCatalogFilters, manaUsdRate: number): Promise<{ data: UnifiedListing[]; total: number }>
 }
 
 export type ImportableListingRow = {
@@ -133,6 +154,28 @@ export type ShopListingRow = {
   wearable_category: string | null
   creator: string | null
   price: string
+  available: string | null
+  network: string | null
+  created_at: string
+  total: string
+}
+
+// Raw DB row for the unified feed (native + legacy), before mapping to UnifiedListing. priceCredits is
+// computed in SQL (CEIL of the USD-wei-equivalent) so the merged feed is sorted/paginated as one set.
+export type UnifiedListingRow = {
+  source: UnifiedListingSource
+  trade_id: string
+  trade_type: string
+  contract_address: string
+  item_id: string | null
+  token_id: string | null
+  name: string | null
+  image: string | null
+  rarity: string | null
+  item_type: string | null
+  wearable_category: string | null
+  creator: string | null
+  price_credits: string
   available: string | null
   network: string | null
   created_at: string

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -106,6 +106,9 @@ export type UnifiedListingSource = 'native' | 'legacy'
 // their raw MANA price with the live rate and rounded UP to whole credits (same "Model B" as native).
 export type UnifiedListing = ShopListing & {
   source: UnifiedListingSource
+  // Raw MANA price (wei), present only for legacy items so the client can size the purchase at the live
+  // rate at checkout. `null` for native (USD-pegged) items.
+  manaWei: string | null
 }
 
 // Filters for the unified feed: the full ShopCatalogFilters (price-range works across BOTH sources now
@@ -176,6 +179,7 @@ export type UnifiedListingRow = {
   wearable_category: string | null
   creator: string | null
   price_credits: string
+  mana_wei: string | null
   available: string | null
   network: string | null
   created_at: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ import { IPicksComponent } from './ports/favorites/picks'
 import { ISnapshotComponent } from './ports/favorites/snapshot'
 import { IItemsComponent } from './ports/items'
 import { IJobComponent } from './ports/job'
+import { IManaUsdRateComponent } from './ports/mana-rate/types'
 import { INFTsComponent } from './ports/nfts/types'
 import { IOrdersComponent } from './ports/orders/types'
 import { IOwnersComponent } from './ports/owners/types'
@@ -54,6 +55,7 @@ export type BaseComponents = {
   dappsWriteDatabase: IPgComponent
   catalog: ICatalogComponent
   shopCatalog: IShopCatalogComponent
+  manaUsdRate: IManaUsdRateComponent
   wertSigner: IWertSignerComponent
   wertApi: IWertApiComponent
   transak: ITransakComponent

--- a/test/components.ts
+++ b/test/components.ts
@@ -283,7 +283,8 @@ export function createTestAccessComponent(
 export function createTestItemsComponent({ validateItemExists = jest.fn() }): IItemsComponent {
   return {
     validateItemExists,
-    getItems: jest.fn()
+    getItems: jest.fn(),
+    getCatalogItems: jest.fn()
   }
 }
 

--- a/test/components.ts
+++ b/test/components.ts
@@ -29,6 +29,7 @@ import { IPicksComponent, createPicksComponent } from '../src/ports/favorites/pi
 import { ISnapshotComponent, createSnapshotComponent } from '../src/ports/favorites/snapshot'
 import { IItemsComponent, createItemsComponent } from '../src/ports/items'
 import { createJobComponent } from '../src/ports/job'
+import { createManaUsdRateComponent } from '../src/ports/mana-rate/component'
 import { createNFTsComponent } from '../src/ports/nfts/component'
 import { createOrdersComponent } from '../src/ports/orders/component'
 import { createOwnersComponent } from '../src/ports/owners/component'
@@ -115,6 +116,7 @@ async function initComponents(): Promise<TestComponents> {
   const picks = createPicksComponent({ favoritesDatabase, items, snapshot, logs, lists })
   const catalog = await createCatalogComponent({ dappsDatabase: dappsReadDatabase, dappsWriteDatabase, picks }, SEGMENT_WRITE_KEY)
   const shopCatalog = createShopCatalogComponent({ dappsDatabase: dappsReadDatabase, logs })
+  const manaUsdRate = await createManaUsdRateComponent({ config, logs })
   const schemaValidator = await createSchemaValidatorComponent()
   const trades = createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs })
   const bids = createBidsComponents({ dappsDatabase: dappsReadDatabase })
@@ -174,6 +176,7 @@ async function initComponents(): Promise<TestComponents> {
     favoritesDatabase,
     catalog,
     shopCatalog,
+    manaUsdRate,
     wertSigner,
     wertApi,
     ens,

--- a/test/unit/items-catalog-component.spec.ts
+++ b/test/unit/items-catalog-component.spec.ts
@@ -1,0 +1,152 @@
+import { Network, Rarity } from '@dcl/schemas'
+import { createItemsComponent } from '../../src/ports/items'
+import { CatalogDBItem, IItemsComponent, ItemType } from '../../src/ports/items/types'
+import { createTestLogsComponent, createTestPgComponent } from '../components'
+
+// A catalog-items row: the columns fromDBItemToItem consumes plus the SQL-computed price_credits. The
+// asset-aware credit conversion happens in SQL, so the row supplies price_credits directly; the
+// SQL-shape assertions below cover the conversion (rate vs no-rate) itself.
+function catalogRow(overrides: Partial<CatalogDBItem> = {}): CatalogDBItem {
+  return {
+    count: 1,
+    id: '0xcollection-3',
+    image: 'ipfs://hat.png',
+    uri: 'url',
+    item_type: ItemType.WEARABLE_V2,
+    item_id: '3',
+    contract_address: '0xcollection',
+    rarity: Rarity.RARE,
+    price: '0',
+    available: 10,
+    creator: '0xcreator',
+    beneficiary: '0x',
+    created_at: 1_700_000_000,
+    updated_at: 1_700_000_000,
+    reviewed_at: 1_700_000_000,
+    sold_at: 0,
+    urn: 'urn',
+    name: 'Cool Hat',
+    network: Network.MATIC,
+    search_is_store_minter: true,
+    search_is_marketplace_v3_minter: false,
+    first_listed_at: new Date(1_700_000_000_000),
+    trade_price: '0',
+    price_credits: '5',
+    ...overrides
+  } as CatalogDBItem
+}
+
+describe('Items catalog feed (getCatalogItems)', () => {
+  let items: IItemsComponent
+  let query: jest.Mock
+  const RATE = 0.5
+  const RATE_STR = RATE.toFixed(18)
+
+  beforeEach(() => {
+    query = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 })
+    const dappsDatabase = createTestPgComponent({ query })
+    const logs = createTestLogsComponent({
+      getLogger: jest.fn().mockReturnValue({ error: () => undefined, info: () => undefined, warn: () => undefined, debug: () => undefined })
+    })
+    items = createItemsComponent({ dappsDatabase, logs })
+  })
+
+  describe('when mapping a catalog item row', () => {
+    it('should attach the SQL-computed priceCredits to the /v1/items item shape', async () => {
+      query.mockResolvedValueOnce({ rows: [catalogRow({ price_credits: '5' })], rowCount: 1 })
+
+      const { data, total } = await items.getCatalogItems({}, RATE)
+
+      expect(total).toBe(1)
+      expect(data[0]).toMatchObject({
+        id: '0xcollection-3',
+        contractAddress: '0xcollection',
+        itemId: '3',
+        priceCredits: 5
+      })
+    })
+
+    it('should map a not-for-sale item (price_credits 0) to priceCredits 0', async () => {
+      query.mockResolvedValueOnce({
+        rows: [catalogRow({ available: 0, search_is_store_minter: false, price_credits: '0' })],
+        rowCount: 1
+      })
+
+      const { data } = await items.getCatalogItems({}, RATE)
+
+      expect(data[0].priceCredits).toBe(0)
+    })
+
+    it('should treat a null price_credits as 0 instead of NaN', async () => {
+      query.mockResolvedValueOnce({ rows: [catalogRow({ price_credits: null })], rowCount: 1 })
+
+      const { data } = await items.getCatalogItems({}, RATE)
+
+      expect(data[0].priceCredits).toBe(0)
+    })
+  })
+
+  describe('when building the catalog-items query', () => {
+    it('should compute an asset-type-aware price_credits column keyed on the USD-pegged asset type', async () => {
+      await items.getCatalogItems({}, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('AS price_credits')
+      // The USD-pegged branch is selected by the received asset type (USD_PEGGED_MANA = 2).
+      expect(sql.text).toContain("ta.direction = 'received'")
+      expect(sql.values).toContain(2)
+    })
+
+    it('should pass USD-pegged amounts straight through (no rate) but multiply MANA amounts by the rate', async () => {
+      await items.getCatalogItems({}, RATE)
+
+      const sql = query.mock.calls[0][0]
+      // USD-pegged trade: divide the raw amount by the wei-per-credit only -- never multiplied by a rate.
+      expect(sql.text).toContain("THEN CEIL((unified_trades.assets -> 'received' ->> 'amount')::numeric / ")
+      // MANA store-minter price: multiplied by the bound rate before dividing.
+      expect(sql.text).toContain('CEIL(item.price::numeric * ')
+      // The rate is bound as a parameter, never interpolated into the text.
+      expect(sql.values).toContain(RATE_STR)
+    })
+
+    it('should ceil-round to whole credits so a credit price never under-states the settlement amount', async () => {
+      await items.getCatalogItems({}, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('CEIL(')
+      expect(sql.text).toContain('::bigint AS price_credits')
+    })
+
+    it('should degrade to a 0 rate literal for a broken (non-positive) rate rather than pricing off it', async () => {
+      await items.getCatalogItems({}, 0)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.values).toContain('0')
+    })
+
+    it('should filter by a lowercased creator', async () => {
+      await items.getCatalogItems({ creator: ['0xABCDEF'] }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('LOWER(item.creator) = ANY(')
+      expect(sql.values).toContainEqual(['0xabcdef'])
+    })
+
+    it('should filter by contract address (collection)', async () => {
+      await items.getCatalogItems({ contractAddresses: ['0xcollection'] }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('item.collection_id = ANY (')
+      expect(sql.values).toContainEqual(['0xcollection'])
+    })
+
+    it('should bind LIMIT/OFFSET for pagination', async () => {
+      await items.getCatalogItems({ first: 20, skip: 40 }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('LIMIT')
+      expect(sql.text).toContain('OFFSET')
+      expect(sql.values).toEqual(expect.arrayContaining([20, 40]))
+    })
+  })
+})

--- a/test/unit/mana-rate-component.spec.ts
+++ b/test/unit/mana-rate-component.spec.ts
@@ -1,0 +1,156 @@
+import { createManaUsdRateComponent } from '../../src/ports/mana-rate/component'
+import { IManaUsdRateComponent } from '../../src/ports/mana-rate/types'
+
+// The aggregator methods are backed by these module-scope mocks so each test can drive the on-chain
+// oracle response. Classes are used for the ethers constructors so `resetMocks` can't wipe them.
+const mockDecimals = jest.fn()
+const mockLatestRoundData = jest.fn()
+
+jest.mock('ethers', () => ({
+  ethers: {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- must match the ethers API names.
+    JsonRpcProvider: class {},
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- must match the ethers API names.
+    Contract: class {
+      decimals = (...args: unknown[]) => mockDecimals(...args)
+      latestRoundData = (...args: unknown[]) => mockLatestRoundData(...args)
+    }
+  }
+}))
+
+// A recent unix timestamp (seconds) so the staleness guard passes unless a test overrides it.
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+// [roundId, answer, startedAt, updatedAt, answeredInRound]
+function roundData(overrides: Partial<{ roundId: bigint; answer: bigint; updatedAt: number; answeredInRound: bigint }> = {}) {
+  const roundId = overrides.roundId ?? 10n
+  return [
+    roundId,
+    overrides.answer ?? 2_000_000n, // 0.02 USD/MANA at 8 decimals
+    0n,
+    BigInt(overrides.updatedAt ?? nowSeconds()),
+    overrides.answeredInRound ?? roundId
+  ]
+}
+
+function createConfig(values: Record<string, string | undefined>) {
+  return {
+    getString: jest.fn(async (key: string) => values[key]),
+    getNumber: jest.fn(async (key: string) => (values[key] != null ? Number(values[key]) : undefined)),
+    requireString: jest.fn(),
+    requireNumber: jest.fn(),
+    getBoolean: jest.fn(),
+    requireBoolean: jest.fn()
+  } as any
+}
+
+const warn = jest.fn()
+const logs = {
+  getLogger: () => ({ warn, info: jest.fn(), error: jest.fn(), debug: jest.fn() })
+} as any
+
+// The oracle-configured happy path config (decimals + a valid round).
+const ORACLE_CONFIG = {
+  RPC_ENDPOINT_POLYGON: 'http://rpc.example',
+  MANA_USD_ORACLE_ADDRESS: '0xaggregator'
+}
+
+describe('MANA/USD rate component', () => {
+  let component: IManaUsdRateComponent
+
+  afterEach(async () => {
+    await component?.stop?.()
+  })
+
+  describe('when the oracle is not configured', () => {
+    it('should return the configured fallback rate and never throw on refresh', async () => {
+      component = await createManaUsdRateComponent({ config: createConfig({ MANA_USD_FALLBACK_RATE: '0.05' }), logs })
+
+      await expect(component.refresh()).resolves.toBeUndefined()
+      expect(component.getRate()).toBe(0.05)
+    })
+
+    it('should fall back to the code default when no fallback is configured', async () => {
+      component = await createManaUsdRateComponent({ config: createConfig({}), logs })
+
+      expect(component.getRate()).toBe(0.02)
+    })
+  })
+
+  describe('when the oracle is configured and answers a valid round', () => {
+    it('should cache the converted USD-per-MANA rate after a refresh', async () => {
+      mockDecimals.mockResolvedValue(8)
+      mockLatestRoundData.mockResolvedValue(roundData({ answer: 3_500_000n })) // 0.035
+      component = await createManaUsdRateComponent({ config: createConfig(ORACLE_CONFIG), logs })
+
+      await component.refresh()
+
+      expect(component.getRate()).toBeCloseTo(0.035, 8)
+    })
+
+    it('should keep the last-known rate when a later refresh fails (fail safe)', async () => {
+      mockDecimals.mockResolvedValue(8)
+      mockLatestRoundData.mockResolvedValueOnce(roundData({ answer: 4_000_000n })) // 0.04 on the first call
+      component = await createManaUsdRateComponent({ config: createConfig(ORACLE_CONFIG), logs })
+
+      await component.refresh()
+      expect(component.getRate()).toBeCloseTo(0.04, 8)
+
+      mockLatestRoundData.mockRejectedValueOnce(new Error('RPC down'))
+      await expect(component.refresh()).resolves.toBeUndefined()
+
+      // Still the last-known value, not the fallback.
+      expect(component.getRate()).toBeCloseTo(0.04, 8)
+    })
+  })
+
+  describe('when the oracle returns a bad round', () => {
+    beforeEach(() => {
+      mockDecimals.mockResolvedValue(8)
+    })
+
+    it('should ignore an incomplete round (answeredInRound < roundId) and use the fallback', async () => {
+      mockLatestRoundData.mockResolvedValue(roundData({ roundId: 10n, answeredInRound: 9n }))
+      component = await createManaUsdRateComponent({ config: createConfig({ ...ORACLE_CONFIG, MANA_USD_FALLBACK_RATE: '0.07' }), logs })
+
+      await component.refresh()
+
+      expect(component.getRate()).toBe(0.07)
+    })
+
+    it('should ignore a stale round and use the fallback', async () => {
+      mockLatestRoundData.mockResolvedValue(roundData({ updatedAt: nowSeconds() - 200_000 }))
+      component = await createManaUsdRateComponent({
+        config: createConfig({ ...ORACLE_CONFIG, MANA_USD_FALLBACK_RATE: '0.07', MANA_ORACLE_MAX_STALENESS_SECONDS: '86400' }),
+        logs
+      })
+
+      await component.refresh()
+
+      expect(component.getRate()).toBe(0.07)
+    })
+
+    it('should ignore a non-positive rate and use the fallback', async () => {
+      mockLatestRoundData.mockResolvedValue(roundData({ answer: 0n }))
+      component = await createManaUsdRateComponent({ config: createConfig({ ...ORACLE_CONFIG, MANA_USD_FALLBACK_RATE: '0.07' }), logs })
+
+      await component.refresh()
+
+      expect(component.getRate()).toBe(0.07)
+    })
+  })
+
+  describe('when starting the component', () => {
+    it('should perform an initial refresh so the rate is available immediately', async () => {
+      mockDecimals.mockResolvedValue(8)
+      mockLatestRoundData.mockResolvedValue(roundData({ answer: 1_500_000n })) // 0.015
+      component = await createManaUsdRateComponent({ config: createConfig(ORACLE_CONFIG), logs })
+
+      await component.start?.({} as any)
+
+      expect(component.getRate()).toBeCloseTo(0.015, 8)
+    })
+  })
+})

--- a/test/unit/mana-rate-component.spec.ts
+++ b/test/unit/mana-rate-component.spec.ts
@@ -5,11 +5,14 @@ import { IManaUsdRateComponent } from '../../src/ports/mana-rate/types'
 // oracle response. Classes are used for the ethers constructors so `resetMocks` can't wipe them.
 const mockDecimals = jest.fn()
 const mockLatestRoundData = jest.fn()
+const mockDestroy = jest.fn()
 
 jest.mock('ethers', () => ({
   ethers: {
     // eslint-disable-next-line @typescript-eslint/naming-convention -- must match the ethers API names.
-    JsonRpcProvider: class {},
+    JsonRpcProvider: class {
+      destroy = (...args: unknown[]) => mockDestroy(...args)
+    },
     // eslint-disable-next-line @typescript-eslint/naming-convention -- must match the ethers API names.
     Contract: class {
       decimals = (...args: unknown[]) => mockDecimals(...args)
@@ -151,6 +154,35 @@ describe('MANA/USD rate component', () => {
       await component.start?.({} as any)
 
       expect(component.getRate()).toBeCloseTo(0.015, 8)
+    })
+
+    it('should not block startup forever when the oracle hangs, booting on the fallback instead', async () => {
+      mockDecimals.mockResolvedValue(8)
+      // Oracle never answers: the initial refresh hangs, so start() must fall through on the timeout.
+      mockLatestRoundData.mockReturnValue(new Promise(() => undefined))
+      component = await createManaUsdRateComponent({
+        config: createConfig({ ...ORACLE_CONFIG, MANA_USD_FALLBACK_RATE: '0.09', MANA_RATE_STARTUP_TIMEOUT_MS: '20' }),
+        logs
+      })
+
+      await component.start?.({} as any)
+
+      // Booted without a live rate; still returns the fallback rather than wedging.
+      expect(component.getRate()).toBe(0.09)
+    })
+  })
+
+  describe('when stopping the component', () => {
+    it('should destroy the RPC provider so its sockets/timers are released', async () => {
+      mockDecimals.mockResolvedValue(8)
+      mockLatestRoundData.mockResolvedValue(roundData({ answer: 2_000_000n }))
+      component = await createManaUsdRateComponent({ config: createConfig(ORACLE_CONFIG), logs })
+      // A refresh builds the provider so stop() has something to tear down.
+      await component.refresh()
+
+      await component.stop?.()
+
+      expect(mockDestroy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -46,6 +46,31 @@ function legacyRow(overrides: Record<string, unknown> = {}) {
   }
 }
 
+// A row from the unified feed. priceCredits is computed in SQL (CEIL of the USD-wei-equivalent), so a
+// test that mocks the query supplies it directly; SQL-shape assertions cover the conversion itself.
+function unifiedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    source: 'native',
+    trade_id: 'trade-1',
+    trade_type: 'public_item_order',
+    contract_address: '0xcollection',
+    item_id: '3',
+    token_id: null,
+    name: 'Cool Hat',
+    image: 'ipfs://hat.png',
+    rarity: 'RARE',
+    item_type: 'wearable_v2',
+    wearable_category: 'hat',
+    creator: '0xcreator',
+    price_credits: '5',
+    available: '10',
+    network: 'MATIC',
+    created_at: '1700000000000',
+    total: '1',
+    ...overrides
+  }
+}
+
 describe('Shop Catalog Component', () => {
   let shopCatalog: IShopCatalogComponent
   let query: jest.Mock
@@ -334,6 +359,124 @@ describe('Shop Catalog Component', () => {
         network: 'MATIC',
         createdAt: 1700000000000
       })
+    })
+  })
+
+  describe('when building the unified listings query', () => {
+    // 0.5 USD/MANA, formatted the way the component binds it into the numeric multiply.
+    const RATE = 0.5
+    const RATE_STR = RATE.toFixed(18)
+
+    beforeEach(() => {
+      query.mockResolvedValue({ rows: [] })
+    })
+
+    it('should merge native and legacy sources with UNION ALL by default', async () => {
+      await shopCatalog.getUnifiedListings({}, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('UNION ALL')
+      // Both asset types are present: native (USD-pegged = 2) and legacy classic ERC20 (= 1).
+      expect(sql.values).toContain(2)
+      expect(sql.values).toContain(1)
+    })
+
+    it('should compute priceCredits in SQL as CEIL of the USD-wei-equivalent', async () => {
+      await shopCatalog.getUnifiedListings({}, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('CEIL(sub.usd_wei /')
+      expect(sql.text).toContain('AS price_credits')
+    })
+
+    it('should apply the MANA/USD rate to legacy amounts but leave native amounts untouched', async () => {
+      await shopCatalog.getUnifiedListings({}, RATE)
+
+      const sql = query.mock.calls[0][0]
+      // Legacy branch multiplies the raw MANA amount by the bound rate; native branch does not.
+      expect(sql.text).toContain('mv.amount_received::numeric * ')
+      expect(sql.values).toContain(RATE_STR)
+    })
+
+    it('should filter the merged set by a credit price range translated into USD wei', async () => {
+      await shopCatalog.getUnifiedListings({ minPriceCredits: 3, maxPriceCredits: 10 }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('sub.usd_wei >=')
+      expect(sql.text).toContain('sub.usd_wei <=')
+      expect(sql.values).toContain((3n * WEI_PER_CREDIT).toString())
+      expect(sql.values).toContain((10n * WEI_PER_CREDIT).toString())
+    })
+
+    it('should restrict to the legacy source only when source=legacy (no native branch)', async () => {
+      await shopCatalog.getUnifiedListings({ source: 'legacy' }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).not.toContain('UNION ALL')
+      expect(sql.values).toContain(1)
+      expect(sql.values).not.toContain(2)
+    })
+
+    it('should restrict to the native source only when source=native (no legacy branch)', async () => {
+      await shopCatalog.getUnifiedListings({ source: 'native' }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).not.toContain('UNION ALL')
+      expect(sql.values).toContain(2)
+      expect(sql.values).not.toContain(1)
+    })
+
+    it('should sort the merged set on the USD-wei-equivalent, never on user input', async () => {
+      await shopCatalog.getUnifiedListings({ sortBy: 'cheapest' }, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY sub.usd_wei ASC')
+
+      query.mockClear()
+      await shopCatalog.getUnifiedListings({ sortBy: 'most_expensive' }, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY sub.usd_wei DESC')
+
+      query.mockClear()
+      await shopCatalog.getUnifiedListings({}, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY sub.created_at DESC')
+    })
+
+    it('should drop free items via a usd_wei guard on the merged set', async () => {
+      await shopCatalog.getUnifiedListings({}, RATE)
+
+      expect(query.mock.calls[0][0].text).toContain('sub.usd_wei > 0')
+    })
+  })
+
+  describe('when mapping unified listing rows', () => {
+    it('should carry a server-computed priceCredits and a source discriminator for each item', async () => {
+      query.mockResolvedValueOnce({
+        rows: [
+          unifiedRow({ source: 'native', trade_id: 'native-1', price_credits: '5', total: '2' }),
+          unifiedRow({
+            source: 'legacy',
+            trade_id: 'legacy-1',
+            trade_type: 'public_item_order',
+            token_id: null,
+            price_credits: '3',
+            total: '2'
+          })
+        ]
+      })
+
+      const { data, total } = await shopCatalog.getUnifiedListings({}, 0.5)
+
+      expect(total).toBe(2)
+      expect(data[0]).toMatchObject({ source: 'native', tradeId: 'native-1', priceCredits: 5, listingType: 'primary' })
+      expect(data[1]).toMatchObject({ source: 'legacy', tradeId: 'legacy-1', priceCredits: 3, listingType: 'primary' })
+    })
+
+    it('should tag a secondary (public_nft_order) native row and keep its tokenId', async () => {
+      query.mockResolvedValueOnce({
+        rows: [unifiedRow({ source: 'native', trade_type: 'public_nft_order', token_id: '99', item_id: null, price_credits: '7' })]
+      })
+
+      const { data } = await shopCatalog.getUnifiedListings({}, 0.5)
+
+      expect(data[0]).toMatchObject({ source: 'native', listingType: 'secondary', tokenId: '99', priceCredits: 7 })
     })
   })
 })

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -63,6 +63,7 @@ function unifiedRow(overrides: Record<string, unknown> = {}) {
     wearable_category: 'hat',
     creator: '0xcreator',
     price_credits: '5',
+    mana_wei: null,
     available: '10',
     network: 'MATIC',
     created_at: '1700000000000',
@@ -488,13 +489,14 @@ describe('Shop Catalog Component', () => {
     it('should carry a server-computed priceCredits and a source discriminator for each item', async () => {
       query.mockResolvedValueOnce({
         rows: [
-          unifiedRow({ source: 'native', trade_id: 'native-1', price_credits: '5', total: '2' }),
+          unifiedRow({ source: 'native', trade_id: 'native-1', price_credits: '5', mana_wei: null, total: '2' }),
           unifiedRow({
             source: 'legacy',
             trade_id: 'legacy-1',
             trade_type: 'public_item_order',
             token_id: null,
             price_credits: '3',
+            mana_wei: '2500000000000000000',
             total: '2'
           })
         ]
@@ -503,8 +505,9 @@ describe('Shop Catalog Component', () => {
       const { data, total } = await shopCatalog.getUnifiedListings({}, 0.5)
 
       expect(total).toBe(2)
-      expect(data[0]).toMatchObject({ source: 'native', tradeId: 'native-1', priceCredits: 5, listingType: 'primary' })
-      expect(data[1]).toMatchObject({ source: 'legacy', tradeId: 'legacy-1', priceCredits: 3, listingType: 'primary' })
+      // Native carries no MANA price; legacy carries the raw MANA wei for live-rate sizing at checkout.
+      expect(data[0]).toMatchObject({ source: 'native', tradeId: 'native-1', priceCredits: 5, manaWei: null })
+      expect(data[1]).toMatchObject({ source: 'legacy', tradeId: 'legacy-1', priceCredits: 3, manaWei: '2500000000000000000' })
     })
 
     it('should tag a secondary (public_nft_order) native row and keep its tokenId', async () => {

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -372,6 +372,18 @@ describe('Shop Catalog Component', () => {
       query.mockResolvedValue({ rows: [] })
     })
 
+    it('should keep the mana_wei column separated from the FROM clause (no token concatenation)', async () => {
+      await shopCatalog.getUnifiedListings({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      // Guards the SELECT→FROM boundary: a missing space would emit `mana_weiFROM`, a SQL syntax error.
+      expect(text).not.toMatch(/mana_weiFROM/)
+      expect(text).toContain('AS mana_wei FROM marketplace.mv_trades')
+      // Both branches: native has no MANA price, legacy carries the raw amount.
+      expect(text).toContain('NULL::text AS mana_wei FROM')
+      expect(text).toContain('mv.amount_received::text AS mana_wei FROM')
+    })
+
     it('should merge native and legacy sources with UNION ALL by default', async () => {
       await shopCatalog.getUnifiedListings({}, RATE)
 

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -398,14 +398,52 @@ describe('Shop Catalog Component', () => {
       expect(sql.values).toContain(RATE_STR)
     })
 
-    it('should filter the merged set by a credit price range translated into USD wei', async () => {
+    it('should filter the merged set by a credit price range translated into USD wei (ceil-consistent lower bound)', async () => {
       await shopCatalog.getUnifiedListings({ minPriceCredits: 3, maxPriceCredits: 10 }, RATE)
 
       const sql = query.mock.calls[0][0]
-      expect(sql.text).toContain('sub.usd_wei >=')
+      // Lower bound is CEIL-consistent: keep usd_wei > (m - 1) * WEI so items whose displayed CEIL price
+      // equals m are included. Upper bound stays an inclusive <=.
+      expect(sql.text).toContain('sub.usd_wei > ')
       expect(sql.text).toContain('sub.usd_wei <=')
-      expect(sql.values).toContain((3n * WEI_PER_CREDIT).toString())
+      expect(sql.values).toContain((2n * WEI_PER_CREDIT).toString())
       expect(sql.values).toContain((10n * WEI_PER_CREDIT).toString())
+    })
+
+    it('should include a fractional-priced legacy item whose displayed (CEIL) credit price equals minPriceCredits', async () => {
+      // A legacy item at usd_wei = 4.2e17 displays as CEIL(4.2) = 5 credits. With minPriceCredits=5 the
+      // ceil-consistent bound is usd_wei > (5-1)*1e17 = 4e17, so 4.2e17 IS included. A naive `>= 5e17`
+      // bound would wrongly exclude it (the fixed bug).
+      await shopCatalog.getUnifiedListings({ minPriceCredits: 5 }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.values).toContain((4n * WEI_PER_CREDIT).toString())
+      expect(sql.values).not.toContain((5n * WEI_PER_CREDIT).toString())
+    })
+
+    it('should not append a negative lower bound when minPriceCredits is 0', async () => {
+      await shopCatalog.getUnifiedListings({ minPriceCredits: 0 }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      // Only the free-item guard (usd_wei > 0) remains; no negative (m-1)*WEI bound is bound as a value.
+      expect(sql.values).not.toContain((-1n * WEI_PER_CREDIT).toString())
+    })
+
+    it('should append a stable trade_id tiebreaker to every sort so pagination is deterministic', async () => {
+      await shopCatalog.getUnifiedListings({ sortBy: 'cheapest' }, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY sub.usd_wei ASC, sub.trade_id')
+
+      query.mockClear()
+      await shopCatalog.getUnifiedListings({ sortBy: 'most_expensive' }, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY sub.usd_wei DESC, sub.trade_id')
+
+      query.mockClear()
+      await shopCatalog.getUnifiedListings({ sortBy: 'name' }, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY sub.name ASC, sub.trade_id')
+
+      query.mockClear()
+      await shopCatalog.getUnifiedListings({}, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY sub.created_at DESC, sub.trade_id')
     })
 
     it('should restrict to the legacy source only when source=legacy (no native branch)', async () => {


### PR DESCRIPTION
Adds server-side, credit-priced catalog feeds so the Shop shows every item in Credits with a price that matches what checkout charges — instead of the client guessing a conversion. Purely additive: `/v1/*` and `/v2/*` are untouched.

## Changes

- **MANA/USD rate component** (`src/ports/mana-rate/`) — reads the same on-chain aggregator the purchase path settles at, caches it and refreshes on an interval, and fails safe (last-known / configured fallback; `getRate()` never throws, bounded startup, clean shutdown).
- **`GET /v3/catalog/items`** — the credit-aware catalog feed the Shop's collection/creator pages consume. Same data source and full-catalog semantics as `/v1/items` (all items, `creator`/`contractAddress` filters), plus a server-computed **`priceCredits`** per item that is **asset-type-aware**: USD-pegged priced directly (`CEIL(amount/1e17)`, no rate), classic MANA / store-minter converted at the rate, not-for-sale → 0. The price branch selection is equivalent to how `/v1/items` resolves the sold price, so credits never diverge from it.
- **`GET /v3/catalog/unified`** — native + legacy listings merged into one credit-priced, sortable/filterable feed (groundwork for a single unified browse). Carries `priceCredits` + a `source` discriminator.
- Fixes on the unified feed: ceil-consistent `minPriceCredits` lower bound, a stable sort tiebreaker for deterministic pagination.

## Test plan

- [x] jest suite green (735 passing); new coverage for asset-aware pricing (USD-pegged not rate-applied vs MANA rate-applied), not-for-sale → 0, `creator`/`contractAddress` filters, the min-filter boundary, sort tiebreaker, and rate cache/fallback/shutdown.
- [x] build + lint clean.