### PR TITLE
feat: notify shop waitlist when an item goes on sale

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -73,3 +73,9 @@ MANA_USD_ORACLE_ADDRESS=
 MANA_RATE_REFRESH_INTERVAL_MS=90000
 MANA_USD_FALLBACK_RATE=0.02
 MANA_ORACLE_MAX_STALENESS_SECONDS=86400
+
+# Shop waitlist notifier. When an item transitions from not-for-sale to on-sale (a first open listing),
+# the server best-effort POSTs to the Shop so it can email waitlist subscribers. Leaving either value
+# unset disables the feature cleanly (no-op). Use real values only outside this committed file.
+SHOP_SERVER_URL=https://shop-api.example.org
+NOTIFY_TRIGGER_TOKEN=example-shared-secret-rotate-me

--- a/src/components.ts
+++ b/src/components.ts
@@ -36,6 +36,7 @@ import { createRankingsComponent } from './ports/rankings/component'
 import { createRentalsComponent } from './ports/rentals/components'
 import { createSalesComponents } from './ports/sales'
 import { createShopCatalogComponent } from './ports/shop-catalog/component'
+import { createShopNotifierComponent } from './ports/shop-notifier/component'
 import { createStatsComponent } from './ports/stats/component'
 import { createTradesComponent } from './ports/trades'
 import { createTransakComponent } from './ports/transak/component'
@@ -148,7 +149,8 @@ export async function initComponents(): Promise<AppComponents> {
   const catalog = await createCatalogComponent({ dappsDatabase: dappsReadDatabase, dappsWriteDatabase, picks }, SEGMENT_WRITE_KEY)
   const shopCatalog = createShopCatalogComponent({ dappsDatabase: dappsReadDatabase, logs })
   const manaUsdRate = await createManaUsdRateComponent({ config, logs })
-  const trades = await createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs })
+  const shopNotifier = await createShopNotifierComponent({ config, logs, fetch })
+  const trades = await createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs, shopNotifier })
   const bids = await createBidsComponents({ dappsDatabase: dappsReadDatabase })
   const nfts = await createNFTsComponent({ dappsDatabase: dappsReadDatabase, config, rentals })
   const orders = await createOrdersComponent({ dappsDatabase: dappsReadDatabase })
@@ -202,6 +204,7 @@ export async function initComponents(): Promise<AppComponents> {
     dappsWriteDatabase,
     catalog,
     shopCatalog,
+    shopNotifier,
     manaUsdRate,
     wertSigner,
     wertApi,

--- a/src/ports/shop-notifier/component.ts
+++ b/src/ports/shop-notifier/component.ts
@@ -1,0 +1,50 @@
+import { isErrorWithMessage } from '../../logic/errors'
+import { AppComponents } from '../../types'
+import { IShopNotifierComponent, NotifyItemOnSaleParams } from './types'
+
+// Hard cap on how long the ping may take. The Shop endpoint is not on the critical path of trade
+// creation, so a slow/unreachable Shop server must never delay us: after this we abort and move on.
+const NOTIFY_TIMEOUT_MS = 2000
+
+export async function createShopNotifierComponent(
+  components: Pick<AppComponents, 'config' | 'logs' | 'fetch'>
+): Promise<IShopNotifierComponent> {
+  const { config, logs, fetch } = components
+  const logger = logs.getLogger('shop-notifier')
+
+  const shopServerUrl = await config.getString('SHOP_SERVER_URL')
+  const notifyTriggerToken = await config.getString('NOTIFY_TRIGGER_TOKEN')
+  // Feature is disabled cleanly unless BOTH the Shop URL and the shared secret are configured.
+  const enabled = !!shopServerUrl && !!notifyTriggerToken
+
+  if (!enabled) {
+    logger.info('Shop notifier disabled: SHOP_SERVER_URL and/or NOTIFY_TRIGGER_TOKEN are not set')
+  }
+
+  async function notifyItemOnSale({ contractAddress, itemId }: NotifyItemOnSaleParams): Promise<void> {
+    if (!enabled) {
+      return
+    }
+
+    try {
+      await fetch.fetch(`${shopServerUrl}/notify/item-on-sale`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${notifyTriggerToken}`
+        },
+        body: JSON.stringify({ contractAddress, itemId }),
+        signal: AbortSignal.timeout(NOTIFY_TIMEOUT_MS)
+      })
+    } catch (error) {
+      // Swallow + log: notifying the waitlist is best-effort and must never surface to the caller.
+      logger.warn(
+        `Failed to notify shop that item ${contractAddress}-${itemId} went on sale: ${
+          isErrorWithMessage(error) ? error.message : 'unknown error'
+        }`
+      )
+    }
+  }
+
+  return { notifyItemOnSale }
+}

--- a/src/ports/shop-notifier/component.ts
+++ b/src/ports/shop-notifier/component.ts
@@ -27,7 +27,7 @@ export async function createShopNotifierComponent(
     }
 
     try {
-      await fetch.fetch(`${shopServerUrl}/notify/item-on-sale`, {
+      const response = await fetch.fetch(`${shopServerUrl}/notify/item-on-sale`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -36,6 +36,8 @@ export async function createShopNotifierComponent(
         body: JSON.stringify({ contractAddress, itemId }),
         signal: AbortSignal.timeout(NOTIFY_TIMEOUT_MS)
       })
+      // Drain the body so @dcl/fetch-component (native fetch) doesn't keep the socket tied up until GC.
+      await response.text().catch(() => undefined)
     } catch (error) {
       // Swallow + log: notifying the waitlist is best-effort and must never surface to the caller.
       logger.warn(

--- a/src/ports/shop-notifier/component.ts
+++ b/src/ports/shop-notifier/component.ts
@@ -31,7 +31,7 @@ export async function createShopNotifierComponent(
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${notifyTriggerToken}`
+          authorization: `Bearer ${notifyTriggerToken}`
         },
         body: JSON.stringify({ contractAddress, itemId }),
         signal: AbortSignal.timeout(NOTIFY_TIMEOUT_MS)

--- a/src/ports/shop-notifier/index.ts
+++ b/src/ports/shop-notifier/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './component'

--- a/src/ports/shop-notifier/types.ts
+++ b/src/ports/shop-notifier/types.ts
@@ -1,0 +1,12 @@
+export type NotifyItemOnSaleParams = {
+  contractAddress: string
+  itemId: string
+}
+
+// Best-effort, fire-and-forget notifier that tells the Shop server an item has just gone on sale so it
+// can email its waitlist subscribers. Every method is fail-safe: it never throws and never blocks the
+// caller in a way that could affect trade creation. When SHOP_SERVER_URL / NOTIFY_TRIGGER_TOKEN are not
+// configured the port is a clean no-op (feature disabled).
+export type IShopNotifierComponent = {
+  notifyItemOnSale(params: NotifyItemOnSaleParams): Promise<void>
+}

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -1,5 +1,5 @@
 import SQL from 'sql-template-strings'
-import { Event, Trade, TradeAssetDirection, TradeAssetType, TradeCreation, TradeType } from '@dcl/schemas'
+import { Event, Trade, TradeAsset, TradeAssetDirection, TradeAssetType, TradeCreation, TradeType } from '@dcl/schemas'
 import { ContractName, getContract } from 'decentraland-transactions'
 import { fromDbTradeAndDBTradeAssetWithValueListToTrade } from '../../adapters/trades/trades'
 import { isErrorWithMessage } from '../../logic/errors'
@@ -22,6 +22,8 @@ import {
   getInsertTradeAssetQuery,
   getInsertTradeAssetValueByTypeQuery,
   getInsertTradeQuery,
+  getItemIdByTokenIdQuery,
+  getOtherOpenListingForItemQuery,
   getTradeAssetsWithValuesByHashedSignatureQuery,
   getTradeAssetsWithValuesByIdQuery,
   getTradesByAddressQuery
@@ -54,8 +56,10 @@ type TradeWithAssetRow = {
   item_id: string | null
 }
 
-export function createTradesComponent(components: Pick<AppComponents, 'dappsDatabase' | 'eventPublisher' | 'logs'>): ITradesComponent {
-  const { dappsDatabase: pg, eventPublisher, logs } = components
+export function createTradesComponent(
+  components: Pick<AppComponents, 'dappsDatabase' | 'eventPublisher' | 'logs' | 'shopNotifier'>
+): ITradesComponent {
+  const { dappsDatabase: pg, eventPublisher, logs, shopNotifier } = components
   const logger = logs.getLogger('Trades component')
 
   async function getTrades() {
@@ -218,7 +222,58 @@ export function createTradesComponent(components: Pick<AppComponents, 'dappsData
       logger.error(`Could not trigger trade creation event for trade type ${trade.type}`, isErrorWithMessage(e) ? e.message : (e as any))
     }
 
+    // Best-effort: tell the Shop waitlist when this listing makes the item go on sale. The trade is
+    // already persisted, so this MUST NOT throw, delay or otherwise affect trade creation; the ping
+    // result is irrelevant to the response.
+    try {
+      await notifyShopIfItemGoesOnSale(insertedTrade)
+    } catch (e) {
+      logger.error(`Could not notify shop waitlist for trade ${insertedTrade.id}`, isErrorWithMessage(e) ? e.message : (e as any))
+    }
+
     return insertedTrade
+  }
+
+  // Notifies the Shop that an item transitioned from not-for-sale to on-sale, so it can email its
+  // waitlist. Only listings qualify (primary re-list via PUBLIC_ITEM_ORDER or secondary via
+  // PUBLIC_NFT_ORDER); bids and everything else return early. Skips when the item already had another
+  // open listing (it was already on sale) and when the item id cannot be resolved (never guesses).
+  async function notifyShopIfItemGoesOnSale(trade: Trade): Promise<void> {
+    if (trade.type !== TradeType.PUBLIC_ITEM_ORDER && trade.type !== TradeType.PUBLIC_NFT_ORDER) {
+      return
+    }
+
+    const sentAsset: TradeAsset | undefined = trade.sent[0]
+    if (!sentAsset) {
+      return
+    }
+    const contractAddress = sentAsset.contractAddress
+
+    // Resolve the item id of the asset being listed.
+    let itemId: string | undefined
+    if (sentAsset.assetType === TradeAssetType.COLLECTION_ITEM) {
+      // Primary re-list: the sold asset is the collection item itself, so its item id is direct.
+      itemId = sentAsset.itemId
+    } else if (sentAsset.assetType === TradeAssetType.ERC721) {
+      // Secondary listing: the sold asset is an ERC721 token; resolve it to the item id it was minted
+      // from via the squid `nft` table (same contract_address + token_id join the trade queries use).
+      const result = await pg.query<{ item_id: string | null }>(getItemIdByTokenIdQuery(contractAddress, sentAsset.tokenId))
+      itemId = result.rows[0]?.item_id ?? undefined
+    }
+
+    // Can't resolve an item id -> skip rather than guess.
+    if (!itemId) {
+      return
+    }
+
+    // Transition check: only ping on a real not-for-sale -> on-sale change. If any OTHER open listing of
+    // the same item already exists, the item was already on sale, so skip.
+    const otherOpen = await pg.query(getOtherOpenListingForItemQuery(contractAddress, itemId, trade.id))
+    if (otherOpen.rowCount && otherOpen.rowCount > 0) {
+      return
+    }
+
+    await shopNotifier.notifyItemOnSale({ contractAddress, itemId })
   }
 
   async function getTrade(id: string) {

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -222,14 +222,13 @@ export function createTradesComponent(
       logger.error(`Could not trigger trade creation event for trade type ${trade.type}`, isErrorWithMessage(e) ? e.message : (e as any))
     }
 
-    // Best-effort: tell the Shop waitlist when this listing makes the item go on sale. The trade is
-    // already persisted, so this MUST NOT throw, delay or otherwise affect trade creation; the ping
-    // result is irrelevant to the response.
-    try {
-      await notifyShopIfItemGoesOnSale(insertedTrade)
-    } catch (e) {
+    // Best-effort, fire-and-forget: tell the Shop waitlist when this listing makes the item go on sale.
+    // The trade is already persisted, so we deliberately do NOT await — the ping (a couple of queries +
+    // up to a 2s HTTP timeout) must not delay the trade response. Errors are swallowed here and inside
+    // the notifier, so it can never affect trade creation.
+    void notifyShopIfItemGoesOnSale(insertedTrade).catch(e =>
       logger.error(`Could not notify shop waitlist for trade ${insertedTrade.id}`, isErrorWithMessage(e) ? e.message : (e as any))
-    }
+    )
 
     return insertedTrade
   }

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -226,7 +226,7 @@ export function createTradesComponent(
     // The trade is already persisted, so we deliberately do NOT await — the ping (a couple of queries +
     // up to a 2s HTTP timeout) must not delay the trade response. Errors are swallowed here and inside
     // the notifier, so it can never affect trade creation.
-    void notifyShopIfItemGoesOnSale(insertedTrade).catch(e =>
+    void notifyShopIfItemGoesOnSale(insertedTrade).catch((e: unknown) =>
       logger.error(`Could not notify shop waitlist for trade ${insertedTrade.id}`, isErrorWithMessage(e) ? e.message : (e as any))
     )
 

--- a/src/ports/trades/queries.ts
+++ b/src/ports/trades/queries.ts
@@ -4,6 +4,7 @@ import { TradeAsset, ListingStatus, TradeAssetType, TradeAssetWithBeneficiary, T
 import { ContractName, getContract } from 'decentraland-transactions'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getEthereumChainId, getPolygonChainId } from '../../logic/chainIds'
+import { TRADES_MV_NAME } from '../../logic/trades/materialized-view'
 
 export function getTradeAssetsWithValuesQuery(customWhere?: SQLStatement) {
   return SQL`
@@ -350,4 +351,29 @@ export function getTradesByAddressQuery(address: string, options: { limit: numbe
       OFFSET ${offset}
     )
     ORDER BY t.created_at DESC, ta.direction ASC`
+}
+
+// Resolves the item id of an ERC721 (secondary listing) asset. Uses the same join the trade queries and
+// the trades materialized view rely on: the squid `nft` table keyed by contract_address + token_id, from
+// which `item_blockchain_id` is the item id the NFT was minted from.
+export function getItemIdByTokenIdQuery(contractAddress: string, tokenId: string): SQLStatement {
+  return SQL`SELECT nft.item_blockchain_id::text AS item_id FROM `
+    .append(MARKETPLACE_SQUID_SCHEMA)
+    .append(SQL`.nft AS nft WHERE nft.contract_address = ${contractAddress.toLowerCase()} AND nft.token_id = ${tokenId}::numeric LIMIT 1`)
+}
+
+// Transition check for the "item went on sale" waitlist ping. Returns a row when the item already has
+// ANOTHER open listing (item or nft order) besides the just-created trade, meaning it was already on
+// sale and no ping is warranted. Reads the trades materialized view, which can be up to
+// TRADES_MV_REFRESH_INTERVAL_SECONDS (~30s) stale; the worst case is a duplicate ping, which the Shop
+// dedupes, so a slightly stale read is acceptable here.
+export function getOtherOpenListingForItemQuery(contractAddress: string, itemId: string, excludeTradeId: string): SQLStatement {
+  return SQL`SELECT 1 FROM marketplace.`.append(TRADES_MV_NAME).append(
+    SQL` WHERE status = 'open'
+      AND type IN ('public_item_order', 'public_nft_order')
+      AND sent_contract_address = ${contractAddress.toLowerCase()}
+      AND sent_item_id = ${itemId}
+      AND id <> ${excludeTradeId}
+      LIMIT 1`
+  )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ import { IItemsDayDataComponent } from './ports/rankings/types'
 import { IRentalsComponent } from './ports/rentals/types'
 import { ISalesComponent } from './ports/sales'
 import { IShopCatalogComponent } from './ports/shop-catalog/types'
+import { IShopNotifierComponent } from './ports/shop-notifier/types'
 import { IStatsComponent } from './ports/stats/types'
 import { ITradesComponent } from './ports/trades/types'
 import { ITransakComponent } from './ports/transak/types'
@@ -55,6 +56,7 @@ export type BaseComponents = {
   dappsWriteDatabase: IPgComponent
   catalog: ICatalogComponent
   shopCatalog: IShopCatalogComponent
+  shopNotifier: IShopNotifierComponent
   manaUsdRate: IManaUsdRateComponent
   wertSigner: IWertSignerComponent
   wertApi: IWertApiComponent

--- a/test/components.ts
+++ b/test/components.ts
@@ -38,6 +38,7 @@ import { createRankingsComponent } from '../src/ports/rankings/component'
 import { createRentalsComponent } from '../src/ports/rentals/components'
 import { createSalesComponents } from '../src/ports/sales'
 import { createShopCatalogComponent } from '../src/ports/shop-catalog/component'
+import { createShopNotifierComponent } from '../src/ports/shop-notifier/component'
 import { createStatsComponent } from '../src/ports/stats/component'
 import { createTradesComponent } from '../src/ports/trades'
 import { createTransakComponent } from '../src/ports/transak/component'
@@ -117,8 +118,9 @@ async function initComponents(): Promise<TestComponents> {
   const catalog = await createCatalogComponent({ dappsDatabase: dappsReadDatabase, dappsWriteDatabase, picks }, SEGMENT_WRITE_KEY)
   const shopCatalog = createShopCatalogComponent({ dappsDatabase: dappsReadDatabase, logs })
   const manaUsdRate = await createManaUsdRateComponent({ config, logs })
+  const shopNotifier = await createShopNotifierComponent({ config, logs, fetch })
   const schemaValidator = await createSchemaValidatorComponent()
-  const trades = createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs })
+  const trades = createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs, shopNotifier })
   const bids = createBidsComponents({ dappsDatabase: dappsReadDatabase })
 
   const rentalsSubgraph = await createSubgraphComponent(
@@ -176,6 +178,7 @@ async function initComponents(): Promise<TestComponents> {
     favoritesDatabase,
     catalog,
     shopCatalog,
+    shopNotifier,
     manaUsdRate,
     wertSigner,
     wertApi,

--- a/test/unit/shop-notifier-component.spec.ts
+++ b/test/unit/shop-notifier-component.spec.ts
@@ -1,0 +1,88 @@
+import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { IFetchComponent } from '@dcl/core-commons'
+import { createShopNotifierComponent } from '../../src/ports/shop-notifier/component'
+import { IShopNotifierComponent } from '../../src/ports/shop-notifier/types'
+import { createTestLogsComponent } from '../components'
+
+const SHOP_SERVER_URL = 'https://shop-api.example.org'
+const NOTIFY_TRIGGER_TOKEN = 'example-shared-secret-rotate-me'
+
+let config: IConfigComponent
+let fetchComponent: IFetchComponent
+let fetchMock: jest.Mock
+let logs: ILoggerComponent
+let getStringMock: jest.Mock
+
+function buildConfig(values: Record<string, string | undefined>): IConfigComponent {
+  getStringMock = jest.fn().mockImplementation((key: string) => Promise.resolve(values[key]))
+  return {
+    getString: getStringMock,
+    getNumber: jest.fn(),
+    requireString: jest.fn(),
+    requireNumber: jest.fn()
+  }
+}
+
+describe('when creating the shop notifier component', () => {
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}) })
+    fetchComponent = { fetch: fetchMock } as unknown as IFetchComponent
+    logs = createTestLogsComponent({
+      getLogger: jest.fn().mockReturnValue({ error: () => undefined, info: () => undefined, warn: () => undefined })
+    })
+  })
+
+  describe('and both SHOP_SERVER_URL and NOTIFY_TRIGGER_TOKEN are configured', () => {
+    let notifier: IShopNotifierComponent
+
+    beforeEach(async () => {
+      config = buildConfig({ SHOP_SERVER_URL, NOTIFY_TRIGGER_TOKEN })
+      notifier = await createShopNotifierComponent({ config, logs, fetch: fetchComponent })
+    })
+
+    it('should POST to the shop notify endpoint with the bearer token and body', async () => {
+      await notifier.notifyItemOnSale({ contractAddress: '0xabc', itemId: '42' })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const [url, init] = fetchMock.mock.calls[0]
+      const headers = init.headers as Record<string, string>
+      expect(url).toBe(`${SHOP_SERVER_URL}/notify/item-on-sale`)
+      expect(init.method).toBe('POST')
+      expect(headers['Content-Type']).toBe('application/json')
+      expect(headers['Authorization']).toBe(`Bearer ${NOTIFY_TRIGGER_TOKEN}`)
+      expect(init.body).toBe(JSON.stringify({ contractAddress: '0xabc', itemId: '42' }))
+    })
+
+    it('should never throw when the fetch rejects', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('network down'))
+      await expect(notifier.notifyItemOnSale({ contractAddress: '0xabc', itemId: '42' })).resolves.toBeUndefined()
+    })
+  })
+
+  describe('and SHOP_SERVER_URL is not configured', () => {
+    let notifier: IShopNotifierComponent
+
+    beforeEach(async () => {
+      config = buildConfig({ SHOP_SERVER_URL: undefined, NOTIFY_TRIGGER_TOKEN })
+      notifier = await createShopNotifierComponent({ config, logs, fetch: fetchComponent })
+    })
+
+    it('should be a no-op and not call fetch', async () => {
+      await notifier.notifyItemOnSale({ contractAddress: '0xabc', itemId: '42' })
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and NOTIFY_TRIGGER_TOKEN is not configured', () => {
+    let notifier: IShopNotifierComponent
+
+    beforeEach(async () => {
+      config = buildConfig({ SHOP_SERVER_URL, NOTIFY_TRIGGER_TOKEN: undefined })
+      notifier = await createShopNotifierComponent({ config, logs, fetch: fetchComponent })
+    })
+
+    it('should be a no-op and not call fetch', async () => {
+      await notifier.notifyItemOnSale({ contractAddress: '0xabc', itemId: '42' })
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/unit/shop-notifier-component.spec.ts
+++ b/test/unit/shop-notifier-component.spec.ts
@@ -48,7 +48,7 @@ describe('when creating the shop notifier component', () => {
       expect(url).toBe(`${SHOP_SERVER_URL}/notify/item-on-sale`)
       expect(init.method).toBe('POST')
       expect(headers['Content-Type']).toBe('application/json')
-      expect(headers['Authorization']).toBe(`Bearer ${NOTIFY_TRIGGER_TOKEN}`)
+      expect(headers['authorization']).toBe(`Bearer ${NOTIFY_TRIGGER_TOKEN}`)
       expect(init.body).toBe(JSON.stringify({ contractAddress: '0xabc', itemId: '42' }))
     })
 

--- a/test/unit/shop-notifier-component.spec.ts
+++ b/test/unit/shop-notifier-component.spec.ts
@@ -25,7 +25,7 @@ function buildConfig(values: Record<string, string | undefined>): IConfigCompone
 
 describe('when creating the shop notifier component', () => {
   beforeEach(() => {
-    fetchMock = jest.fn().mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}) })
+    fetchMock = jest.fn().mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}), text: () => Promise.resolve('') })
     fetchComponent = { fetch: fetchMock } as unknown as IFetchComponent
     logs = createTestLogsComponent({
       getLogger: jest.fn().mockReturnValue({ error: () => undefined, info: () => undefined, warn: () => undefined })

--- a/test/unit/trades-component.spec.ts
+++ b/test/unit/trades-component.spec.ts
@@ -19,6 +19,7 @@ import { fromDbTradeAndDBTradeAssetWithValueListToTrade } from '../../src/adapte
 import * as signatureUtils from '../../src/logic/trades/utils'
 import { IPgComponent } from '../../src/ports/db/types'
 import { IEventPublisherComponent } from '../../src/ports/events/types'
+import { IShopNotifierComponent } from '../../src/ports/shop-notifier/types'
 import {
   DBTrade,
   DBTradeAsset,
@@ -43,9 +44,11 @@ let mockTrade: TradeCreation
 let mockSigner: string
 let mockPg: IPgComponent
 let mockEventPublisher: IEventPublisherComponent
+let mockShopNotifier: IShopNotifierComponent
 let tradesComponent: ITradesComponent
 let logs: ILoggerComponent
 let publishMessageMock: jest.Mock
+let notifyItemOnSaleMock: jest.Mock
 
 describe('when adding a new trade', () => {
   beforeEach(() => {
@@ -108,12 +111,22 @@ describe('when adding a new trade', () => {
       publishMessage: publishMessageMock
     }
 
+    notifyItemOnSaleMock = jest.fn().mockResolvedValue(undefined)
+    mockShopNotifier = {
+      notifyItemOnSale: notifyItemOnSaleMock
+    }
+
     logs = createTestLogsComponent({
-      getLogger: jest.fn().mockReturnValue({ error: () => undefined, info: () => undefined })
+      getLogger: jest.fn().mockReturnValue({ error: () => undefined, info: () => undefined, warn: () => undefined })
     })
 
     jest.clearAllMocks()
-    tradesComponent = createTradesComponent({ dappsDatabase: mockPg, eventPublisher: mockEventPublisher, logs })
+    tradesComponent = createTradesComponent({
+      dappsDatabase: mockPg,
+      eventPublisher: mockEventPublisher,
+      logs,
+      shopNotifier: mockShopNotifier
+    })
   })
 
   describe('when the expiration date is in the past', () => {
@@ -336,7 +349,12 @@ describe('when getting a trade', () => {
       mockEventPublisher = {
         publishMessage: publishMessageMock
       }
-      tradesComponent = createTradesComponent({ dappsDatabase: mockPg, eventPublisher: mockEventPublisher, logs })
+      tradesComponent = createTradesComponent({
+        dappsDatabase: mockPg,
+        eventPublisher: mockEventPublisher,
+        logs,
+        shopNotifier: mockShopNotifier
+      })
     })
 
     it('should throw TradeNotFoundError', async () => {
@@ -443,7 +461,12 @@ describe('when getting a trade', () => {
         publishMessage: jest.fn()
       }
 
-      tradesComponent = createTradesComponent({ dappsDatabase: mockPg, eventPublisher: mockEventPublisher, logs })
+      tradesComponent = createTradesComponent({
+        dappsDatabase: mockPg,
+        eventPublisher: mockEventPublisher,
+        logs,
+        shopNotifier: mockShopNotifier
+      })
     })
 
     it('should return trade', async () => {

--- a/test/unit/trades-shop-notify.spec.ts
+++ b/test/unit/trades-shop-notify.spec.ts
@@ -1,0 +1,291 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { ChainId, Network, TradeAssetDirection, TradeAssetType, TradeCreation, TradeType } from '@dcl/schemas'
+import * as signatureUtils from '../../src/logic/trades/utils'
+import { IPgComponent } from '../../src/ports/db/types'
+import { IEventPublisherComponent } from '../../src/ports/events/types'
+import { IShopNotifierComponent } from '../../src/ports/shop-notifier/types'
+import { DBTrade, DBTradeAsset, ITradesComponent, createTradesComponent } from '../../src/ports/trades'
+import * as utils from '../../src/ports/trades/utils'
+import { createTestLogsComponent } from '../components'
+
+const VALID_SIGNATURE =
+  '0x6e1ac0d382ee06b56c6376a9ea5a7641bc7efc6c50ea12728e09637072c60bf15574a2ced086ef1f7f8fbb4a6ab7b925e08c34c918f57d0b63e036eff21fa2ee1c'
+const CONTRACT_ADDRESS = '0xcollectioncontract'
+
+let mockSigner: string
+let mockPg: IPgComponent
+let mockPgQuery: jest.Mock
+let mockTopLevelQuery: jest.Mock
+let mockEventPublisher: IEventPublisherComponent
+let mockShopNotifier: IShopNotifierComponent
+let notifyItemOnSaleMock: jest.Mock
+let logs: ILoggerComponent
+let tradesComponent: ITradesComponent
+
+function buildValidChecks() {
+  return {
+    expiration: Date.now() + 100000000000,
+    effective: Date.now(),
+    uses: 1,
+    salt: '',
+    allowedRoot: '',
+    contractSignatureIndex: 0,
+    externalChecks: [],
+    signerSignatureIndex: 0
+  }
+}
+
+// Wires the transaction so the insert flow returns a persisted Trade built from the given sent asset
+// row/value plus a received (priced) asset. Call order inside the tx mirrors the component:
+// trade insert, sent asset insert, received asset insert, sent value insert, received value insert.
+function stubTransaction(insertedTrade: DBTrade, sentAsset: DBTradeAsset, sentValue: object) {
+  const receivedAsset: DBTradeAsset = {
+    id: 'received-asset-1',
+    trade_id: insertedTrade.id,
+    asset_type: TradeAssetType.ERC20,
+    contract_address: '0xmana',
+    direction: TradeAssetDirection.RECEIVED,
+    extra: '0x',
+    beneficiary: '0xbuyer',
+    created_at: new Date()
+  }
+  mockPgQuery
+    .mockResolvedValueOnce({ rows: [insertedTrade] })
+    .mockResolvedValueOnce({ rows: [sentAsset] })
+    .mockResolvedValueOnce({ rows: [receivedAsset] })
+    .mockResolvedValueOnce({ rows: [sentValue] })
+    .mockResolvedValueOnce({ rows: [{ amount: '1000' }] })
+}
+
+describe('when adding a listing trade', () => {
+  beforeEach(() => {
+    mockSigner = '0x1234567890'
+    mockPgQuery = jest.fn()
+    mockTopLevelQuery = jest.fn()
+    mockPg = {
+      getPool: jest.fn(),
+      withTransaction: jest.fn().mockImplementation((fn, _onError) => fn({ query: mockPgQuery })),
+      withAsyncContextTransaction: jest.fn(),
+      start: jest.fn(),
+      query: mockTopLevelQuery,
+      stop: jest.fn(),
+      streamQuery: jest.fn()
+    }
+    notifyItemOnSaleMock = jest.fn().mockResolvedValue(undefined)
+    mockShopNotifier = { notifyItemOnSale: notifyItemOnSaleMock }
+    mockEventPublisher = { publishMessage: jest.fn() }
+    logs = createTestLogsComponent({
+      getLogger: jest.fn().mockReturnValue({ error: () => undefined, info: () => undefined, warn: () => undefined })
+    })
+
+    // Isolate the shop-notify path: signature/structure validations pass, the SNS notification is a no-op.
+    jest.spyOn(signatureUtils, 'validateTradeSignature').mockReturnValue(true)
+    jest.spyOn(signatureUtils, 'validateAssetOwnership').mockResolvedValue(true)
+    jest.spyOn(utils, 'validateTradeByType').mockResolvedValue(true)
+    jest.spyOn(utils, 'isValidEstateTrade').mockResolvedValue(true)
+    jest.spyOn(utils, 'getNotificationEventForTrade').mockResolvedValue(null)
+
+    tradesComponent = createTradesComponent({
+      dappsDatabase: mockPg,
+      eventPublisher: mockEventPublisher,
+      logs,
+      shopNotifier: mockShopNotifier
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('and the trade is a primary item order (PUBLIC_ITEM_ORDER)', () => {
+    let itemOrderTrade: TradeCreation
+
+    beforeEach(() => {
+      itemOrderTrade = {
+        signer: mockSigner,
+        signature: VALID_SIGNATURE,
+        type: TradeType.PUBLIC_ITEM_ORDER,
+        network: Network.MATIC,
+        chainId: ChainId.MATIC_MAINNET,
+        checks: buildValidChecks(),
+        sent: [{ assetType: TradeAssetType.COLLECTION_ITEM, contractAddress: CONTRACT_ADDRESS, itemId: '42', extra: '0x' }],
+        received: [{ assetType: TradeAssetType.ERC20, contractAddress: '0xmana', amount: '1000', extra: '0x', beneficiary: '0xbuyer' }]
+      }
+
+      const insertedTrade: DBTrade = {
+        id: 'listing-item-1',
+        chain_id: itemOrderTrade.chainId,
+        network: itemOrderTrade.network,
+        checks: itemOrderTrade.checks,
+        created_at: new Date(),
+        effective_since: new Date(),
+        expires_at: new Date(),
+        signature: VALID_SIGNATURE,
+        signer: mockSigner,
+        type: TradeType.PUBLIC_ITEM_ORDER,
+        contract: 'OffChainMarketplaceV2'
+      }
+      const sentAsset: DBTradeAsset = {
+        id: 'sent-asset-1',
+        trade_id: insertedTrade.id,
+        asset_type: TradeAssetType.COLLECTION_ITEM,
+        contract_address: CONTRACT_ADDRESS,
+        direction: TradeAssetDirection.SENT,
+        extra: '0x',
+        created_at: new Date()
+      }
+      stubTransaction(insertedTrade, sentAsset, { item_id: '42' })
+    })
+
+    describe('and there is no other open listing for the item', () => {
+      beforeEach(() => {
+        mockTopLevelQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 }) // transition check: none
+      })
+
+      it('should notify the shop with the resolved contract address and item id', async () => {
+        await tradesComponent.addTrade(itemOrderTrade, mockSigner)
+        expect(notifyItemOnSaleMock).toHaveBeenCalledWith({ contractAddress: CONTRACT_ADDRESS, itemId: '42' })
+      })
+    })
+
+    describe('and the item already has another open listing', () => {
+      beforeEach(() => {
+        mockTopLevelQuery.mockResolvedValueOnce({ rows: [{ exists: 1 }], rowCount: 1 }) // transition check: exists
+      })
+
+      it('should not notify the shop', async () => {
+        await tradesComponent.addTrade(itemOrderTrade, mockSigner)
+        expect(notifyItemOnSaleMock).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and the shop notifier rejects', () => {
+      beforeEach(() => {
+        mockTopLevelQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        notifyItemOnSaleMock.mockRejectedValueOnce(new Error('network down'))
+      })
+
+      it('should still return the created trade without throwing', async () => {
+        const response = await tradesComponent.addTrade(itemOrderTrade, mockSigner)
+        expect(response.id).toBe('listing-item-1')
+      })
+    })
+  })
+
+  describe('and the trade is a secondary nft order (PUBLIC_NFT_ORDER)', () => {
+    let nftOrderTrade: TradeCreation
+
+    beforeEach(() => {
+      nftOrderTrade = {
+        signer: mockSigner,
+        signature: VALID_SIGNATURE,
+        type: TradeType.PUBLIC_NFT_ORDER,
+        network: Network.MATIC,
+        chainId: ChainId.MATIC_MAINNET,
+        checks: buildValidChecks(),
+        sent: [{ assetType: TradeAssetType.ERC721, contractAddress: CONTRACT_ADDRESS, tokenId: '7', extra: '0x' }],
+        received: [{ assetType: TradeAssetType.ERC20, contractAddress: '0xmana', amount: '1000', extra: '0x', beneficiary: '0xbuyer' }]
+      }
+
+      const insertedTrade: DBTrade = {
+        id: 'listing-nft-1',
+        chain_id: nftOrderTrade.chainId,
+        network: nftOrderTrade.network,
+        checks: nftOrderTrade.checks,
+        created_at: new Date(),
+        effective_since: new Date(),
+        expires_at: new Date(),
+        signature: VALID_SIGNATURE,
+        signer: mockSigner,
+        type: TradeType.PUBLIC_NFT_ORDER,
+        contract: 'OffChainMarketplaceV2'
+      }
+      const sentAsset: DBTradeAsset = {
+        id: 'sent-asset-nft-1',
+        trade_id: insertedTrade.id,
+        asset_type: TradeAssetType.ERC721,
+        contract_address: CONTRACT_ADDRESS,
+        direction: TradeAssetDirection.SENT,
+        extra: '0x',
+        created_at: new Date()
+      }
+      stubTransaction(insertedTrade, sentAsset, { token_id: '7' })
+
+      // First top-level query resolves the ERC721 token to its item id; second is the transition check.
+      mockTopLevelQuery.mockResolvedValueOnce({ rows: [{ item_id: '99' }], rowCount: 1 }).mockResolvedValueOnce({ rows: [], rowCount: 0 })
+    })
+
+    it('should resolve the item id from the token and notify the shop', async () => {
+      await tradesComponent.addTrade(nftOrderTrade, mockSigner)
+      expect(notifyItemOnSaleMock).toHaveBeenCalledWith({ contractAddress: CONTRACT_ADDRESS, itemId: '99' })
+    })
+  })
+
+  describe('and the trade is a bid (not a listing)', () => {
+    let bidTrade: TradeCreation
+
+    beforeEach(() => {
+      bidTrade = {
+        signer: mockSigner,
+        signature: VALID_SIGNATURE,
+        type: TradeType.BID,
+        network: Network.ETHEREUM,
+        chainId: ChainId.ETHEREUM_MAINNET,
+        checks: buildValidChecks(),
+        sent: [{ assetType: TradeAssetType.ERC20, contractAddress: '0xmana', amount: '1000', extra: '0x' }],
+        received: [
+          { assetType: TradeAssetType.ERC721, contractAddress: CONTRACT_ADDRESS, tokenId: '7', extra: '0x', beneficiary: '0xseller' }
+        ]
+      }
+
+      const insertedTrade: DBTrade = {
+        id: 'bid-1',
+        chain_id: bidTrade.chainId,
+        network: bidTrade.network,
+        checks: bidTrade.checks,
+        created_at: new Date(),
+        effective_since: new Date(),
+        expires_at: new Date(),
+        signature: VALID_SIGNATURE,
+        signer: mockSigner,
+        type: TradeType.BID,
+        contract: 'OffChainMarketplaceV2'
+      }
+      const sentAsset: DBTradeAsset = {
+        id: 'bid-sent-asset-1',
+        trade_id: insertedTrade.id,
+        asset_type: TradeAssetType.ERC20,
+        contract_address: '0xmana',
+        direction: TradeAssetDirection.SENT,
+        extra: '0x',
+        created_at: new Date()
+      }
+      // Bid: sent is ERC20 (price), received is the ERC721; the received asset needs a beneficiary.
+      mockPgQuery
+        .mockResolvedValueOnce({ rows: [insertedTrade] })
+        .mockResolvedValueOnce({ rows: [sentAsset] })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 'bid-received-asset-1',
+              trade_id: insertedTrade.id,
+              asset_type: TradeAssetType.ERC721,
+              contract_address: CONTRACT_ADDRESS,
+              direction: TradeAssetDirection.RECEIVED,
+              extra: '0x',
+              beneficiary: '0xseller',
+              created_at: new Date()
+            }
+          ]
+        })
+        .mockResolvedValueOnce({ rows: [{ amount: '1000' }] })
+        .mockResolvedValueOnce({ rows: [{ token_id: '7' }] })
+    })
+
+    it('should not notify the shop and should not query the materialized view', async () => {
+      await tradesComponent.addTrade(bidTrade, mockSigner)
+      expect(notifyItemOnSaleMock).not.toHaveBeenCalled()
+      expect(mockTopLevelQuery).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/unit/trades-shop-notify.spec.ts
+++ b/test/unit/trades-shop-notify.spec.ts
@@ -12,6 +12,10 @@ const VALID_SIGNATURE =
   '0x6e1ac0d382ee06b56c6376a9ea5a7641bc7efc6c50ea12728e09637072c60bf15574a2ced086ef1f7f8fbb4a6ab7b925e08c34c918f57d0b63e036eff21fa2ee1c'
 const CONTRACT_ADDRESS = '0xcollectioncontract'
 
+// addTrade fires the shop-notify ping fire-and-forget (not awaited), so let the background promise —
+// itemId resolution + transition check + the notifier call — settle before asserting on it.
+const flushBackground = () => new Promise(resolve => setImmediate(resolve))
+
 let mockSigner: string
 let mockPg: IPgComponent
 let mockPgQuery: jest.Mock
@@ -144,6 +148,7 @@ describe('when adding a listing trade', () => {
 
       it('should notify the shop with the resolved contract address and item id', async () => {
         await tradesComponent.addTrade(itemOrderTrade, mockSigner)
+        await flushBackground()
         expect(notifyItemOnSaleMock).toHaveBeenCalledWith({ contractAddress: CONTRACT_ADDRESS, itemId: '42' })
       })
     })
@@ -155,6 +160,7 @@ describe('when adding a listing trade', () => {
 
       it('should not notify the shop', async () => {
         await tradesComponent.addTrade(itemOrderTrade, mockSigner)
+        await flushBackground()
         expect(notifyItemOnSaleMock).not.toHaveBeenCalled()
       })
     })
@@ -167,6 +173,7 @@ describe('when adding a listing trade', () => {
 
       it('should still return the created trade without throwing', async () => {
         const response = await tradesComponent.addTrade(itemOrderTrade, mockSigner)
+        await flushBackground()
         expect(response.id).toBe('listing-item-1')
       })
     })
@@ -217,6 +224,7 @@ describe('when adding a listing trade', () => {
 
     it('should resolve the item id from the token and notify the shop', async () => {
       await tradesComponent.addTrade(nftOrderTrade, mockSigner)
+      await flushBackground()
       expect(notifyItemOnSaleMock).toHaveBeenCalledWith({ contractAddress: CONTRACT_ADDRESS, itemId: '99' })
     })
   })
@@ -284,6 +292,7 @@ describe('when adding a listing trade', () => {
 
     it('should not notify the shop and should not query the materialized view', async () => {
       await tradesComponent.addTrade(bidTrade, mockSigner)
+      await flushBackground()
       expect(notifyItemOnSaleMock).not.toHaveBeenCalled()
       expect(mockTopLevelQuery).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
## Changes

Adds a best-effort notification so the Shop's waitlist can email subscribers when an item transitions from not-for-sale to on-sale. The hook is trade creation.

- New injectable port `src/ports/shop-notifier` with `notifyItemOnSale({ contractAddress, itemId })`. It POSTs `{ contractAddress, itemId }` to `${SHOP_SERVER_URL}/notify/item-on-sale` with an `Authorization: Bearer ${NOTIFY_TRIGGER_TOKEN}` header and a 2s abort timeout. When either `SHOP_SERVER_URL` or `NOTIFY_TRIGGER_TOKEN` is unset the port is a clean no-op (feature disabled), and it never throws (network errors are swallowed + logged).
- `trades` component: after the trade is committed and after the existing SNS notification block, a new fire-and-forget try/catch pings the shop. It never throws, delays, or affects trade creation.
  - Only listings qualify: `PUBLIC_ITEM_ORDER` (primary re-list) and `PUBLIC_NFT_ORDER` (secondary). Bids and everything else return early.
  - Item id resolution: `PUBLIC_ITEM_ORDER` reads `itemId` directly off the `COLLECTION_ITEM` asset; `PUBLIC_NFT_ORDER` resolves the `ERC721` token to its item id via the squid `nft` table (`item_blockchain_id`, keyed on `contract_address` + `token_id`), the same join the trade queries use. If it can't be resolved, it skips (no guessing).
  - Transition check: queries `marketplace.mv_trades` for any OTHER open listing (`public_item_order`/`public_nft_order`) of the same item. If one exists the item was already on sale, so it skips; otherwise this is the first open listing (a real transition) and it pings. The MV can be up to ~30s stale; worst case is a duplicate ping, which the Shop dedupes.
- Config: `SHOP_SERVER_URL` and `NOTIFY_TRIGGER_TOKEN` read via the config component, documented in `.env.default` with fake values.
- Wired through `components.ts` (and `test/components.ts`) so the port is injectable and mockable.

## Test plan

- `npm run build` — green
- `npm run lint` — 0 errors
- `npm test` — 771 passed / 64 suites
- New unit tests:
  - shop-notifier component: POSTs with the bearer token + body when configured; no-op (no fetch) when `SHOP_SERVER_URL` or `NOTIFY_TRIGGER_TOKEN` is unset; never throws when fetch rejects.
  - trades notify block: pings on a first listing (MV shows no other open row); skips when the MV has another open listing; skips for BID (and does not query the MV); covers both `PUBLIC_ITEM_ORDER` and `PUBLIC_NFT_ORDER` (resolving the item id for the ERC721 case); still returns the created trade when the notifier rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)