### PR TITLE
fix: return the trade id not the joined asset id from GET /v1/trades/:id

### DIFF
--- a/src/ports/trades/queries.ts
+++ b/src/ports/trades/queries.ts
@@ -6,8 +6,13 @@ import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getEthereumChainId, getPolygonChainId } from '../../logic/chainIds'
 
 export function getTradeAssetsWithValuesQuery(customWhere?: SQLStatement) {
+  // NOTE: select the trade asset's columns EXPLICITLY (never `ta.*`). `marketplace.trades` and
+  // `marketplace.trade_assets` both have `id` and `created_at` columns, so `SELECT t.*, ta.*` let
+  // `ta.id`/`ta.created_at` clobber `t.id`/`t.created_at` in the result row — making getTrade return
+  // the trade with its ASSET's id instead of the trade's own id (the asset mapping never reads either
+  // column, so listing only the fields it needs keeps the trade's id/created_at intact).
   return SQL`
-    SELECT t.*, ta.*, erc721.token_id, erc20.amount, item.item_id
+    SELECT t.*, ta.direction, ta.asset_type, ta.contract_address, ta.beneficiary, ta.extra, erc721.token_id, erc20.amount, item.item_id
     FROM marketplace.trades as t
     JOIN marketplace.trade_assets as ta ON t.id = ta.trade_id
     LEFT JOIN marketplace.trade_assets_erc721 as erc721 ON ta.id = erc721.asset_id

--- a/test/integration/trades-controller.spec.ts
+++ b/test/integration/trades-controller.spec.ts
@@ -334,6 +334,7 @@ test('trades controller', function ({ components }) {
   describe('when getting a trade', () => {
     let trade: TradeCreation
     let response: Response
+    let createdTrade: { id: string }
 
     beforeEach(async () => {
       const { localFetch } = components
@@ -380,19 +381,24 @@ test('trades controller', function ({ components }) {
         body: JSON.stringify(trade),
         headers: { ...signedRequest.headers, 'Content-Type': 'application/json' }
       })
-      const createdTrade = (await createdTradeResponse.json()).data
+      createdTrade = (await createdTradeResponse.json()).data
       response = await localFetch.fetch(`/v1/trades/${createdTrade.id}`, {
         method: 'GET',
         headers: signedRequest.headers
       })
     })
 
-    it('should return 200 status with trade body', async () => {
+    it('should return 200 status with the trade body carrying the trade id (not the joined asset id)', async () => {
       expect(response.status).toEqual(StatusCode.OK)
-      expect(await response.json()).toEqual({
+      const body = await response.json()
+      expect(body).toEqual({
         data: { ...trade, id: expect.any(String), createdAt: expect.any(Number), contract: expect.any(String) },
         ok: true
       })
+      // Regression guard: trades and trade_assets both have an `id` column, so a `SELECT t.*, ta.*`
+      // let the asset's id clobber the trade's id — the endpoint returned the trade with its ASSET's
+      // id. Assert the returned id is the trade's own id (matches the POST response + the URL param).
+      expect(body.data.id).toEqual(createdTrade.id)
     })
   })
 })


### PR DESCRIPTION
## Changes

- `getTradeAssetsWithValuesQuery` (`src/ports/trades/queries.ts`): select the `trade_assets` columns EXPLICITLY instead of `ta.*`. Both `marketplace.trades` (`t`) and `marketplace.trade_assets` (`ta`) have `id` **and** `created_at` columns, so `SELECT t.*, ta.*` let `ta.id`/`ta.created_at` clobber `t.id`/`t.created_at` in the result row. As a result `GET /v1/trades/:id` returned the trade carrying its **received asset's id** instead of the trade's own id (and the asset's `created_at`). The asset mapping only reads `contract_address`/`extra`/`asset_type`/`amount`/`token_id`/`item_id`/`beneficiary` (never `id`/`created_at`), so listing just those keeps `t.id`/`t.created_at` intact.
- Integration test (`trades-controller` → "getting a trade"): assert the returned `data.id` equals the trade's id (the POST response id / the URL param). The old test only checked `id: expect.any(String)`, so the wrong id slipped through.

## Why it matters

The by-id (and by-hashed-signature accept) endpoints returned a wrong `id`. The marketplace webapp is unaffected — it calls `fetchTrade(tradeId)` with an id it already holds and uses only the trade's `signature`/`checks`/`sent`/`received` to execute, ignoring the returned `id`. The credits shop exposed the latent bug: it stored the returned `id` on a purchase record and later re-fetched by it, always 404ing (the stored value was a `trade_asset` id, not a trade id).

## Test plan

- [ ] `npm run test:integration -- trades-controller` "getting a trade" passes (asserts `data.id === createdTrade.id`). Needs the test Postgres (`:5433`) — validated in CI; not runnable locally here. `tsc` build is green.