### PR TITLE
feat: shop catalog creator filter

### DIFF
--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -119,6 +119,7 @@ export function createShopUnifiedHandler(
     const category = params.getString('category')
     const contractAddress = params.getString('contractAddress')
     const itemId = params.getString('itemId')
+    const creator = params.getString('creator')
     const rarities = csv(params.getString('rarity'))
     const wearableCategories = csv(params.getString('wearableCategory'))
     const minPriceCredits = params.getNumber('minPriceCredits')
@@ -136,6 +137,7 @@ export function createShopUnifiedHandler(
           category,
           contractAddress,
           itemId,
+          creator,
           rarities,
           wearableCategories,
           minPriceCredits,

--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -34,6 +34,7 @@ export function createShopCatalogHandler(
     const category = params.getString('category')
     const contractAddress = params.getString('contractAddress')
     const itemId = params.getString('itemId')
+    const creator = params.getString('creator')
     const rarities = csv(params.getString('rarity'))
     const wearableCategories = csv(params.getString('wearableCategory'))
     const minPriceCredits = params.getNumber('minPriceCredits')
@@ -48,6 +49,7 @@ export function createShopCatalogHandler(
         category,
         contractAddress,
         itemId,
+        creator,
         rarities,
         wearableCategories,
         minPriceCredits,

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -146,6 +146,9 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
     if (filters.itemId != null) {
       query.append(SQL` AND mv.sent_item_id = ${filters.itemId}`)
     }
+    if (filters.creator) {
+      query.append(SQL` AND lower(COALESCE(item_p.creator, item_s.creator, '')) = ${filters.creator.toLowerCase()}`)
+    }
     if (filters.category === 'emote') {
       query.append(SQL` AND COALESCE(item_p.item_type, item_s.item_type, nft.item_type) ILIKE 'emote%'`)
     } else if (filters.category === 'wearable') {

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -137,6 +137,9 @@ function appendUnifiedFilters(query: SQLStatement, filters: UnifiedCatalogFilter
   if (filters.itemId != null) {
     query.append(SQL` AND mv.sent_item_id = ${filters.itemId}`)
   }
+  if (filters.creator) {
+    query.append(SQL` AND lower(COALESCE(item_p.creator, item_s.creator, '')) = ${filters.creator.toLowerCase()}`)
+  }
   if (filters.category === 'emote') {
     query.append(SQL` AND COALESCE(item_p.item_type, item_s.item_type, nft.item_type) ILIKE 'emote%'`)
   } else if (filters.category === 'wearable') {

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -36,6 +36,7 @@ export type ShopCatalogFilters = {
   category?: string // 'wearable' | 'emote'
   contractAddress?: string
   itemId?: string
+  creator?: string // item creator address — a creator's storefront (their credit-buyable listings)
   rarities?: string[]
   wearableCategories?: string[] // on-chain categories (upper_body, hat, ...)
   minPriceCredits?: number

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -195,6 +195,20 @@ describe('Shop Catalog Component', () => {
       // % and _ are escaped so they match literally instead of acting as wildcards.
       expect(sql.values).toContain('%50\\%\\_off%')
     })
+
+    it('should filter by a lowercased creator address bound as a parameter', async () => {
+      await shopCatalog.getShopListings({ creator: '0xCREATOR' })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain("lower(COALESCE(item_p.creator, item_s.creator, '')) =")
+      expect(sql.values).toContain('0xcreator')
+    })
+
+    it('should not constrain by creator when none is supplied', async () => {
+      await shopCatalog.getShopListings({})
+
+      expect(query.mock.calls[0][0].text).not.toContain("lower(COALESCE(item_p.creator, item_s.creator, '')) =")
+    })
   })
 
   describe('when fetching a seller importable listings', () => {


### PR DESCRIPTION
This pull request adds support for filtering shop catalog listings by the creator's address. The main changes include updating the handler and types to accept a `creator` parameter, modifying the query logic to filter by creator when provided, and adding tests to verify the new behavior.

**Testing improvements:**

* Added unit tests to ensure filtering by creator works as expected and that no filtering occurs when the creator is not supplied.