### PR TITLE
fix: expose seller and issuedId on the item-unified shop feed

### DIFF
--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -750,6 +750,10 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
         wearableCategory: r.wearable_category,
         gender: r.gender ?? null,
         creator: r.creator ?? '',
+        // Representative listing's seller + issued id (buildUnifiedInner carries both): populated when
+        // the headline listing is a secondary (resale), null when it's a primary (mint).
+        seller: r.seller ?? null,
+        issuedId: r.issued_id ?? null,
         priceCredits: Number(r.price_credits),
         manaWei: r.mana_wei ?? null,
         listingCount: Number(r.listing_count),

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -818,5 +818,26 @@ describe('Shop Catalog Component', () => {
         listingCount: 2
       })
     })
+
+    it('should surface the representative seller and issuedId for a secondary headline, null for a primary', async () => {
+      query.mockResolvedValueOnce({
+        rows: [
+          itemRow({
+            trade_id: 'sec-1',
+            trade_type: 'public_nft_order',
+            token_id: '99',
+            item_id: null,
+            seller: '0xreseller',
+            issued_id: '42'
+          }),
+          itemRow({ trade_id: 'prim-1', trade_type: 'public_item_order', seller: null, issued_id: null })
+        ]
+      })
+
+      const { data } = await shopCatalog.getShopItems({}, 0.5)
+
+      expect(data[0]).toMatchObject({ listingType: 'secondary', seller: '0xreseller', issuedId: '42' })
+      expect(data[1]).toMatchObject({ listingType: 'primary', seller: null, issuedId: null })
+    })
   })
 })


### PR DESCRIPTION
## Context

#375 added the required `seller` / `issuedId` fields to `ShopListing` (and therefore to `UnifiedListing` → `UnifiedItem`), but branched off `main` before #374's `getShopItems` (item-unified `groupBy=item`) branch existed, so that mapper was never updated. On `main` (post-merge) the item-feed mapper builds `UnifiedItem[]` objects missing those two required fields, which fails the `tsc` build in the deploy job.

## Changes

- Populate `seller` / `issuedId` in the `getShopItems` mapper from the representative listing row (`buildUnifiedInner` already selects both columns, so they propagate through `u.* → f.* → d.*`): the reseller + mint index when the headline listing is a secondary, `null` when it's a primary.
- Add a regression test asserting the item feed surfaces `seller`/`issuedId` for a secondary headline and leaves them `null` for a primary.

## Test plan

- [x] `npm run build` (the step that was failing) passes
- [x] shop-catalog unit tests green (incl. the new assertion)