### PR TITLE
feat: expose seller and issuedId on shop-catalog secondary listings

### DIFF
--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -198,6 +198,8 @@ function unifiedBranch(opts: {
           item_s.search_wearable_category, item_s.search_emote_category
         ) AS wearable_category,
         COALESCE(item_p.creator, item_s.creator, '') AS creator,
+        mv.assets->'sent'->>'owner' AS seller,
+        mv.assets->'sent'->>'issued_id' AS issued_id,
         `
     .append(usdWei)
     .append(
@@ -254,6 +256,8 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
           item_s.search_wearable_category, item_s.search_emote_category
         ) AS wearable_category,
         COALESCE(item_p.creator, item_s.creator, '') AS creator,
+        mv.assets->'sent'->>'owner' AS seller,
+        mv.assets->'sent'->>'issued_id' AS issued_id,
         mv.amount_received::text AS price,
         mv.available::text AS available,
         mv.network AS network,
@@ -351,6 +355,8 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
         wearableCategory: r.wearable_category,
         gender: r.gender ?? null,
         creator: r.creator ?? '',
+        seller: r.seller ?? null,
+        issuedId: r.issued_id ?? null,
         priceCredits,
         available: r.available ? Number(r.available) : 1,
         network: isPolygon ? Network.MATIC : Network.ETHEREUM,
@@ -625,6 +631,8 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
         wearableCategory: r.wearable_category,
         gender: r.gender ?? null,
         creator: r.creator ?? '',
+        seller: r.seller ?? null,
+        issuedId: r.issued_id ?? null,
         priceCredits: Number(r.price_credits),
         manaWei: r.mana_wei ?? null,
         available: r.available ? Number(r.available) : 1,

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -26,6 +26,8 @@ export type ShopListing = {
   wearableCategory: string | null // on-chain category (upper_body, hat, ...) when applicable
   gender: ShopGender // male | female | unisex (from body shapes); null for emotes/unknown
   creator: string
+  seller: string | null // secondary (resale): the reseller = current owner of the sent NFT; null for primary
+  issuedId: string | null // secondary (resale): the NFT mint index (issued id); null for primary
   priceCredits: number // USD -> fixed credits (1 credit = $0.10)
   available: number
   network: string
@@ -165,6 +167,8 @@ export type ShopListingRow = {
   wearable_category: string | null
   gender: ShopGender
   creator: string | null
+  seller: string | null // secondary: sent NFT owner (from mv.assets->'sent'->>'owner'); null for primary
+  issued_id: string | null // secondary: sent NFT issued id (from mv.assets->'sent'->>'issued_id'); null for primary
   price: string
   available: string | null
   network: string | null
@@ -188,6 +192,8 @@ export type UnifiedListingRow = {
   wearable_category: string | null
   gender: ShopGender
   creator: string | null
+  seller: string | null // secondary: sent NFT owner (from mv.assets->'sent'->>'owner'); null for primary
+  issued_id: string | null // secondary: sent NFT issued id (from mv.assets->'sent'->>'issued_id'); null for primary
   price_credits: string
   mana_wei: string | null
   available: string | null

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -17,6 +17,8 @@ function shopRow(overrides: Record<string, unknown> = {}) {
     item_type: 'wearable_v2',
     wearable_category: 'hat',
     creator: '0xcreator',
+    seller: null,
+    issued_id: null,
     price: (5n * WEI_PER_CREDIT).toString(),
     available: '10',
     network: 'MATIC',
@@ -63,6 +65,8 @@ function unifiedRow(overrides: Record<string, unknown> = {}) {
     wearable_category: 'hat',
     gender: 'unisex',
     creator: '0xcreator',
+    seller: null,
+    issued_id: null,
     price_credits: '5',
     mana_wei: null,
     available: '10',
@@ -135,6 +139,32 @@ describe('Shop Catalog Component', () => {
 
       expect(data[0]).toMatchObject({ rarity: 'mythic', listingType: 'secondary', tokenId: '99' })
     })
+
+    it('should surface the seller and issuedId for a secondary (resale) row', async () => {
+      query.mockResolvedValueOnce({
+        rows: [
+          shopRow({
+            trade_type: 'public_nft_order',
+            token_id: '99',
+            item_id: null,
+            seller: '0xreseller',
+            issued_id: '42'
+          })
+        ]
+      })
+
+      const { data } = await shopCatalog.getShopListings({})
+
+      expect(data[0]).toMatchObject({ listingType: 'secondary', seller: '0xreseller', issuedId: '42' })
+    })
+
+    it('should leave seller and issuedId null for a primary row', async () => {
+      query.mockResolvedValueOnce({ rows: [shopRow({ seller: null, issued_id: null })] })
+
+      const { data } = await shopCatalog.getShopListings({})
+
+      expect(data[0]).toMatchObject({ listingType: 'primary', seller: null, issuedId: null })
+    })
   })
 
   describe('when building the shop listings query', () => {
@@ -148,6 +178,14 @@ describe('Shop Catalog Component', () => {
       const sql = query.mock.calls[0][0]
       expect(sql.text).toContain("ta.direction = 'received' AND ta.asset_type =")
       expect(sql.values).toContain(2)
+    })
+
+    it('should select the seller and issued id from the sent asset JSON (no extra join)', async () => {
+      await shopCatalog.getShopListings({})
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain("mv.assets->'sent'->>'owner' AS seller")
+      expect(sql.text).toContain("mv.assets->'sent'->>'issued_id' AS issued_id")
     })
 
     it('should clamp pagination to the default page size and a zero offset', async () => {
@@ -433,6 +471,14 @@ describe('Shop Catalog Component', () => {
       expect(sql.text).toContain('AS price_credits')
     })
 
+    it('should select the seller and issued id from the sent asset JSON in each branch', async () => {
+      await shopCatalog.getUnifiedListings({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      expect(text).toContain("mv.assets->'sent'->>'owner' AS seller")
+      expect(text).toContain("mv.assets->'sent'->>'issued_id' AS issued_id")
+    })
+
     it('should apply the MANA/USD rate to legacy amounts but leave native amounts untouched', async () => {
       await shopCatalog.getUnifiedListings({}, RATE)
 
@@ -561,6 +607,25 @@ describe('Shop Catalog Component', () => {
       const { data } = await shopCatalog.getUnifiedListings({}, 0.5)
 
       expect(data[0]).toMatchObject({ source: 'native', listingType: 'secondary', tokenId: '99', priceCredits: 7 })
+    })
+
+    it('should surface the seller and issuedId for a secondary (resale) row', async () => {
+      query.mockResolvedValueOnce({
+        rows: [
+          unifiedRow({
+            source: 'native',
+            trade_type: 'public_nft_order',
+            token_id: '99',
+            item_id: null,
+            seller: '0xreseller',
+            issued_id: '42'
+          })
+        ]
+      })
+
+      const { data } = await shopCatalog.getUnifiedListings({}, 0.5)
+
+      expect(data[0]).toMatchObject({ listingType: 'secondary', seller: '0xreseller', issuedId: '42' })
     })
 
     it('should surface the body-shape-derived gender and coalesce a missing one to null', async () => {


### PR DESCRIPTION
## What

Adds `seller` and `issuedId` to the shop-catalog listing rows for **secondary** (resale, `public_nft_order`) listings. Both are `null` for primary (`public_item_order`) listings.

- `seller`: the reseller — the current owner of the sent NFT.
- `issuedId`: the NFT mint index (issued id).

Both are pulled directly from the existing `marketplace.mv_trades` row via `mv.assets->'sent'->>'owner'` and `mv.assets->'sent'->>'issued_id'` — **no new joins**, purely additive.

Applied to both the per-listing feed (`getShopListings`) and the unified feed (`getUnifiedListings`, whose `UnifiedListing` extends `ShopListing`).

## Why

Lets the Shop's resale list drop its per-token `/v1/nfts` N+1 lookup: the reseller address and mint index now arrive with the listing.

## Notes

- Primary behavior and all existing per-listing fields are unchanged.
- Unit tests extended to assert the new columns are selected and mapped for a secondary row (and left `null` for a primary).

## Gate

- `npm run build` (tsc): pass
- lint (changed files): 0 errors
- prettier: pass
- unit tests: 776 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wnep2cFXa5jSkkpvhYvQwy