### PR TITLE
fix: use live queries for duplicate order detection

### DIFF
--- a/src/controllers/handlers/trades-handler.ts
+++ b/src/controllers/handlers/trades-handler.ts
@@ -15,6 +15,7 @@ import {
   TradeNotFoundBySignatureError,
   TradeNotFoundError,
   DuplicateNFTOrderError,
+  DuplicateItemOrderError,
   InvalidEstateTrade,
   EstateContractNotFoundForChainId
 } from '../../ports/trades/errors'
@@ -94,7 +95,7 @@ export async function addTradeHandler(
       }
     }
 
-    if (e instanceof DuplicatedBidError || e instanceof DuplicateNFTOrderError) {
+    if (e instanceof DuplicatedBidError || e instanceof DuplicateNFTOrderError || e instanceof DuplicateItemOrderError) {
       return {
         status: StatusCode.CONFLICT,
         body: {

--- a/src/ports/trades/queries.ts
+++ b/src/ports/trades/queries.ts
@@ -175,19 +175,21 @@ export function getTradesForTypeQuery(type: TradeType) {
   `
 }
 
-export function getOpenItemOrderQuery(contractAddress: string, itemId: string): SQLStatement {
+export function getOpenItemOrderQuery(contractAddress: string, itemId: string, network: string): SQLStatement {
   return SQL`SELECT 1 FROM (`
     .append(getTradesForTypeQuery(TradeType.PUBLIC_ITEM_ORDER))
     .append(SQL`) AS item_order_trades WHERE item_order_trades.status = ${ListingStatus.OPEN}`)
+    .append(SQL` AND item_order_trades.network = ${network}`)
     .append(SQL` AND (item_order_trades.assets -> 'sent' ->> 'contract_address') = ${contractAddress}`)
     .append(SQL` AND (item_order_trades.assets -> 'sent' ->> 'item_id') = ${itemId}`)
     .append(SQL` LIMIT 1`)
 }
 
-export function getOpenNFTOrderQuery(contractAddress: string, tokenId: string): SQLStatement {
+export function getOpenNFTOrderQuery(contractAddress: string, tokenId: string, network: string): SQLStatement {
   return SQL`SELECT 1 FROM (`
     .append(getTradesForTypeQuery(TradeType.PUBLIC_NFT_ORDER))
     .append(SQL`) AS nft_order_trades WHERE nft_order_trades.status = ${ListingStatus.OPEN}`)
+    .append(SQL` AND nft_order_trades.network = ${network}`)
     .append(SQL` AND (nft_order_trades.assets -> 'sent' ->> 'contract_address') = ${contractAddress}`)
     .append(SQL` AND (nft_order_trades.assets -> 'sent' ->> 'token_id') = ${tokenId}`)
     .append(SQL` LIMIT 1`)

--- a/src/ports/trades/queries.ts
+++ b/src/ports/trades/queries.ts
@@ -175,6 +175,24 @@ export function getTradesForTypeQuery(type: TradeType) {
   `
 }
 
+export function getOpenItemOrderQuery(contractAddress: string, itemId: string): SQLStatement {
+  return SQL`SELECT 1 FROM (`
+    .append(getTradesForTypeQuery(TradeType.PUBLIC_ITEM_ORDER))
+    .append(SQL`) AS item_order_trades WHERE item_order_trades.status = ${ListingStatus.OPEN}`)
+    .append(SQL` AND (item_order_trades.assets -> 'sent' ->> 'contract_address') = ${contractAddress}`)
+    .append(SQL` AND (item_order_trades.assets -> 'sent' ->> 'item_id') = ${itemId}`)
+    .append(SQL` LIMIT 1`)
+}
+
+export function getOpenNFTOrderQuery(contractAddress: string, tokenId: string): SQLStatement {
+  return SQL`SELECT 1 FROM (`
+    .append(getTradesForTypeQuery(TradeType.PUBLIC_NFT_ORDER))
+    .append(SQL`) AS nft_order_trades WHERE nft_order_trades.status = ${ListingStatus.OPEN}`)
+    .append(SQL` AND (nft_order_trades.assets -> 'sent' ->> 'contract_address') = ${contractAddress}`)
+    .append(SQL` AND (nft_order_trades.assets -> 'sent' ->> 'token_id') = ${tokenId}`)
+    .append(SQL` LIMIT 1`)
+}
+
 export function getTradesForTypeQueryWithFilters(type: TradeType, filters: NFTFilters & { nftIds?: string[] }) {
   const marketplacePolygon = getContract(ContractName.OffChainMarketplace, getPolygonChainId())
   const marketplaceEthereum = getContract(ContractName.OffChainMarketplace, getEthereumChainId())

--- a/src/ports/trades/utils.ts
+++ b/src/ports/trades/utils.ts
@@ -156,7 +156,7 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
       }
 
       const duplicateOrder = await client.query(
-        getOpenNFTOrderQuery(trade.sent[0].contractAddress, (trade.sent[0] as ERC721TradeAsset).tokenId)
+        getOpenNFTOrderQuery(trade.sent[0].contractAddress, (trade.sent[0] as ERC721TradeAsset).tokenId, trade.network)
       )
 
       if (duplicateOrder.rowCount > 0) {
@@ -178,7 +178,7 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
       }
 
       const duplicateOrder = await client.query(
-        getOpenItemOrderQuery(trade.sent[0].contractAddress, (trade.sent[0] as CollectionItemTradeAsset).itemId)
+        getOpenItemOrderQuery(trade.sent[0].contractAddress, (trade.sent[0] as CollectionItemTradeAsset).itemId, trade.network)
       )
 
       if (duplicateOrder.rowCount > 0) {

--- a/src/ports/trades/utils.ts
+++ b/src/ports/trades/utils.ts
@@ -19,7 +19,6 @@ import { getMarketplaceContracts } from '../../logic/contracts'
 import { isEstateFingerprintValid } from '../../logic/trades/utils'
 import { getBidsQuery } from '../bids/queries'
 import { getItemByItemIdQuery } from '../items/queries'
-import { getOpenItemOrderQuery, getOpenNFTOrderQuery } from './queries'
 import { DBItem } from '../items/types'
 import { getNftByTokenIdQuery } from '../nfts/queries'
 import { DBNFT } from '../nfts/types'
@@ -31,6 +30,7 @@ import {
   InvalidTradePriceAssetError,
   InvalidTradeStructureError
 } from './errors'
+import { getOpenItemOrderQuery, getOpenNFTOrderQuery } from './queries'
 import { TradeEvent } from './types'
 
 export function isERC20TradeAsset(asset: TradeAsset): asset is ERC20TradeAsset {

--- a/src/ports/trades/utils.ts
+++ b/src/ports/trades/utils.ts
@@ -18,9 +18,10 @@ import { fromTradeAndAssetsToEventNotification } from '../../adapters/trades/tra
 import { getMarketplaceContracts } from '../../logic/contracts'
 import { isEstateFingerprintValid } from '../../logic/trades/utils'
 import { getBidsQuery } from '../bids/queries'
-import { getItemByItemIdQuery, getItemsQuery } from '../items/queries'
+import { getItemByItemIdQuery } from '../items/queries'
+import { getOpenItemOrderQuery, getOpenNFTOrderQuery } from './queries'
 import { DBItem } from '../items/types'
-import { getNftByTokenIdQuery, getNFTsQuery } from '../nfts/queries'
+import { getNftByTokenIdQuery } from '../nfts/queries'
 import { DBNFT } from '../nfts/types'
 import {
   DuplicatedBidError,
@@ -154,13 +155,9 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
         throw new InvalidTradePriceAssetError()
       }
 
-      const query = getNFTsQuery({
-        contractAddresses: [trade.sent[0].contractAddress],
-        tokenId: (trade.sent[0] as ERC721TradeAsset).tokenId,
-        network: trade.network,
-        isOnSale: true
-      })
-      const duplicateOrder = await client.query(query)
+      const duplicateOrder = await client.query(
+        getOpenNFTOrderQuery(trade.sent[0].contractAddress, (trade.sent[0] as ERC721TradeAsset).tokenId)
+      )
 
       if (duplicateOrder.rowCount > 0) {
         throw new DuplicateNFTOrderError()
@@ -181,12 +178,7 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
       }
 
       const duplicateOrder = await client.query(
-        getItemsQuery({
-          contractAddresses: [trade.sent[0].contractAddress],
-          itemId: (trade.sent[0] as CollectionItemTradeAsset).itemId,
-          network: trade.network,
-          isOnSale: true
-        })
+        getOpenItemOrderQuery(trade.sent[0].contractAddress, (trade.sent[0] as CollectionItemTradeAsset).itemId)
       )
 
       if (duplicateOrder.rowCount > 0) {

--- a/test/unit/trades-handler.spec.ts
+++ b/test/unit/trades-handler.spec.ts
@@ -7,6 +7,8 @@ import {
 } from '../../src/controllers/handlers/trades-handler'
 import {
   DuplicatedBidError,
+  DuplicateNFTOrderError,
+  DuplicateItemOrderError,
   EstateContractNotFoundForChainId,
   InvalidEstateTrade,
   EventNotGeneratedError,
@@ -100,7 +102,9 @@ describe('when handling the creation of a new trade', () => {
         error: new EstateContractNotFoundForChainId(ChainId.AVALANCHE_MAINNET),
         code: StatusCode.BAD_REQUEST
       },
-      { errorName: 'DuplicatedBidError', error: new DuplicatedBidError(), code: StatusCode.CONFLICT }
+      { errorName: 'DuplicatedBidError', error: new DuplicatedBidError(), code: StatusCode.CONFLICT },
+      { errorName: 'DuplicateNFTOrderError', error: new DuplicateNFTOrderError(), code: StatusCode.CONFLICT },
+      { errorName: 'DuplicateItemOrderError', error: new DuplicateItemOrderError(), code: StatusCode.CONFLICT }
     ])('and the error is an instance of $errorName', ({ error, code }) => {
       beforeEach(() => {
         body = { type: 'bid' } as TradeCreation


### PR DESCRIPTION
## Problem

When importing multiple listings via the shop import feature, items fail in an alternating pattern: the first succeeds, the second fails with a duplicate order error, the third succeeds, etc. Retrying for up to 2 minutes does not resolve it.

### Root cause

The duplicate order check in `validateTradeByType` used `getItemsQuery({isOnSale: true})` and `getNFTsQuery({isOnSale: true})`, which read from the **materialized view** `mv_trades`. This MV has a **30-second refresh throttle** (`TRADES_MV_REFRESH_INTERVAL_SECONDS = 30`) using a `FOR UPDATE SKIP LOCKED` gate — triggers that fire within the throttle window are silently dropped, not queued.

During sequential import:
1. **Item 1**: cancel old trade on-chain → triggers MV refresh (success) → POST new trade → MV sees no duplicate → ✅
2. **Item 2**: cancel old trade (within 30s) → trigger silently dropped → POST new trade → MV still shows old trade as open → ❌ duplicate error
3. **Item 3**: cancel old trade (throttle expired ~42s later) → MV refreshes → ✅
4. Cycle repeats

Client retries don't help because they're read-only — no new trigger fires to refresh the MV.

## Solution

Replace MV-based duplicate checks with **live queries** using the existing `getTradesForTypeQuery()` function. This function computes trade status directly from source tables with all 5 cancellation conditions:

1. Explicit on-chain cancel
2. Expiration
3. Signer signature index change
4. Contract signature index change
5. Uses exceeded (sold out)

Two new query functions added to `queries.ts`:
- `getOpenItemOrderQuery(contractAddress, itemId)` — for `PUBLIC_ITEM_ORDER`
- `getOpenNFTOrderQuery(contractAddress, tokenId)` — for `PUBLIC_NFT_ORDER`

Both follow the proven pattern used by `getBidTradesQuery` for bid duplicate detection.

### Additional fix (existing commit)
- `DuplicateItemOrderError` now correctly returns 409 CONFLICT instead of 500 (was already missing from the handler's instanceof check)

## Test plan

- [x] TypeScript compilation passes
- [ ] Existing unit tests pass (handler tests for 409 mapping already cover `DuplicateItemOrderError` and `DuplicateNFTOrderError`)
- [ ] Manual test: import multiple shop listings sequentially — all should succeed without alternating failures
- [ ] Verify no regression in bid duplicate detection (unchanged code path)