### PR TITLE
fix: reject bid and order prices paid in a non-mana erc20

### DIFF
--- a/src/controllers/handlers/trades-handler.ts
+++ b/src/controllers/handlers/trades-handler.ts
@@ -6,6 +6,7 @@ import {
   DuplicatedBidError,
   InvalidECDSASignatureError,
   EventNotGeneratedError,
+  InvalidTradePriceAssetError,
   InvalidTradeSignatureError,
   InvalidTradeSignerError,
   InvalidTradeStructureError,
@@ -77,6 +78,7 @@ export async function addTradeHandler(
       e instanceof TradeAlreadyExpiredError ||
       e instanceof TradeEffectiveAfterExpirationError ||
       e instanceof InvalidTradeStructureError ||
+      e instanceof InvalidTradePriceAssetError ||
       e instanceof InvalidTradeSignatureError ||
       e instanceof InvalidTradeSignerError ||
       e instanceof InvalidECDSASignatureError ||

--- a/src/ports/trades/errors.ts
+++ b/src/ports/trades/errors.ts
@@ -18,6 +18,12 @@ export class InvalidTradeStructureError extends Error {
   }
 }
 
+export class InvalidTradePriceAssetError extends Error {
+  constructor() {
+    super('The price of a trade must be paid in MANA')
+  }
+}
+
 export class EstateContractNotFoundForChainId extends Error {
   constructor(public chainId: ChainId) {
     super(`Estate contract not found for chainId ${chainId}`)

--- a/src/ports/trades/utils.ts
+++ b/src/ports/trades/utils.ts
@@ -13,6 +13,7 @@ import {
   Event,
   ChainId
 } from '@dcl/schemas'
+import { ContractName, getContract } from 'decentraland-transactions'
 import { fromTradeAndAssetsToEventNotification } from '../../adapters/trades/trades'
 import { getMarketplaceContracts } from '../../logic/contracts'
 import { isEstateFingerprintValid } from '../../logic/trades/utils'
@@ -26,6 +27,7 @@ import {
   DuplicateItemOrderError,
   DuplicateNFTOrderError,
   EstateContractNotFoundForChainId,
+  InvalidTradePriceAssetError,
   InvalidTradeStructureError
 } from './errors'
 import { TradeEvent } from './types'
@@ -49,6 +51,30 @@ export function isUSDPeggedManaTradeAsset(asset: TradeAsset): asset is USDPegged
 // The price side of a listing/bid can be paid in MANA (ERC20) or as a USD-pegged amount settled in MANA at execution.
 export function isPriceTradeAsset(asset: TradeAsset): asset is ERC20TradeAsset | USDPeggedManaTradeAsset {
   return isERC20TradeAsset(asset) || isUSDPeggedManaTradeAsset(asset)
+}
+
+// The price of a trade must settle in MANA. A USD_PEGGED_MANA asset is always resolved to MANA at
+// execution time by the contract, so its contract address is irrelevant. A plain ERC20 asset, however,
+// is transferred verbatim from the signed contract address, so it must be restricted to the chain's
+// official MANA token. Without this check the price could be denominated in an arbitrary ERC20 that
+// the marketplace UI still presents to the seller as MANA.
+export function isValidPriceAsset(asset: TradeAsset, chainId: ChainId): boolean {
+  if (isUSDPeggedManaTradeAsset(asset)) {
+    return true
+  }
+
+  if (isERC20TradeAsset(asset)) {
+    let manaAddress: string
+    try {
+      manaAddress = getContract(ContractName.MANAToken, chainId).address.toLowerCase()
+    } catch {
+      // An unsupported chain has no MANA token, so the price asset cannot be valid.
+      return false
+    }
+    return asset.contractAddress.toLowerCase() === manaAddress
+  }
+
+  return false
 }
 
 function isBytesEmpty(bytes: string): boolean {
@@ -95,6 +121,11 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
         throw new InvalidTradeStructureError(type)
       }
 
+      // The bid price must settle in MANA, otherwise the seller could be paid in an arbitrary ERC20.
+      if (!isValidPriceAsset(sent[0], trade.chainId)) {
+        throw new InvalidTradePriceAssetError()
+      }
+
       const duplicateBid = await client.query(
         getBidsQuery({
           bidder: trade.signer,
@@ -118,6 +149,11 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
         throw new InvalidTradeStructureError(trade.type)
       }
 
+      // The order price must settle in MANA, otherwise the seller could be paid in an arbitrary ERC20.
+      if (!isValidPriceAsset(received[0], trade.chainId)) {
+        throw new InvalidTradePriceAssetError()
+      }
+
       const query = getNFTsQuery({
         contractAddresses: [trade.sent[0].contractAddress],
         tokenId: (trade.sent[0] as ERC721TradeAsset).tokenId,
@@ -137,6 +173,11 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
 
       if (!sendsCollectionItemAsset || !receivesPriceAsset) {
         throw new InvalidTradeStructureError(trade.type)
+      }
+
+      // The order price must settle in MANA, otherwise the seller could be paid in an arbitrary ERC20.
+      if (!isValidPriceAsset(received[0], trade.chainId)) {
+        throw new InvalidTradePriceAssetError()
       }
 
       const duplicateOrder = await client.query(

--- a/test/integration/trades-controller.spec.ts
+++ b/test/integration/trades-controller.spec.ts
@@ -11,11 +11,14 @@ import {
   TradeAssetDirection,
   ChainId
 } from '@dcl/schemas'
+import { ContractName, getContract } from 'decentraland-transactions'
 import * as chainIdUtils from '../../src/logic/chainIds'
 import * as tradeUtils from '../../src/logic/trades/utils'
 import { StatusCode } from '../../src/types'
 import { test } from '../components'
 import { getSignedFetchRequest } from '../utils'
+
+const MANA_MAINNET_ADDRESS = getContract(ContractName.MANAToken, ChainId.ETHEREUM_MAINNET).address
 
 test('trades controller', function ({ components }) {
   beforeEach(() => {
@@ -49,7 +52,7 @@ test('trades controller', function ({ components }) {
         sent: [
           {
             assetType: TradeAssetType.ERC20,
-            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            contractAddress: MANA_MAINNET_ADDRESS,
             extra: '0x',
             amount: '100'
           }
@@ -357,7 +360,7 @@ test('trades controller', function ({ components }) {
         sent: [
           {
             assetType: TradeAssetType.ERC20,
-            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            contractAddress: MANA_MAINNET_ADDRESS,
             extra: '0x',
             amount: '100'
           }

--- a/test/integration/utils/bids.ts
+++ b/test/integration/utils/bids.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from '@dcl/crypto'
-import { Network, TradeAssetType, TradeCreation, TradeType } from '@dcl/schemas'
+import { ChainId, Network, TradeAssetType, TradeCreation, TradeType } from '@dcl/schemas'
+import { ContractName, getContract } from 'decentraland-transactions'
 import { TestComponents } from '../../../src/types'
 import { getSignedFetchRequest } from '../../utils'
 
@@ -67,7 +68,7 @@ export async function createBidViaAPI(
     sent: [
       {
         assetType: TradeAssetType.ERC20,
-        contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+        contractAddress: getContract(ContractName.MANAToken, ChainId.ETHEREUM_MAINNET).address,
         extra: '0x',
         amount: price
       }

--- a/test/unit/trades-utils.spec.ts
+++ b/test/unit/trades-utils.spec.ts
@@ -24,7 +24,7 @@ import { DBItem, ItemType } from '../../src/ports/items/types'
 import { getNftByTokenIdQuery } from '../../src/ports/nfts/queries'
 import { DBNFT } from '../../src/ports/nfts/types'
 import { TradeEvent } from '../../src/ports/trades'
-import { EstateContractNotFoundForChainId, InvalidTradeStructureError } from '../../src/ports/trades/errors'
+import { EstateContractNotFoundForChainId, InvalidTradePriceAssetError, InvalidTradeStructureError } from '../../src/ports/trades/errors'
 import { getNotificationEventForTrade, isValidEstateTrade, validateTradeByType } from '../../src/ports/trades/utils'
 import { SquidNetwork } from '../../src/types'
 
@@ -394,6 +394,7 @@ describe('when validating trade by type', () => {
   let pgClient: IPgComponent
   let queryMock: jest.Mock
   let trade: Trade
+  const manaAddress = getContract(ContractName.MANAToken, ChainId.ETHEREUM_SEPOLIA).address
 
   beforeEach(() => {
     queryMock = jest.fn().mockResolvedValue({ rowCount: 0, rows: [] })
@@ -426,7 +427,7 @@ describe('when validating trade by type', () => {
       sent: [
         {
           assetType: TradeAssetType.ERC20,
-          contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+          contractAddress: manaAddress,
           extra: '0x',
           amount: '100'
         }
@@ -531,6 +532,57 @@ describe('when validating trade by type', () => {
       })
     })
 
+    describe('and the sent asset is an ERC20 that is not MANA', () => {
+      beforeEach(() => {
+        trade.sent = [
+          {
+            assetType: TradeAssetType.ERC20,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            extra: '0x',
+            amount: '100'
+          }
+        ]
+      })
+
+      it('should throw InvalidTradePriceAsset error', () => {
+        return expect(validateTradeByType(trade, pgClient)).rejects.toEqual(new InvalidTradePriceAssetError())
+      })
+    })
+
+    describe('and the sent asset is a USD-pegged MANA asset', () => {
+      beforeEach(() => {
+        trade.sent = [
+          {
+            assetType: TradeAssetType.USD_PEGGED_MANA,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            extra: '0x',
+            amount: '100'
+          }
+        ]
+      })
+
+      it('should return true', () => {
+        return expect(validateTradeByType(trade, pgClient)).resolves.toBe(true)
+      })
+    })
+
+    describe('and the sent asset is MANA with a checksummed (mixed-case) address', () => {
+      beforeEach(() => {
+        trade.sent = [
+          {
+            assetType: TradeAssetType.ERC20,
+            contractAddress: manaAddress.toUpperCase().replace('0X', '0x'),
+            extra: '0x',
+            amount: '100'
+          }
+        ]
+      })
+
+      it('should return true', () => {
+        return expect(validateTradeByType(trade, pgClient)).resolves.toBe(true)
+      })
+    })
+
     describe('and the trades is correctly defined', () => {
       it('should return true', () => {
         return expect(validateTradeByType(trade, pgClient)).resolves.toBe(true)
@@ -631,7 +683,7 @@ describe('when validating trade by type', () => {
         trade.received = [
           {
             assetType: TradeAssetType.ERC20,
-            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
+            contractAddress: manaAddress,
             amount: '100',
             extra: '0x',
             beneficiary: '0x123'
@@ -650,6 +702,33 @@ describe('when validating trade by type', () => {
 
       it('should return true', () => {
         return expect(validateTradeByType(trade, pgClient)).resolves.toBe(true)
+      })
+    })
+
+    describe('and the received asset is an ERC20 that is not MANA', () => {
+      beforeEach(() => {
+        trade.received = [
+          {
+            assetType: TradeAssetType.ERC20,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
+            amount: '100',
+            extra: '0x',
+            beneficiary: '0x123'
+          }
+        ]
+
+        trade.sent = [
+          {
+            assetType: TradeAssetType.ERC721,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            tokenId: '100',
+            extra: '0x'
+          }
+        ]
+      })
+
+      it('should throw InvalidTradePriceAsset error', () => {
+        return expect(validateTradeByType(trade, pgClient)).rejects.toEqual(new InvalidTradePriceAssetError())
       })
     })
 
@@ -774,7 +853,7 @@ describe('when validating trade by type', () => {
         trade.received = [
           {
             assetType: TradeAssetType.ERC20,
-            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
+            contractAddress: manaAddress,
             amount: '100',
             extra: '0x',
             beneficiary: '0x123'
@@ -793,6 +872,33 @@ describe('when validating trade by type', () => {
 
       it('should return true', () => {
         return expect(validateTradeByType(trade, pgClient)).resolves.toBe(true)
+      })
+    })
+
+    describe('and the received asset is an ERC20 that is not MANA', () => {
+      beforeEach(() => {
+        trade.received = [
+          {
+            assetType: TradeAssetType.ERC20,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763b',
+            amount: '100',
+            extra: '0x',
+            beneficiary: '0x123'
+          }
+        ]
+
+        trade.sent = [
+          {
+            assetType: TradeAssetType.COLLECTION_ITEM,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            itemId: '1',
+            extra: '0x'
+          }
+        ]
+      })
+
+      it('should throw InvalidTradePriceAsset error', () => {
+        return expect(validateTradeByType(trade, pgClient)).rejects.toEqual(new InvalidTradePriceAssetError())
       })
     })
 


### PR DESCRIPTION
## Changes

`validateTradeByType` now rejects any trade whose price asset is a plain ERC20 that is not the chain's official MANA token. Previously the price side of a bid or order could carry an arbitrary ERC20 contract address: the schema validated only the address format, and `validateTradeByType` accepted any `ERC20` asset as a valid price. A trade could therefore be denominated in a token that is not MANA while the marketplace UI still presents the amount to the seller as MANA.

- Add `isValidPriceAsset(asset, chainId)`: a `USD_PEGGED_MANA` asset is allowed (the settlement contract resolves it to MANA at execution, so its address is irrelevant); a plain `ERC20` asset is allowed only when its `contractAddress` equals `getContract(ContractName.MANAToken, chainId)`. Comparison is case-insensitive. An unsupported `chainId` (no MANA token) is treated as invalid.
- Enforce it in all three trade types — bid (`sent[0]`) and both public orders (`received[0]`) — right after the structure check and before signature/ownership validation.
- New `InvalidTradePriceAssetError` mapped to HTTP 400 in the trades handler.

## Test plan

- [x] `npm run build`
- [x] `npm test` (752 unit tests)
- [x] Unit: non-MANA ERC20 price rejected with `InvalidTradePriceAssetError` for bid / NFT order / item order; MANA and `USD_PEGGED_MANA` accepted; mixed-case MANA address accepted
- [x] Integration fixtures updated to sign bids in MANA
- [ ] `npm run test:integration` (requires DB)