### PR TITLE
fix: require the signer of a collection item order to be the item creator

### DIFF
--- a/src/controllers/handlers/trades-handler.ts
+++ b/src/controllers/handlers/trades-handler.ts
@@ -4,6 +4,7 @@ import { getNumberParameter, getParameter } from '../../logic/http'
 import { DBTrade } from '../../ports/trades'
 import {
   DuplicatedBidError,
+  InvalidCollectionItemCreatorError,
   InvalidECDSASignatureError,
   EventNotGeneratedError,
   InvalidTradePriceAssetError,
@@ -79,6 +80,7 @@ export async function addTradeHandler(
       e instanceof TradeEffectiveAfterExpirationError ||
       e instanceof InvalidTradeStructureError ||
       e instanceof InvalidTradePriceAssetError ||
+      e instanceof InvalidCollectionItemCreatorError ||
       e instanceof InvalidTradeSignatureError ||
       e instanceof InvalidTradeSignerError ||
       e instanceof InvalidECDSASignatureError ||

--- a/src/ports/trades/errors.ts
+++ b/src/ports/trades/errors.ts
@@ -24,6 +24,12 @@ export class InvalidTradePriceAssetError extends Error {
   }
 }
 
+export class InvalidCollectionItemCreatorError extends Error {
+  constructor() {
+    super('The signer of a collection item order must be the creator of the item')
+  }
+}
+
 export class EstateContractNotFoundForChainId extends Error {
   constructor(public chainId: ChainId) {
     super(`Estate contract not found for chainId ${chainId}`)

--- a/src/ports/trades/utils.ts
+++ b/src/ports/trades/utils.ts
@@ -27,6 +27,7 @@ import {
   DuplicateItemOrderError,
   DuplicateNFTOrderError,
   EstateContractNotFoundForChainId,
+  InvalidCollectionItemCreatorError,
   InvalidTradePriceAssetError,
   InvalidTradeStructureError
 } from './errors'
@@ -178,6 +179,21 @@ export async function validateTradeByType(trade: TradeCreation, client: IPgCompo
       // The order price must settle in MANA, otherwise the seller could be paid in an arbitrary ERC20.
       if (!isValidPriceAsset(received[0], trade.chainId)) {
         throw new InvalidTradePriceAssetError()
+      }
+
+      // A collection item order is a primary sale that mints from the collection, so only the item's
+      // creator can list it. The on-chain contract enforces this (reverting with NotCreator), but
+      // without this check the server would still admit an order signed by any wallet and surface it
+      // as the item's open listing (attacker price and beneficiary), defacing the item and blocking
+      // the creator's own listing via the duplicate-order check below.
+      // collection_id is stored lowercased, so normalize the address to avoid rejecting a legitimate
+      // creator who signs with a checksummed (mixed-case) contract address.
+      const itemResult = await client.query<DBItem>(
+        getItemByItemIdQuery(trade.sent[0].contractAddress.toLowerCase(), (trade.sent[0] as CollectionItemTradeAsset).itemId)
+      )
+      const item = itemResult.rows[0]
+      if (!item || !item.creator || item.creator.toLowerCase() !== trade.signer.toLowerCase()) {
+        throw new InvalidCollectionItemCreatorError()
       }
 
       const duplicateOrder = await client.query(

--- a/test/unit/trades-utils.spec.ts
+++ b/test/unit/trades-utils.spec.ts
@@ -24,7 +24,12 @@ import { DBItem, ItemType } from '../../src/ports/items/types'
 import { getNftByTokenIdQuery } from '../../src/ports/nfts/queries'
 import { DBNFT } from '../../src/ports/nfts/types'
 import { TradeEvent } from '../../src/ports/trades'
-import { EstateContractNotFoundForChainId, InvalidTradePriceAssetError, InvalidTradeStructureError } from '../../src/ports/trades/errors'
+import {
+  EstateContractNotFoundForChainId,
+  InvalidCollectionItemCreatorError,
+  InvalidTradePriceAssetError,
+  InvalidTradeStructureError
+} from '../../src/ports/trades/errors'
 import { getNotificationEventForTrade, isValidEstateTrade, validateTradeByType } from '../../src/ports/trades/utils'
 import { SquidNetwork } from '../../src/types'
 
@@ -868,6 +873,130 @@ describe('when validating trade by type', () => {
             extra: '0x'
           }
         ]
+
+        // The item ownership query resolves to an item whose creator is the signer.
+        queryMock.mockResolvedValueOnce({ rowCount: 1, rows: [{ creator: trade.signer }] })
+      })
+
+      it('should return true', () => {
+        return expect(validateTradeByType(trade, pgClient)).resolves.toBe(true)
+      })
+    })
+
+    describe('and the signer is not the creator of the item', () => {
+      beforeEach(() => {
+        trade.received = [
+          {
+            assetType: TradeAssetType.ERC20,
+            contractAddress: manaAddress,
+            amount: '100',
+            extra: '0x',
+            beneficiary: '0x123'
+          }
+        ]
+
+        trade.sent = [
+          {
+            assetType: TradeAssetType.COLLECTION_ITEM,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            itemId: '1',
+            extra: '0x'
+          }
+        ]
+
+        // The item exists but its creator is a different address than the signer.
+        queryMock.mockResolvedValueOnce({ rowCount: 1, rows: [{ creator: '0xanothercreator' }] })
+      })
+
+      it('should throw InvalidCollectionItemCreator error', () => {
+        return expect(validateTradeByType(trade, pgClient)).rejects.toEqual(new InvalidCollectionItemCreatorError())
+      })
+    })
+
+    describe('and the item does not exist', () => {
+      beforeEach(() => {
+        trade.received = [
+          {
+            assetType: TradeAssetType.ERC20,
+            contractAddress: manaAddress,
+            amount: '100',
+            extra: '0x',
+            beneficiary: '0x123'
+          }
+        ]
+
+        trade.sent = [
+          {
+            assetType: TradeAssetType.COLLECTION_ITEM,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            itemId: '1',
+            extra: '0x'
+          }
+        ]
+
+        // The item ownership query returns no rows.
+        queryMock.mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      })
+
+      it('should throw InvalidCollectionItemCreator error', () => {
+        return expect(validateTradeByType(trade, pgClient)).rejects.toEqual(new InvalidCollectionItemCreatorError())
+      })
+    })
+
+    describe('and the item is missing its creator', () => {
+      beforeEach(() => {
+        trade.received = [
+          {
+            assetType: TradeAssetType.ERC20,
+            contractAddress: manaAddress,
+            amount: '100',
+            extra: '0x',
+            beneficiary: '0x123'
+          }
+        ]
+
+        trade.sent = [
+          {
+            assetType: TradeAssetType.COLLECTION_ITEM,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            itemId: '1',
+            extra: '0x'
+          }
+        ]
+
+        // The item exists but has no creator recorded.
+        queryMock.mockResolvedValueOnce({ rowCount: 1, rows: [{ creator: null }] })
+      })
+
+      it('should throw InvalidCollectionItemCreator error', () => {
+        return expect(validateTradeByType(trade, pgClient)).rejects.toEqual(new InvalidCollectionItemCreatorError())
+      })
+    })
+
+    describe('and the signer matches the creator with a different address casing', () => {
+      beforeEach(() => {
+        trade.signer = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+        trade.received = [
+          {
+            assetType: TradeAssetType.ERC20,
+            contractAddress: manaAddress,
+            amount: '100',
+            extra: '0x',
+            beneficiary: '0x123'
+          }
+        ]
+
+        trade.sent = [
+          {
+            assetType: TradeAssetType.COLLECTION_ITEM,
+            contractAddress: '0x9d32aac179153a991e832550d9f96441ea27763a',
+            itemId: '1',
+            extra: '0x'
+          }
+        ]
+
+        // The stored creator is the same address as the signer but checksummed (mixed-case).
+        queryMock.mockResolvedValueOnce({ rowCount: 1, rows: [{ creator: '0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD' }] })
       })
 
       it('should return true', () => {
@@ -922,6 +1051,9 @@ describe('when validating trade by type', () => {
             extra: '0x'
           }
         ]
+
+        // The item ownership query resolves to an item whose creator is the signer.
+        queryMock.mockResolvedValueOnce({ rowCount: 1, rows: [{ creator: trade.signer }] })
       })
 
       it('should return true', () => {


### PR DESCRIPTION
## Changes

`validateTradeByType` now rejects a `PUBLIC_ITEM_ORDER` whose signer is not the creator of the collection item being listed.

A collection item order is a primary sale that mints from the collection, so only the item's creator can list it — the on-chain marketplace contract enforces this and reverts purchases with `NotCreator`. The server, however, only ran an ownership check when the sent asset was an ERC721; for a collection-item sent asset it performed no authorization check, and `validateTradeByType` never verified `signer == creator`. As a result any authenticated wallet could publish an order on another creator's eligible, unlisted item. Once indexed, that order surfaced as the item's open listing with the attacker's price and beneficiary (`isOnSale: true`, attacker `tradeId`), defacing the item and — via the duplicate-order check — blocking the real creator from listing it. No funds are at risk (purchases revert on-chain), but the item's marketplace presentation is falsified and relisting is blocked until the attacker's order expires or is cancelled.

- Look up the item by collection + item id and throw the new `InvalidTradePriceAssetError`-style `InvalidCollectionItemCreatorError` unless it exists and its `creator` equals `trade.signer` (both compared lowercased; the contract address is normalized to lowercase for the lookup since `collection_id` is stored lowercased).
- Map `InvalidCollectionItemCreatorError` to HTTP 400.

Scope: this closes the ingestion path (no new fraudulent order can be created). Hardening the visibility layer (`trades_owner_ok` in the trades materialized view, which currently admits such rows because a collection-item sent row makes the ownership expression `NULL` and `bool_and` ignores it) and cleaning up any already-persisted invalid rows are deliberately left as follow-ups.

## Test plan

- [x] `npm run build`
- [x] `npm test` (756 unit tests)
- [x] Unit: order rejected when signer != creator, when the item is missing, and when the item has no creator; accepted when signer == creator (incl. mixed-case address); other trade types and USD_PEGGED_MANA item orders unaffected