### PR TITLE
fix: keep the trades materialized view refresh trailing-safe

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -151,6 +151,13 @@ export async function initComponents(): Promise<AppComponents> {
   const manaUsdRate = await createManaUsdRateComponent({ config, logs })
   const shopNotifier = await createShopNotifierComponent({ config, logs, fetch })
   const trades = await createTradesComponent({ dappsDatabase: dappsWriteDatabase, eventPublisher, logs, shopNotifier })
+  // Trailing flush for the debounced trades materialized view refresh: any write that
+  // arrived while the leading-edge debounce gate was closed only marks the state row
+  // dirty, so this reflects it within one interval instead of waiting for an unrelated
+  // trigger (see flushTradesMaterializedViewIfDirty).
+  const flushTradesMaterializedViewJob = createJobComponent({ logs }, () => trades.flushMaterializedViewIfDirty(), thirtySeconds, {
+    startupDelay: thirtySeconds
+  })
   const bids = await createBidsComponents({ dappsDatabase: dappsReadDatabase })
   const nfts = await createNFTsComponent({ dappsDatabase: dappsReadDatabase, config, rentals })
   const orders = await createOrdersComponent({ dappsDatabase: dappsReadDatabase })
@@ -210,6 +217,7 @@ export async function initComponents(): Promise<AppComponents> {
     wertApi,
     ens,
     updateBuilderServerItemsViewJob,
+    flushTradesMaterializedViewJob,
     schemaValidator,
     snapshot,
     items,

--- a/src/components.ts
+++ b/src/components.ts
@@ -155,8 +155,15 @@ export async function initComponents(): Promise<AppComponents> {
   // arrived while the leading-edge debounce gate was closed only marks the state row
   // dirty, so this reflects it within one interval instead of waiting for an unrelated
   // trigger (see flushTradesMaterializedViewIfDirty).
+  const flushTradesMaterializedViewLogger = logs.getLogger('flush-trades-mv-job')
   const flushTradesMaterializedViewJob = createJobComponent({ logs }, () => trades.flushMaterializedViewIfDirty(), thirtySeconds, {
-    startupDelay: thirtySeconds
+    startupDelay: thirtySeconds,
+    // A failed REFRESH re-marks the state row dirty (flushTradesMaterializedViewIfDirty) so it retries
+    // next tick; log it here so the failure isn't swallowed silently.
+    onError: error =>
+      flushTradesMaterializedViewLogger.error(
+        `Failed to flush the trades materialized view: ${error instanceof Error ? error.message : String(error)}`
+      )
   })
   const bids = await createBidsComponents({ dappsDatabase: dappsReadDatabase })
   const nfts = await createNFTsComponent({ dappsDatabase: dappsReadDatabase, config, rentals })

--- a/src/logic/trades/materialized-view.ts
+++ b/src/logic/trades/materialized-view.ts
@@ -220,26 +220,44 @@ export async function recreateTradesMaterializedView(db: IPgComponent) {
       `CREATE INDEX IF NOT EXISTS idx_mv_trades_contract_token ON marketplace.${TRADES_MV_NAME} (contract_address_sent, sent_token_id)`
     )
 
-    // Single-row gate recording the last refresh time, shared by every trigger
+    // Single-row gate recording the last refresh time, shared by every trigger.
+    // `dirty` marks that writes arrived while the debounce gate was closed (a
+    // refresh those writes never made it into); the app-side trailing flush uses
+    // it to guarantee a debounced refresh is never permanently dropped.
     await client.query(`
       CREATE TABLE IF NOT EXISTS marketplace.mv_trades_refresh_state (
         id boolean PRIMARY KEY DEFAULT true CHECK (id),
-        last_refresh timestamptz NOT NULL DEFAULT '-infinity'
+        last_refresh timestamptz NOT NULL DEFAULT '-infinity',
+        dirty boolean NOT NULL DEFAULT false
       );
     `)
+    // Add the column on already-provisioned databases where the table predates it.
+    await client.query('ALTER TABLE marketplace.mv_trades_refresh_state ADD COLUMN IF NOT EXISTS dirty boolean NOT NULL DEFAULT false')
     await client.query('INSERT INTO marketplace.mv_trades_refresh_state (id) VALUES (true) ON CONFLICT (id) DO NOTHING')
     // Trigger functions run as whoever performs the write. Every user able to run
     // the trigger successfully is already a member of mv_trades_owner (the REFRESH
     // itself requires it), so that role is exactly the right audience for the gate
     await client.query('GRANT SELECT, UPDATE ON marketplace.mv_trades_refresh_state TO mv_trades_owner')
 
-    // Create refresh function. The UPDATE is an atomic gate: only one writing
+    // Create refresh function. The first UPDATE is an atomic gate: only one writing
     // statement per interval wins and pays the refresh; concurrent writers skip
     // immediately (SKIP LOCKED) instead of queueing behind the winner. last_refresh
     // must be clock_timestamp() (wall clock), not now() (transaction start): a
     // long-running writing transaction would otherwise record a stale timestamp and
     // re-open the gate immediately. Worst-case staleness is the interval plus the
     // winner's remaining transaction time, since the row lock is held to commit.
+    //
+    // The gate winner also clears `dirty` up front: it is about to REFRESH, so its
+    // snapshot supersedes any pending marker. Any write that commits after that
+    // snapshot re-sets `dirty` below and is picked up by the trailing flush.
+    //
+    // When the gate is closed (debounced) the writer instead marks the state row
+    // `dirty` so the app-side trailing flush knows changes arrived that this
+    // interval's refresh did not capture. This second UPDATE intentionally blocks
+    // on the gate winner's row lock: a writer whose change lands during an in-flight
+    // refresh must wait until that refresh commits and then flag `dirty`, otherwise
+    // its change could be silently dropped. It performs no REFRESH of its own, so it
+    // does not reintroduce the per-statement CONCURRENTLY storm the gate prevents.
     await client.query(`
       CREATE OR REPLACE FUNCTION refresh_trades_mv()
           RETURNS TRIGGER
@@ -247,7 +265,7 @@ export async function recreateTradesMaterializedView(db: IPgComponent) {
           AS $$
           BEGIN
           UPDATE marketplace.mv_trades_refresh_state s
-             SET last_refresh = clock_timestamp()
+             SET last_refresh = clock_timestamp(), dirty = false
             FROM (
               SELECT id FROM marketplace.mv_trades_refresh_state
                WHERE last_refresh < now() - interval '${TRADES_MV_REFRESH_INTERVAL_SECONDS} seconds'
@@ -257,6 +275,10 @@ export async function recreateTradesMaterializedView(db: IPgComponent) {
 
           IF FOUND THEN
             REFRESH MATERIALIZED VIEW CONCURRENTLY marketplace.${TRADES_MV_NAME};
+          ELSE
+            UPDATE marketplace.mv_trades_refresh_state
+               SET dirty = true
+             WHERE id = true;
           END IF;
 
           RETURN NULL;
@@ -358,4 +380,39 @@ export async function recreateTradesMaterializedView(db: IPgComponent) {
   } finally {
     client.release()
   }
+}
+
+// Trailing flush for the leading-edge debounce in refresh_trades_mv(). Writes that
+// arrive while the gate is closed only mark the state row `dirty`; nothing refreshes
+// the view for them until this runs. Intended to be invoked on an interval (~every
+// TRADES_MV_REFRESH_INTERVAL_SECONDS) so any debounced change is reflected within one
+// interval instead of waiting indefinitely for the next unrelated trigger.
+//
+// The claim UPDATE is the same atomic gate the trigger uses: it only proceeds when
+// the row is `dirty` AND the debounce interval has elapsed, and it clears `dirty` +
+// stamps last_refresh in one statement (FOR UPDATE SKIP LOCKED). That prevents two
+// flushers, or a flusher racing a trigger, from both refreshing, and it re-closes the
+// debounce gate so the concurrent trigger path stays quiet. As with the trigger, any
+// write committing after the REFRESH snapshot re-sets `dirty` and is caught next tick.
+// Returns true when it performed a REFRESH, false when there was nothing to flush.
+export async function flushTradesMaterializedViewIfDirty(db: IPgComponent): Promise<boolean> {
+  const claim = await db.query<{ id: boolean }>(`
+    UPDATE marketplace.mv_trades_refresh_state s
+       SET last_refresh = clock_timestamp(), dirty = false
+      FROM (
+        SELECT id FROM marketplace.mv_trades_refresh_state
+         WHERE dirty = true
+           AND last_refresh < now() - interval '${TRADES_MV_REFRESH_INTERVAL_SECONDS} seconds'
+         FOR UPDATE SKIP LOCKED
+      ) gate
+     WHERE s.id = gate.id
+    RETURNING s.id;
+  `)
+
+  if (!claim.rowCount) {
+    return false
+  }
+
+  await db.query(`REFRESH MATERIALIZED VIEW CONCURRENTLY marketplace.${TRADES_MV_NAME}`)
+  return true
 }

--- a/src/logic/trades/materialized-view.ts
+++ b/src/logic/trades/materialized-view.ts
@@ -413,6 +413,14 @@ export async function flushTradesMaterializedViewIfDirty(db: IPgComponent): Prom
     return false
   }
 
-  await db.query(`REFRESH MATERIALIZED VIEW CONCURRENTLY marketplace.${TRADES_MV_NAME}`)
+  try {
+    await db.query(`REFRESH MATERIALIZED VIEW CONCURRENTLY marketplace.${TRADES_MV_NAME}`)
+  } catch (error) {
+    // The claim already cleared `dirty`, but the REFRESH failed — the changes it was meant to capture
+    // are still unreflected. Re-mark `dirty` so the next tick retries instead of silently dropping them
+    // (the exact bug this flush exists to prevent), then rethrow so the job's onError surfaces it.
+    await db.query('UPDATE marketplace.mv_trades_refresh_state SET dirty = true WHERE id = true')
+    throw error
+  }
   return true
 }

--- a/src/ports/trades/component.ts
+++ b/src/ports/trades/component.ts
@@ -3,7 +3,7 @@ import { Event, Trade, TradeAsset, TradeAssetDirection, TradeAssetType, TradeCre
 import { ContractName, getContract } from 'decentraland-transactions'
 import { fromDbTradeAndDBTradeAssetWithValueListToTrade } from '../../adapters/trades/trades'
 import { isErrorWithMessage } from '../../logic/errors'
-import { recreateTradesMaterializedView } from '../../logic/trades/materialized-view'
+import { flushTradesMaterializedViewIfDirty, recreateTradesMaterializedView } from '../../logic/trades/materialized-view'
 import { validateAssetOwnership, validateTradeSignature } from '../../logic/trades/utils'
 import { AppComponents } from '../../types'
 import {
@@ -310,12 +310,21 @@ export function createTradesComponent(
     await recreateTradesMaterializedView(pg)
   }
 
+  async function flushMaterializedViewIfDirty() {
+    const refreshed = await flushTradesMaterializedViewIfDirty(pg)
+    if (refreshed) {
+      logger.info('Flushed a debounced trades materialized view refresh')
+    }
+    return refreshed
+  }
+
   return {
     getTrades,
     getTradesByAddress,
     addTrade,
     getTrade,
     getTradeAcceptedEvent,
-    recreateMaterializedView
+    recreateMaterializedView,
+    flushMaterializedViewIfDirty
   }
 }

--- a/src/ports/trades/types.ts
+++ b/src/ports/trades/types.ts
@@ -7,6 +7,7 @@ export type ITradesComponent = {
   getTrade(id: string): Promise<Trade>
   getTradeAcceptedEvent(hashedSignature: string, acceptedDate: number, caller: string): Promise<Event>
   recreateMaterializedView(): Promise<void>
+  flushMaterializedViewIfDirty(): Promise<boolean>
 }
 
 export enum TradeEvent {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export type BaseComponents = {
   transak: ITransakComponent
   ens: IENSComponent
   updateBuilderServerItemsViewJob: IJobComponent
+  flushTradesMaterializedViewJob: IJobComponent
   schemaValidator: ISchemaValidatorComponent<GlobalContext>
   lists: IListsComponents
   snapshot: ISnapshotComponent

--- a/test/components.ts
+++ b/test/components.ts
@@ -145,6 +145,9 @@ async function initComponents(): Promise<TestComponents> {
   const updateBuilderServerItemsViewJob = createJobComponent({ logs }, () => undefined, 5 * 60 * 1000, {
     startupDelay: 30
   })
+  const flushTradesMaterializedViewJob = createJobComponent({ logs }, () => undefined, 30 * 1000, {
+    startupDelay: 30
+  })
 
   const transak = createTransakComponent(
     { fetch, logs, cache },
@@ -184,6 +187,7 @@ async function initComponents(): Promise<TestComponents> {
     wertApi,
     ens,
     updateBuilderServerItemsViewJob,
+    flushTradesMaterializedViewJob,
     access,
     lists,
     picks,

--- a/test/unit/trades-handler.spec.ts
+++ b/test/unit/trades-handler.spec.ts
@@ -34,6 +34,7 @@ describe('when handling the creation of a new trade', () => {
       components: {
         trades: {
           recreateMaterializedView: jest.fn().mockResolvedValue({}),
+          flushMaterializedViewIfDirty: jest.fn().mockResolvedValue(false),
           getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
           getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
           addTrade: jest.fn().mockResolvedValue({}),
@@ -168,6 +169,7 @@ describe('when handling the retrieval of a trade', () => {
         components: {
           trades: {
             recreateMaterializedView: jest.fn().mockResolvedValue({}),
+            flushMaterializedViewIfDirty: jest.fn().mockResolvedValue(false),
             getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
             getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
             addTrade: jest.fn().mockResolvedValue({}),
@@ -204,6 +206,7 @@ describe('when handling the retrieval of a trade', () => {
         components: {
           trades: {
             recreateMaterializedView: jest.fn().mockResolvedValue({}),
+            flushMaterializedViewIfDirty: jest.fn().mockResolvedValue(false),
             getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
             getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
             addTrade: jest.fn().mockResolvedValue({}),
@@ -241,6 +244,7 @@ describe('when handling the retrieval of a trade', () => {
         components: {
           trades: {
             recreateMaterializedView: jest.fn().mockResolvedValue({}),
+            flushMaterializedViewIfDirty: jest.fn().mockResolvedValue(false),
             getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
             getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
             addTrade: jest.fn().mockResolvedValue({}),
@@ -275,6 +279,7 @@ describe('when handling the retrieval of a trade accepted event', () => {
       components: {
         trades: {
           recreateMaterializedView: jest.fn().mockResolvedValue({}),
+          flushMaterializedViewIfDirty: jest.fn().mockResolvedValue(false),
           getTrades: jest.fn().mockResolvedValue({ data: [], count: 0 }),
           getTradesByAddress: jest.fn().mockResolvedValue({ data: [] }),
           addTrade: jest.fn().mockResolvedValue({}),
@@ -365,6 +370,7 @@ describe('when handling the retrieval of a trade accepted event', () => {
         components: {
           trades: {
             recreateMaterializedView: recreateMaterializedViewMock,
+            flushMaterializedViewIfDirty: jest.fn().mockResolvedValue(false),
             getTrades: jest.fn(),
             getTradesByAddress: jest.fn(),
             addTrade: jest.fn(),

--- a/test/unit/trades-materialized-view.spec.ts
+++ b/test/unit/trades-materialized-view.spec.ts
@@ -1,0 +1,71 @@
+import { flushTradesMaterializedViewIfDirty, TRADES_MV_NAME } from '../../src/logic/trades/materialized-view'
+import { IPgComponent } from '../../src/ports/db/types'
+
+let mockQuery: jest.Mock
+let mockPg: IPgComponent
+
+beforeEach(() => {
+  mockQuery = jest.fn()
+  mockPg = {
+    getPool: jest.fn(),
+    withTransaction: jest.fn(),
+    withAsyncContextTransaction: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    streamQuery: jest.fn(),
+    query: mockQuery
+  } as unknown as IPgComponent
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('when flushing a debounced trades materialized view refresh', () => {
+  describe('and the state row is dirty and the debounce interval has elapsed', () => {
+    beforeEach(() => {
+      // First call is the claim UPDATE (wins), second call is the REFRESH
+      mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: true }] }).mockResolvedValueOnce({ rowCount: 0, rows: [] })
+    })
+
+    it('should claim the flush by clearing dirty and stamping last_refresh', async () => {
+      await flushTradesMaterializedViewIfDirty(mockPg)
+
+      const claimSql = mockQuery.mock.calls[0][0] as string
+      expect(claimSql).toContain('UPDATE marketplace.mv_trades_refresh_state')
+      expect(claimSql).toContain('dirty = false')
+      expect(claimSql).toContain('last_refresh = clock_timestamp()')
+      expect(claimSql).toContain('WHERE dirty = true')
+      expect(claimSql).toContain('FOR UPDATE SKIP LOCKED')
+    })
+
+    it('should refresh the materialized view concurrently', async () => {
+      await flushTradesMaterializedViewIfDirty(mockPg)
+
+      expect(mockQuery).toHaveBeenCalledTimes(2)
+      expect(mockQuery.mock.calls[1][0]).toBe(`REFRESH MATERIALIZED VIEW CONCURRENTLY marketplace.${TRADES_MV_NAME}`)
+    })
+
+    it('should return true', async () => {
+      await expect(flushTradesMaterializedViewIfDirty(mockPg)).resolves.toBe(true)
+    })
+  })
+
+  describe('and the state row is not dirty or the interval has not elapsed', () => {
+    beforeEach(() => {
+      // The claim UPDATE matches no row
+      mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] })
+    })
+
+    it('should not refresh the materialized view', async () => {
+      await flushTradesMaterializedViewIfDirty(mockPg)
+
+      expect(mockQuery).toHaveBeenCalledTimes(1)
+      expect(mockQuery.mock.calls[0][0]).not.toContain('REFRESH MATERIALIZED VIEW')
+    })
+
+    it('should return false', async () => {
+      await expect(flushTradesMaterializedViewIfDirty(mockPg)).resolves.toBe(false)
+    })
+  })
+})

--- a/test/unit/trades-materialized-view.spec.ts
+++ b/test/unit/trades-materialized-view.spec.ts
@@ -68,4 +68,24 @@ describe('when flushing a debounced trades materialized view refresh', () => {
       await expect(flushTradesMaterializedViewIfDirty(mockPg)).resolves.toBe(false)
     })
   })
+
+  describe('and the REFRESH fails after the claim', () => {
+    beforeEach(() => {
+      // claim wins, REFRESH throws, then the re-mark UPDATE runs
+      mockQuery
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: true }] })
+        .mockRejectedValueOnce(new Error('refresh boom'))
+        .mockResolvedValueOnce({ rowCount: 1, rows: [] })
+    })
+
+    it('should re-mark the state row dirty so the next tick retries, and rethrow', async () => {
+      await expect(flushTradesMaterializedViewIfDirty(mockPg)).rejects.toThrow('refresh boom')
+
+      // 3rd query restores dirty = true (the claim had cleared it before the failed REFRESH).
+      expect(mockQuery).toHaveBeenCalledTimes(3)
+      const remarkSql = mockQuery.mock.calls[2][0] as string
+      expect(remarkSql).toContain('UPDATE marketplace.mv_trades_refresh_state')
+      expect(remarkSql).toContain('SET dirty = true')
+    })
+  })
 })


### PR DESCRIPTION
## Changes

`refresh_trades_mv()` is a leading-edge debounce: it only runs `REFRESH MATERIALIZED VIEW CONCURRENTLY` when the last refresh was >30s ago, and **silently drops** any trigger that fires inside the window. A trade whose amount (`trade_assets_erc20`) commits during that window has its refresh debounced away, so `mv_trades.amount_received` stays NULL until some unrelated later write triggers a post-window refresh — on a quiet DB, indefinitely. Downstream that trade is excluded from the shop v3 catalog (`usd_wei > 0`) and `/v1/nfts` returns its order with `price: null` (observed on dev; a manual `REFRESH` fixes it).

- Add a `dirty` flag to `mv_trades_refresh_state`. The trigger fn now: on gate pass → refresh + clear `dirty`; on gate fail (debounced) → set `dirty = true` (blocking on the in-flight refresh's row lock so the write can't be lost), no refresh of its own.
- New `flushTradesMaterializedViewIfDirty()` + a 30s app-side job (via the existing `createJobComponent`, WKC-managed lifecycle) that runs exactly one extra `REFRESH CONCURRENTLY` **only** when `dirty` and the interval has elapsed.
- Net: leading-edge debounce still prevents the per-statement refresh storm (the reason it exists); no refresh is ever permanently dropped — a debounced change is flushed within one interval.

## Test plan

- [x] Unit tests for the flush claim logic (dirty + elapsed → refresh; otherwise no-op; clears dirty / stamps last_refresh / `FOR UPDATE SKIP LOCKED`). `npm run build`, lint, `npm test` (776) green.
- [ ] Dev: recreate the MV (applies the new trigger fn + `dirty` column), force a refresh, insert a trade sub-asset within 30s → `dirty=true`, no refresh; within one interval the job flushes → `amount_received` populated, order `price` non-null, catalog includes it.