### PR TITLE
feat: item-unified shop catalog feed (groupBy=item)

### DIFF
--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -20,6 +20,15 @@ const SOURCE_VALUES: Record<UnifiedListingSource, UnifiedListingSource> = {
   legacy: 'legacy'
 }
 
+// Valid `groupBy` values for the unified feed. 'listing' (default) -> one row per open trade (the PDP
+// resale view needs this). 'item' -> one row per item, priced primary-if-present else cheapest
+// credit-buyable secondary, with a per-item listingCount (the shop BROWSE feed).
+type UnifiedGroupBy = 'listing' | 'item'
+const GROUP_BY_VALUES: Record<UnifiedGroupBy, UnifiedGroupBy> = {
+  listing: 'listing',
+  item: 'item'
+}
+
 function csv(value?: string): string[] | undefined {
   const parts = value
     ?.split(',')
@@ -109,6 +118,10 @@ export function createShopLegacyHandler(
 // converted MANA->credits with the live rate) and a `source` discriminator. Same query params as
 // /v3/catalog/shop plus optional `source` (native|legacy). Sorting and minPriceCredits/maxPriceCredits
 // work across BOTH sources.
+//
+// `groupBy=item` collapses the feed to ONE row per item (priced primary-if-present else cheapest
+// credit-buyable secondary, plus a per-item listingCount) -- the shop BROWSE feed. The default
+// (`groupBy=listing`) keeps one row per open trade, which the PDP resale view depends on.
 export function createShopUnifiedHandler(
   components: Pick<AppComponents, 'shopCatalog' | 'manaUsdRate'>
 ): IHttpServerComponent.IRequestHandler<Context<'/v3/catalog/unified'>> {
@@ -130,28 +143,29 @@ export function createShopUnifiedHandler(
     const search = params.getString('search')
     const sortBy = params.getValue<ShopSortBy>('sortBy', SORT_VALUES)
     const source = params.getValue<UnifiedListingSource>('source', SOURCE_VALUES)
+    const groupBy = params.getValue<UnifiedGroupBy>('groupBy', GROUP_BY_VALUES, 'listing')
+
+    const filters = {
+      first,
+      skip,
+      category,
+      contractAddress,
+      itemId,
+      creator,
+      rarities,
+      wearableCategories,
+      isSmart,
+      minPriceCredits,
+      maxPriceCredits,
+      search,
+      sortBy,
+      source
+    }
 
     return asJSON(async () => {
       const rate = manaUsdRate.getRate()
-      const { data, total } = await shopCatalog.getUnifiedListings(
-        {
-          first,
-          skip,
-          category,
-          contractAddress,
-          itemId,
-          creator,
-          rarities,
-          wearableCategories,
-          isSmart,
-          minPriceCredits,
-          maxPriceCredits,
-          search,
-          sortBy,
-          source
-        },
-        rate
-      )
+      const { data, total } =
+        groupBy === 'item' ? await shopCatalog.getShopItems(filters, rate) : await shopCatalog.getUnifiedListings(filters, rate)
       return { data, total }
     })
   }

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -14,6 +14,8 @@ import {
   ShopListing,
   ShopListingRow,
   UnifiedCatalogFilters,
+  UnifiedItem,
+  UnifiedItemRow,
   UnifiedListing,
   UnifiedListingRow,
   SHOP_DEFAULT_PAGE_SIZE,
@@ -228,6 +230,45 @@ function unifiedBranch(opts: {
 
   appendUnifiedFilters(query, filters)
   return query
+}
+
+// Build the inner UNION ALL of the requested source branches (native and/or legacy). Shared by the
+// per-listing unified feed and the item-unified browse feed so both draw from the SAME credit-buyable
+// universe (native primary + native secondary + legacy primary) with identical filters. Legacy is
+// primary-only here -- legacy ERC20 SECONDARY is Phase 3; adding it later is a one-line change (drop
+// `primaryOnly`), and the item grouping/ordering below already extends to it unchanged.
+function buildUnifiedInner(filters: UnifiedCatalogFilters, rateNumericString: string): SQLStatement {
+  const parts: SQLStatement[] = []
+  if (filters.source !== 'legacy') {
+    parts.push(
+      unifiedBranch({
+        source: 'native',
+        assetType: USD_PEGGED_ASSET_TYPE,
+        primaryOnly: false,
+        applyRate: false,
+        rateNumericString,
+        filters
+      })
+    )
+  }
+  if (filters.source !== 'native') {
+    parts.push(
+      unifiedBranch({
+        source: 'legacy',
+        assetType: ERC20_ASSET_TYPE,
+        primaryOnly: true,
+        applyRate: true,
+        rateNumericString,
+        filters
+      })
+    )
+  }
+
+  const inner = parts[0]
+  for (let i = 1; i < parts.length; i++) {
+    inner.append(SQL` UNION ALL `).append(parts[i])
+  }
+  return inner
 }
 
 export function createShopCatalogComponent(components: Pick<AppComponents, 'dappsDatabase' | 'logs'>): IShopCatalogComponent {
@@ -535,37 +576,8 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
     const skip = clampCount(filters.skip, 0, 0, Number.MAX_SAFE_INTEGER)
     const rateNumericString = rateToNumericString(manaUsdRate)
 
-    // Build only the requested branch(es); default is both. `parts` are UNION ALL-ed together.
-    const parts: SQLStatement[] = []
-    if (filters.source !== 'legacy') {
-      parts.push(
-        unifiedBranch({
-          source: 'native',
-          assetType: USD_PEGGED_ASSET_TYPE,
-          primaryOnly: false,
-          applyRate: false,
-          rateNumericString,
-          filters
-        })
-      )
-    }
-    if (filters.source !== 'native') {
-      parts.push(
-        unifiedBranch({
-          source: 'legacy',
-          assetType: ERC20_ASSET_TYPE,
-          primaryOnly: true,
-          applyRate: true,
-          rateNumericString,
-          filters
-        })
-      )
-    }
-
-    const inner = parts[0]
-    for (let i = 1; i < parts.length; i++) {
-      inner.append(SQL` UNION ALL `).append(parts[i])
-    }
+    // Build only the requested branch(es); default is both, UNION ALL-ed together.
+    const inner = buildUnifiedInner(filters, rateNumericString)
 
     // Wrap the union so priceCredits, the price-range filter and the sort operate on the merged set.
     const query = SQL`
@@ -637,5 +649,111 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
     return { data, total }
   }
 
-  return { getShopListings, getImportableListings, getLegacyListings, getUnifiedListings }
+  // The item-unified BROWSE feed: the same credit-buyable universe as getUnifiedListings, but collapsed
+  // to ONE row per (contract, item). Layered so each concern stays a distinct, reviewable SQL level:
+  //   u  -- the UNION ALL of the source branches (one row per open credit-buyable listing).
+  //   f  -- drop free/broken listings (usd_wei > 0) and attach a per-item listing_count window; this is
+  //         the "N listings" badge count and it is stable across every row of the same item.
+  //   d  -- DISTINCT ON (contract_address, item_id) keeps exactly one representative listing per item.
+  //         The ORDER BY makes the survivor: PRIMARY before secondary, then NATIVE (fixed USD) before
+  //         LEGACY (rate-floating MANA), then cheapest usd_wei, then trade_id for determinism. That is
+  //         precisely "primary price if present, else cheapest credit-buyable secondary", preferring a
+  //         stable USD headline over a rate-floating one. price_credits is CEIL(usd_wei / C) of the
+  //         survivor (same "Model B" rounding as every other feed).
+  // The outer query then applies the credit price-range on the HEADLINE price, the display sort, and
+  // pagination, exposing COUNT(*) OVER() as the total number of items. sent_item_id is populated for
+  // secondary rows too (mv_trades), so grouping needs no extra joins.
+  async function getShopItems(filters: UnifiedCatalogFilters, manaUsdRate: number): Promise<{ data: UnifiedItem[]; total: number }> {
+    const first = clampCount(filters.first, SHOP_DEFAULT_PAGE_SIZE, SHOP_MIN_PAGE_SIZE, SHOP_MAX_PAGE_SIZE)
+    const skip = clampCount(filters.skip, 0, 0, Number.MAX_SAFE_INTEGER)
+    const rateNumericString = rateToNumericString(manaUsdRate)
+
+    const inner = buildUnifiedInner(filters, rateNumericString)
+
+    const query = SQL`
+      SELECT
+        d.*,
+        COUNT(*) OVER() AS total
+      FROM (
+        SELECT DISTINCT ON (f.contract_address, f.item_id)
+          f.*,
+          CEIL(f.usd_wei / ${USD_WEI_PER_CREDIT.toString()}::numeric)::bigint AS price_credits
+        FROM (
+          SELECT
+            u.*,
+            COUNT(*) OVER (PARTITION BY u.contract_address, u.item_id) AS listing_count
+          FROM (`.append(inner).append(SQL`) u
+          WHERE u.usd_wei > 0
+        ) f
+        ORDER BY
+          f.contract_address,
+          f.item_id,
+          (CASE WHEN f.trade_type = 'public_item_order' THEN 0 ELSE 1 END),
+          (CASE WHEN f.source = 'native' THEN 0 ELSE 1 END),
+          f.usd_wei ASC,
+          f.trade_id
+      ) d
+      WHERE d.usd_wei > 0`)
+
+    // Price-range on the item's DISPLAYED (headline) price -- see getUnifiedListings for the CEIL-consistent
+    // lower bound (usd_wei > (m - 1) * C). listing_count is intentionally NOT narrowed by this filter: the
+    // badge reflects how many listings the item has, independent of the price slider.
+    if (filters.minPriceCredits != null) {
+      const minWei = creditsToWei(filters.minPriceCredits)
+      if (minWei != null && minWei > 0n) {
+        query.append(SQL` AND d.usd_wei > ${(minWei - USD_WEI_PER_CREDIT).toString()}`)
+      }
+    }
+    if (filters.maxPriceCredits != null) {
+      const maxWei = creditsToWei(filters.maxPriceCredits)
+      if (maxWei != null) query.append(SQL` AND d.usd_wei <= ${maxWei.toString()}`)
+    }
+
+    // Sort (fixed expressions only -- never interpolate user input into ORDER BY). A `d.trade_id`
+    // tiebreaker keeps pagination stable when many items share a headline usd_wei/name.
+    const order =
+      filters.sortBy === 'cheapest'
+        ? SQL` ORDER BY d.usd_wei ASC, d.trade_id`
+        : filters.sortBy === 'most_expensive'
+        ? SQL` ORDER BY d.usd_wei DESC, d.trade_id`
+        : filters.sortBy === 'name'
+        ? SQL` ORDER BY d.name ASC, d.trade_id`
+        : SQL` ORDER BY d.created_at DESC, d.trade_id`
+    query.append(order).append(SQL` LIMIT ${first} OFFSET ${skip}`)
+
+    const result = await pg.query<UnifiedItemRow>(query)
+    const polygonChainId = getPolygonChainId()
+    const ethereumChainId = getEthereumChainId()
+    const total = result.rows[0] ? Number(result.rows[0].total) : 0
+
+    const data: UnifiedItem[] = result.rows.map(r => {
+      const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
+      return {
+        source: r.source,
+        tradeId: r.trade_id,
+        listingType: r.trade_type === 'public_item_order' ? 'primary' : 'secondary',
+        contractAddress: r.contract_address,
+        itemId: r.item_id,
+        tokenId: r.token_id,
+        name: r.name ?? '',
+        thumbnail: r.image ?? '',
+        rarity: (r.rarity ?? 'common').toLowerCase(),
+        category: topLevelCategory(r.item_type),
+        wearableCategory: r.wearable_category,
+        gender: r.gender ?? null,
+        creator: r.creator ?? '',
+        priceCredits: Number(r.price_credits),
+        manaWei: r.mana_wei ?? null,
+        listingCount: Number(r.listing_count),
+        available: r.available ? Number(r.available) : 1,
+        network: isPolygon ? Network.MATIC : Network.ETHEREUM,
+        chainId: isPolygon ? polygonChainId : ethereumChainId,
+        createdAt: Number(r.created_at)
+      }
+    })
+
+    return { data, total }
+  }
+
+  return { getShopListings, getImportableListings, getLegacyListings, getUnifiedListings, getShopItems }
 }

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -125,6 +125,15 @@ export type UnifiedCatalogFilters = ShopCatalogFilters & {
   source?: UnifiedListingSource
 }
 
+// The ITEM-unified feed row: one entry per item (not per listing). Same shape as a UnifiedListing (the
+// surviving representative listing -- primary if present, else cheapest credit-buyable secondary) plus a
+// listingCount so the frontend can badge "N listings" / link to the PDP resale column. tradeId/listingType/
+// tokenId/priceCredits/source all describe that representative (headline) listing.
+export type UnifiedItem = UnifiedListing & {
+  // How many open credit-buyable listings this item has (primary + secondary, native + legacy).
+  listingCount: number
+}
+
 export interface IShopCatalogComponent {
   getShopListings(filters: ShopCatalogFilters): Promise<{ data: ShopListing[]; total: number }>
   getImportableListings(seller: string): Promise<ImportableListing[]>
@@ -133,6 +142,10 @@ export interface IShopCatalogComponent {
   // caller supplies the current MANA/USD rate (USD per MANA) used to convert legacy prices to credits
   // and to make the price-range filter + sort comparable across both sources.
   getUnifiedListings(filters: UnifiedCatalogFilters, manaUsdRate: number): Promise<{ data: UnifiedListing[]; total: number }>
+  // Same credit-buyable universe and filters as getUnifiedListings, but UNIFIED BY ITEM: one row per
+  // (contract, item), priced primary-if-present else cheapest credit-buyable secondary, carrying a
+  // per-item listingCount. This is the shop BROWSE feed; getUnifiedListings stays per-listing (PDP resale).
+  getShopItems(filters: UnifiedCatalogFilters, manaUsdRate: number): Promise<{ data: UnifiedItem[]; total: number }>
 }
 
 export type ImportableListingRow = {
@@ -194,6 +207,12 @@ export type UnifiedListingRow = {
   network: string | null
   created_at: string
   total: string
+}
+
+// Raw DB row for the item-unified feed, before mapping to UnifiedItem. Same columns as UnifiedListingRow
+// (of the surviving representative listing) plus the per-item listing_count.
+export type UnifiedItemRow = UnifiedListingRow & {
+  listing_count: string
 }
 
 // Raw DB row for the legacy (classic MANA) primary feed, before mapping to LegacyListing.

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -577,4 +577,181 @@ describe('Shop Catalog Component', () => {
       expect(data.map(d => d.gender)).toEqual(['male', 'female', null])
     })
   })
+
+  // An item-unified row: a UnifiedListingRow (the surviving representative listing) plus listing_count.
+  function itemRow(overrides: Record<string, unknown> = {}) {
+    return unifiedRow({ listing_count: '1', ...overrides })
+  }
+
+  describe('when building the item-unified query', () => {
+    const RATE = 0.5
+    const RATE_STR = RATE.toFixed(18)
+
+    beforeEach(() => {
+      query.mockResolvedValue({ rows: [] })
+    })
+
+    it('should collapse to one row per item via DISTINCT ON (contract_address, item_id)', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      expect(text).toContain('SELECT DISTINCT ON (f.contract_address, f.item_id)')
+    })
+
+    it('should pick the representative listing primary-before-secondary, then native-before-legacy, then cheapest', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      // The DISTINCT ON tiebreak ORDER BY must lead with the grouping key, then the priority chain.
+      expect(text).toContain('ORDER BY\n          f.contract_address,\n          f.item_id,')
+      expect(text).toContain("(CASE WHEN f.trade_type = 'public_item_order' THEN 0 ELSE 1 END)")
+      expect(text).toContain("(CASE WHEN f.source = 'native' THEN 0 ELSE 1 END)")
+      expect(text).toContain('f.usd_wei ASC')
+      expect(text).toContain('f.trade_id')
+    })
+
+    it('should attach a per-item listing_count window partitioned by (contract_address, item_id)', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      expect(text).toContain('COUNT(*) OVER (PARTITION BY u.contract_address, u.item_id) AS listing_count')
+    })
+
+    it('should compute the headline priceCredits in SQL as CEIL of the survivor usd_wei', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      expect(text).toContain('CEIL(f.usd_wei /')
+      expect(text).toContain('AS price_credits')
+    })
+
+    it('should drop free/broken listings before grouping so they never headline or inflate the count', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      expect(text).toContain('WHERE u.usd_wei > 0')
+    })
+
+    it('should merge native and legacy sources with UNION ALL by default', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('UNION ALL')
+      expect(sql.values).toContain(2)
+      expect(sql.values).toContain(1)
+    })
+
+    it('should restrict to a single source (no UNION ALL) when source is set', async () => {
+      await shopCatalog.getShopItems({ source: 'native' }, RATE)
+      let sql = query.mock.calls[0][0]
+      expect(sql.text).not.toContain('UNION ALL')
+      expect(sql.values).toContain(2)
+      expect(sql.values).not.toContain(1)
+
+      query.mockClear()
+      await shopCatalog.getShopItems({ source: 'legacy' }, RATE)
+      sql = query.mock.calls[0][0]
+      expect(sql.text).not.toContain('UNION ALL')
+      expect(sql.values).toContain(1)
+      expect(sql.values).not.toContain(2)
+    })
+
+    it('should apply the MANA/USD rate to legacy amounts only', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('mv.amount_received::numeric * ')
+      expect(sql.values).toContain(RATE_STR)
+    })
+
+    it('should filter the credit price range on the item headline price (ceil-consistent lower bound)', async () => {
+      await shopCatalog.getShopItems({ minPriceCredits: 3, maxPriceCredits: 10 }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('d.usd_wei > ')
+      expect(sql.text).toContain('d.usd_wei <=')
+      expect(sql.values).toContain((2n * WEI_PER_CREDIT).toString())
+      expect(sql.values).toContain((10n * WEI_PER_CREDIT).toString())
+    })
+
+    it('should not append a negative lower bound when minPriceCredits is 0', async () => {
+      await shopCatalog.getShopItems({ minPriceCredits: 0 }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.values).not.toContain((-1n * WEI_PER_CREDIT).toString())
+    })
+
+    it('should sort the deduped items on fixed expressions with a stable trade_id tiebreaker', async () => {
+      await shopCatalog.getShopItems({ sortBy: 'cheapest' }, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY d.usd_wei ASC, d.trade_id')
+
+      query.mockClear()
+      await shopCatalog.getShopItems({ sortBy: 'most_expensive' }, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY d.usd_wei DESC, d.trade_id')
+
+      query.mockClear()
+      await shopCatalog.getShopItems({ sortBy: 'name' }, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY d.name ASC, d.trade_id')
+
+      query.mockClear()
+      await shopCatalog.getShopItems({}, RATE)
+      expect(query.mock.calls[0][0].text).toContain('ORDER BY d.created_at DESC, d.trade_id')
+    })
+
+    it('should clamp pagination and bind LIMIT/OFFSET as params', async () => {
+      await shopCatalog.getShopItems({ first: 99999, skip: 10.7 }, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('LIMIT')
+      expect(sql.text).toContain('OFFSET')
+      expect(sql.values).toEqual(expect.arrayContaining([1000, 10]))
+    })
+
+    it('should count total items from COUNT(*) OVER() on the deduped set', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+      expect(query.mock.calls[0][0].text).toContain('COUNT(*) OVER() AS total')
+    })
+  })
+
+  describe('when mapping item-unified rows', () => {
+    it('should surface the representative listing and the per-item listingCount', async () => {
+      query.mockResolvedValueOnce({
+        rows: [
+          itemRow({ source: 'native', trade_id: 'native-1', price_credits: '5', mana_wei: null, listing_count: '3', total: '2' }),
+          itemRow({
+            source: 'native',
+            trade_id: 'native-2',
+            trade_type: 'public_nft_order',
+            token_id: '99',
+            item_id: null,
+            price_credits: '7',
+            listing_count: '1',
+            total: '2'
+          })
+        ]
+      })
+
+      const { data, total } = await shopCatalog.getShopItems({}, 0.5)
+
+      expect(total).toBe(2)
+      expect(data[0]).toMatchObject({ tradeId: 'native-1', listingType: 'primary', priceCredits: 5, listingCount: 3 })
+      expect(data[1]).toMatchObject({ tradeId: 'native-2', listingType: 'secondary', tokenId: '99', priceCredits: 7, listingCount: 1 })
+    })
+
+    it('should carry the raw MANA price for a legacy representative and the source discriminator', async () => {
+      query.mockResolvedValueOnce({
+        rows: [itemRow({ source: 'legacy', trade_id: 'legacy-1', price_credits: '3', mana_wei: '2500000000000000000', listing_count: '2' })]
+      })
+
+      const { data } = await shopCatalog.getShopItems({}, 0.5)
+
+      expect(data[0]).toMatchObject({
+        source: 'legacy',
+        tradeId: 'legacy-1',
+        priceCredits: 3,
+        manaWei: '2500000000000000000',
+        listingCount: 2
+      })
+    })
+  })
 })

--- a/test/unit/shop-catalog-handler.spec.ts
+++ b/test/unit/shop-catalog-handler.spec.ts
@@ -1,0 +1,74 @@
+import { URL } from 'url'
+import { createShopUnifiedHandler } from '../../src/controllers/handlers/shop-catalog-handler'
+
+// The unified handler is a factory: createShopUnifiedHandler(components) -> (context) => response. These
+// tests drive the `groupBy` dispatch (per-listing default vs item-unified) and confirm the parsed filters
+// reach the component unchanged.
+describe('when handling the unified shop catalog endpoint', () => {
+  let getUnifiedListings: jest.Mock
+  let getShopItems: jest.Mock
+  let getRate: jest.Mock
+  let handler: ReturnType<typeof createShopUnifiedHandler>
+
+  const noop = jest.fn()
+  const invoke = (url: string) => handler({ url: new URL(url), request: {} } as any, noop)
+
+  beforeEach(() => {
+    getUnifiedListings = jest.fn().mockResolvedValue({ data: [{ tradeId: 'listing-1' }], total: 1 })
+    getShopItems = jest.fn().mockResolvedValue({ data: [{ tradeId: 'item-1', listingCount: 3 }], total: 1 })
+    getRate = jest.fn().mockReturnValue(0.5)
+    const components = {
+      shopCatalog: { getUnifiedListings, getShopItems },
+      manaUsdRate: { getRate }
+    } as any
+    handler = createShopUnifiedHandler(components)
+  })
+
+  describe('and no groupBy is provided', () => {
+    it('should default to the per-listing feed (getUnifiedListings)', async () => {
+      const result = await invoke('http://localhost/v3/catalog/unified')
+
+      expect(getUnifiedListings).toHaveBeenCalledTimes(1)
+      expect(getShopItems).not.toHaveBeenCalled()
+      expect(result.body).toEqual({ data: [{ tradeId: 'listing-1' }], total: 1 })
+    })
+  })
+
+  describe('and groupBy=item is provided', () => {
+    it('should dispatch to the item-unified feed (getShopItems) with the live rate', async () => {
+      const result = await invoke('http://localhost/v3/catalog/unified?groupBy=item')
+
+      expect(getShopItems).toHaveBeenCalledTimes(1)
+      expect(getUnifiedListings).not.toHaveBeenCalled()
+      expect(getShopItems.mock.calls[0][1]).toBe(0.5)
+      expect(result.body).toEqual({ data: [{ tradeId: 'item-1', listingCount: 3 }], total: 1 })
+    })
+  })
+
+  describe('and an unknown groupBy is provided', () => {
+    it('should fall back to the per-listing feed', async () => {
+      await invoke('http://localhost/v3/catalog/unified?groupBy=bogus')
+
+      expect(getUnifiedListings).toHaveBeenCalledTimes(1)
+      expect(getShopItems).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and browse filters are provided with groupBy=item', () => {
+    it('should forward the parsed filters to getShopItems', async () => {
+      await invoke(
+        'http://localhost/v3/catalog/unified?groupBy=item&category=emote&rarity=Rare,EPIC&minPriceCredits=3&maxPriceCredits=10&source=native&sortBy=cheapest&search=cool'
+      )
+
+      expect(getShopItems.mock.calls[0][0]).toMatchObject({
+        category: 'emote',
+        rarities: ['Rare', 'EPIC'],
+        minPriceCredits: 3,
+        maxPriceCredits: 10,
+        source: 'native',
+        sortBy: 'cheapest',
+        search: 'cool'
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Changes

Adds an opt-in `groupBy=item` mode to `GET /v3/catalog/unified` (default `groupBy=listing` is unchanged — the PDP resale view depends on the per-listing feed). It returns ONE row per item, priced **primary-if-present, else cheapest credit-buyable secondary**, plus a `listingCount`.

- `DISTINCT ON (contract_address, sent_item_id)` ordered primary-before-secondary, native (fixed USD) before legacy (rate-floating MANA), then cheapest `usd_wei`. `mv_trades.sent_item_id` is populated for secondaries too, so no new joins.
- Shared UNION-ALL builder (`buildUnifiedInner`) so both feeds draw from the identical credit-buyable universe (native primary + native secondary + legacy primary; legacy secondary deferred to a later phase).

Powers the shop browse grid so an item with a primary + N secondary listings renders as one card instead of N duplicates.

## Test plan

- [x] `getShopItems` query-builder + `groupBy` handler dispatch unit tests; build, lint, unit tests (790) green.
- [ ] Integration (CI Postgres); validated locally against the dev DB.