### PR TITLE
feat: expose wearable gender in shop catalog feeds

### DIFF
--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -64,6 +64,20 @@ function metadataJoins() {
     .append(SQL`.item item_s ON mv.type = 'public_nft_order' AND item_s.id = nft.item_id`)
 }
 
+// Display gender as a SELECT expression, derived from the item's supported body shapes
+// (search_wearable_body_shapes contains 'BaseMale'/'BaseFemale'). Both -> unisex, one -> that gender,
+// neither/emote -> null. COALESCE(item_p, item_s) picks whichever side of the primary/secondary join
+// is populated; ::text[] on both sides keeps the @> element types matching. No params -> safe to weave
+// straight into the SELECT list.
+function genderExpr() {
+  return SQL`CASE
+      WHEN COALESCE(item_p.search_wearable_body_shapes, item_s.search_wearable_body_shapes)::text[] @> ARRAY['BaseMale','BaseFemale']::text[] THEN 'unisex'
+      WHEN COALESCE(item_p.search_wearable_body_shapes, item_s.search_wearable_body_shapes)::text[] @> ARRAY['BaseMale']::text[] THEN 'male'
+      WHEN COALESCE(item_p.search_wearable_body_shapes, item_s.search_wearable_body_shapes)::text[] @> ARRAY['BaseFemale']::text[] THEN 'female'
+      ELSE NULL
+    END AS gender`
+}
+
 // 1 credit = $0.10; $1 = 1e18 USD wei = 10 credits, so 1 credit = 1e17 USD wei.
 const USD_WEI_PER_CREDIT = 100000000000000000n
 
@@ -190,6 +204,9 @@ function unifiedBranch(opts: {
     // Raw MANA price, exposed only for legacy (MANA-priced) items so the client can size the purchase
     // at the LIVE rate at checkout; native (USD-pegged) items carry no MANA price.
     .append(applyRate ? SQL`mv.amount_received::text AS mana_wei ` : SQL`NULL::text AS mana_wei `)
+    .append(SQL`, `)
+    .append(genderExpr())
+    .append(SQL` `)
     .append(metadataJoins()).append(SQL`
       WHERE mv.status = 'open'
         AND (mv.available IS NULL OR mv.available > 0)`)
@@ -236,7 +253,11 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
         mv.network AS network,
         EXTRACT(EPOCH FROM mv.created_at)::bigint * 1000 AS created_at,
         COUNT(*) OVER() AS total
-      `.append(metadataJoins()).append(SQL`
+      `
+      .append(SQL`, `)
+      .append(genderExpr())
+      .append(SQL` `)
+      .append(metadataJoins()).append(SQL`
       WHERE mv.status = 'open'
         AND (mv.available IS NULL OR mv.available > 0)
         AND EXISTS (
@@ -316,6 +337,7 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
         rarity: (r.rarity ?? 'common').toLowerCase(),
         category: topLevelCategory(r.item_type),
         wearableCategory: r.wearable_category,
+        gender: r.gender ?? null,
         creator: r.creator ?? '',
         priceCredits,
         available: r.available ? Number(r.available) : 1,
@@ -416,7 +438,11 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
         mv.network AS network,
         EXTRACT(EPOCH FROM mv.created_at)::bigint * 1000 AS created_at,
         COUNT(*) OVER() AS total
-      `.append(metadataJoins()).append(SQL`
+      `
+      .append(SQL`, `)
+      .append(genderExpr())
+      .append(SQL` `)
+      .append(metadataJoins()).append(SQL`
       WHERE mv.status = 'open'
         AND mv.type = 'public_item_order'
         AND (mv.available IS NULL OR mv.available > 0)
@@ -472,6 +498,7 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
         rarity: (r.rarity ?? 'common').toLowerCase(),
         category: topLevelCategory(r.item_type),
         wearableCategory: r.wearable_category,
+        gender: r.gender ?? null,
         creator: r.creator ?? '',
         manaWei: r.mana_wei,
         available: r.available ? Number(r.available) : 1,
@@ -584,6 +611,7 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
         rarity: (r.rarity ?? 'common').toLowerCase(),
         category: topLevelCategory(r.item_type),
         wearableCategory: r.wearable_category,
+        gender: r.gender ?? null,
         creator: r.creator ?? '',
         priceCredits: Number(r.price_credits),
         manaWei: r.mana_wei ?? null,

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -9,6 +9,10 @@ export const SHOP_MAX_PAGE_SIZE = 1000
 
 export type ShopListingType = 'primary' | 'secondary'
 
+// Display gender, derived from a wearable's supported body shapes (BaseMale/BaseFemale). `null` for
+// emotes or items with no body-shape metadata.
+export type ShopGender = 'male' | 'female' | 'unisex' | null
+
 export type ShopListing = {
   tradeId: string
   listingType: ShopListingType
@@ -20,6 +24,7 @@ export type ShopListing = {
   rarity: string
   category: string // top-level: 'wearable' | 'emote'
   wearableCategory: string | null // on-chain category (upper_body, hat, ...) when applicable
+  gender: ShopGender // male | female | unisex (from body shapes); null for emotes/unknown
   creator: string
   priceCredits: number // USD -> fixed credits (1 credit = $0.10)
   available: number
@@ -77,6 +82,7 @@ export type LegacyListing = {
   rarity: string
   category: string // top-level: 'wearable' | 'emote'
   wearableCategory: string | null // on-chain category (upper_body, hat, ...) when applicable
+  gender: ShopGender // male | female | unisex (from body shapes); null for emotes/unknown
   creator: string
   manaWei: string // raw MANA price; the client converts to credits via the oracle
   available: number
@@ -155,6 +161,7 @@ export type ShopListingRow = {
   rarity: string | null
   item_type: string | null
   wearable_category: string | null
+  gender: ShopGender
   creator: string | null
   price: string
   available: string | null
@@ -177,6 +184,7 @@ export type UnifiedListingRow = {
   rarity: string | null
   item_type: string | null
   wearable_category: string | null
+  gender: ShopGender
   creator: string | null
   price_credits: string
   mana_wei: string | null
@@ -196,6 +204,7 @@ export type LegacyListingRow = {
   rarity: string | null
   item_type: string | null
   wearable_category: string | null
+  gender: ShopGender
   creator: string | null
   mana_wei: string
   available: string | null

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -61,6 +61,7 @@ function unifiedRow(overrides: Record<string, unknown> = {}) {
     rarity: 'RARE',
     item_type: 'wearable_v2',
     wearable_category: 'hat',
+    gender: 'unisex',
     creator: '0xcreator',
     price_credits: '5',
     mana_wei: null,
@@ -372,16 +373,18 @@ describe('Shop Catalog Component', () => {
       query.mockResolvedValue({ rows: [] })
     })
 
-    it('should keep the mana_wei column separated from the FROM clause (no token concatenation)', async () => {
+    it('should keep the trailing SELECT columns separated from the FROM clause (no token concatenation)', async () => {
       await shopCatalog.getUnifiedListings({}, RATE)
 
       const text = query.mock.calls[0][0].text as string
-      // Guards the SELECT→FROM boundary: a missing space would emit `mana_weiFROM`, a SQL syntax error.
+      // Guards the SELECT→FROM boundary: a missing space would emit `mana_weiFROM` / `genderFROM`, both
+      // SQL syntax errors. gender is the last SELECT column before FROM; mana_wei precedes it.
       expect(text).not.toMatch(/mana_weiFROM/)
-      expect(text).toContain('AS mana_wei FROM marketplace.mv_trades')
-      // Both branches: native has no MANA price, legacy carries the raw amount.
-      expect(text).toContain('NULL::text AS mana_wei FROM')
-      expect(text).toContain('mv.amount_received::text AS mana_wei FROM')
+      expect(text).not.toMatch(/genderFROM/)
+      expect(text).toContain('END AS gender FROM marketplace.mv_trades')
+      // Both branches carry a mana_wei column, comma-separated from the gender expression that follows.
+      expect(text).toContain('NULL::text AS mana_wei ,')
+      expect(text).toContain('mv.amount_received::text AS mana_wei ,')
     })
 
     it('should merge native and legacy sources with UNION ALL by default', async () => {
@@ -530,6 +533,20 @@ describe('Shop Catalog Component', () => {
       const { data } = await shopCatalog.getUnifiedListings({}, 0.5)
 
       expect(data[0]).toMatchObject({ source: 'native', listingType: 'secondary', tokenId: '99', priceCredits: 7 })
+    })
+
+    it('should surface the body-shape-derived gender and coalesce a missing one to null', async () => {
+      query.mockResolvedValueOnce({
+        rows: [
+          unifiedRow({ trade_id: 'm', gender: 'male' }),
+          unifiedRow({ trade_id: 'f', gender: 'female' }),
+          unifiedRow({ trade_id: 'e', gender: null }) // emote / no body shapes
+        ]
+      })
+
+      const { data } = await shopCatalog.getUnifiedListings({}, 0.5)
+
+      expect(data.map(d => d.gender)).toEqual(['male', 'female', null])
     })
   })
 })


### PR DESCRIPTION
## Changes

- Derive a display `gender` (`male` / `female` / `unisex`, `null` for emotes) from each item's supported body shapes (`search_wearable_body_shapes` contains `BaseMale` / `BaseFemale`) and expose it on the shop, unified, and legacy catalog feeds.
- Add `gender` to `ShopListing` / `UnifiedListing` / `LegacyListing` (and their row types); `getImportableListings` is unchanged.
- The gender expression is param-less SQL woven into each SELECT via a shared `genderExpr()` helper; `::text[]` casts keep the `@>` element types matching.

The Shop card renders a gender chip alongside the rarity + category chips; without this field the client had no gender to show.

## Test plan

- [x] `npm run build`
- [x] shop-catalog unit tests (SQL-shape guard updated for the new SELECT→FROM boundary; added a gender-mapping case)
- [ ] Deploy before the Shop rollout that renders the gender chip