### PR TITLE
feat: shop catalog smart-wearable filter

### DIFF
--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -44,6 +44,7 @@ export function createShopCatalogHandler(
     const creator = params.getString('creator')
     const rarities = csv(params.getString('rarity'))
     const wearableCategories = csv(params.getString('wearableCategory'))
+    const isSmart = params.getBoolean('isSmart')
     const minPriceCredits = params.getNumber('minPriceCredits')
     const maxPriceCredits = params.getNumber('maxPriceCredits')
     const search = params.getString('search')
@@ -59,6 +60,7 @@ export function createShopCatalogHandler(
         creator,
         rarities,
         wearableCategories,
+        isSmart,
         minPriceCredits,
         maxPriceCredits,
         search,
@@ -122,6 +124,7 @@ export function createShopUnifiedHandler(
     const creator = params.getString('creator')
     const rarities = csv(params.getString('rarity'))
     const wearableCategories = csv(params.getString('wearableCategory'))
+    const isSmart = params.getBoolean('isSmart')
     const minPriceCredits = params.getNumber('minPriceCredits')
     const maxPriceCredits = params.getNumber('maxPriceCredits')
     const search = params.getString('search')
@@ -140,6 +143,7 @@ export function createShopUnifiedHandler(
           creator,
           rarities,
           wearableCategories,
+          isSmart,
           minPriceCredits,
           maxPriceCredits,
           search,

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -159,6 +159,9 @@ function appendUnifiedFilters(query: SQLStatement, filters: UnifiedCatalogFilter
       )})`
     )
   }
+  if (filters.isSmart) {
+    query.append(SQL` AND COALESCE(item_p.item_type, item_s.item_type, nft.item_type) = 'smart_wearable_v1'`)
+  }
   if (filters.search) {
     query.append(SQL` AND COALESCE(nft.name, w_p.name, e_p.name) ILIKE ${'%' + escapeLike(filters.search) + '%'}`)
   }
@@ -295,6 +298,9 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
           c => c.toLowerCase()
         )})`
       )
+    }
+    if (filters.isSmart) {
+      query.append(SQL` AND COALESCE(item_p.item_type, item_s.item_type, nft.item_type) = 'smart_wearable_v1'`)
     }
     if (filters.minPriceCredits != null) {
       const minWei = creditsToWei(filters.minPriceCredits)

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -44,6 +44,7 @@ export type ShopCatalogFilters = {
   creator?: string // item creator address — a creator's storefront (their credit-buyable listings)
   rarities?: string[]
   wearableCategories?: string[] // on-chain categories (upper_body, hat, ...)
+  isSmart?: boolean // restrict to smart wearables (Shop "Smart" filter)
   minPriceCredits?: number
   maxPriceCredits?: number
   search?: string

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -199,6 +199,20 @@ describe('Shop Catalog Component', () => {
       expect(sql.values).toContainEqual(['upper_body', 'hat'])
     })
 
+    it('should restrict to smart wearables when isSmart is set', async () => {
+      await shopCatalog.getShopListings({ isSmart: true })
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain("COALESCE(item_p.item_type, item_s.item_type, nft.item_type) = 'smart_wearable_v1'")
+    })
+
+    it('should NOT add the smart-wearable filter when isSmart is absent', async () => {
+      await shopCatalog.getShopListings({})
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).not.toContain("= 'smart_wearable_v1'")
+    })
+
     it('should translate credit price bounds into USD wei', async () => {
       await shopCatalog.getShopListings({ minPriceCredits: 3, maxPriceCredits: 10 })
 


### PR DESCRIPTION
## Changes

Wires the Shop "Smart" filter through the catalog backend. The shop SPA already sends `isSmart=true` to `/v3/catalog/shop` and `/v3/catalog/unified`, but the handlers ignored it — so the toggle had no effect. This parses it and applies a smart-wearable constraint.

- `ShopCatalogFilters.isSmart?: boolean`.
- Both `/v3/catalog/shop` and `/v3/catalog/unified` handlers parse `isSmart` (present ⇒ true).
- Query builder (unified branches + shop-listings) adds `AND COALESCE(item_p.item_type, item_s.item_type, nft.item_type) = 'smart_wearable_v1'` when set. No-op when absent.

## Test plan

- [x] `tsc` clean
- [x] `jest` shop-catalog unit — 44 passed (incl. 2 new: filter present when `isSmart`, absent otherwise)
- [x] prettier clean

## Note

Status filter (on-sale / not-for-sale) is intentionally NOT part of this PR: the shop catalog feed is built entirely on OPEN trades, so "on sale" is already the feed and "not for sale" needs a broader change (surfacing non-listed catalog items). Tracked separately.