### PR TITLE
feat: let the unified catalog feed filter by listing type

### DIFF
--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -1,7 +1,13 @@
 import { IHttpServerComponent } from '@dcl/core-commons'
 import { Params } from '../../logic/http/params'
 import { asJSON } from '../../logic/http/response'
-import { ShopSortBy, UnifiedListingSource, SHOP_DEFAULT_PAGE_SIZE, SHOP_MAX_PAGE_SIZE } from '../../ports/shop-catalog/types'
+import {
+  ShopListingType,
+  ShopSortBy,
+  UnifiedListingSource,
+  SHOP_DEFAULT_PAGE_SIZE,
+  SHOP_MAX_PAGE_SIZE
+} from '../../ports/shop-catalog/types'
 import { AppComponents, Context } from '../../types'
 import { getItemsParams } from './utils'
 
@@ -18,6 +24,12 @@ const SORT_VALUES: Record<ShopSortBy, ShopSortBy> = {
 const SOURCE_VALUES: Record<UnifiedListingSource, UnifiedListingSource> = {
   native: 'native',
   legacy: 'legacy'
+}
+
+// Valid `listingType` values for the unified feed. Omitted = both.
+const LISTING_TYPE_VALUES: Record<ShopListingType, ShopListingType> = {
+  primary: 'primary',
+  secondary: 'secondary'
 }
 
 // Valid `groupBy` values for the unified feed. 'listing' (default) -> one row per open trade (the PDP
@@ -143,6 +155,10 @@ export function createShopUnifiedHandler(
     const search = params.getString('search')
     const sortBy = params.getValue<ShopSortBy>('sortBy', SORT_VALUES)
     const source = params.getValue<UnifiedListingSource>('source', SOURCE_VALUES)
+    // Omitted = both, which is the pre-existing behaviour. `getValue` rejects anything outside the set,
+    // so a typo is a 400 rather than a silently unfiltered feed — the failure mode that matters here,
+    // since a caller asking for `primary` and getting everything would show resales it meant to hide.
+    const listingType = params.getValue<ShopListingType>('listingType', LISTING_TYPE_VALUES)
     const groupBy = params.getValue<UnifiedGroupBy>('groupBy', GROUP_BY_VALUES, 'listing')
 
     const filters = {
@@ -159,7 +175,8 @@ export function createShopUnifiedHandler(
       maxPriceCredits,
       search,
       sortBy,
-      source
+      source,
+      listingType
     }
 
     return asJSON(async () => {

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -167,6 +167,14 @@ function appendUnifiedFilters(query: SQLStatement, filters: UnifiedCatalogFilter
   if (filters.search) {
     query.append(SQL` AND COALESCE(nft.name, w_p.name, e_p.name) ILIKE ${'%' + escapeLike(filters.search) + '%'}`)
   }
+  // Primary is a `public_item_order` (minting from a collection); anything else is a resale. Same
+  // expression the row mapper uses for `listingType`, applied here so the filter and the reported value
+  // can never disagree.
+  if (filters.listingType === 'primary') {
+    query.append(SQL` AND mv.type = 'public_item_order'`)
+  } else if (filters.listingType === 'secondary') {
+    query.append(SQL` AND mv.type <> 'public_item_order'`)
+  }
 }
 
 // One branch of the unified UNION. `usdWei` is the USD-wei-equivalent expression: native listings are

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -125,6 +125,14 @@ export type UnifiedListing = ShopListing & {
 // that the server has a MANA/USD rate) plus an optional source filter to restrict to one pool.
 export type UnifiedCatalogFilters = ShopCatalogFilters & {
   source?: UnifiedListingSource
+  /**
+   * Restrict the feed to primary (mint) or secondary (resale) listings. Omitted = both, which is the
+   * pre-existing behaviour.
+   *
+   * Exists so a client can hide resales WITHOUT filtering them out itself: the feed is paginated and
+   * carries a total, so dropping rows client-side returns short pages and an overstated count.
+   */
+  listingType?: ShopListingType
 }
 
 // The ITEM-unified feed row: one entry per item (not per listing). Same shape as a UnifiedListing (the

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -471,6 +471,60 @@ describe('Shop Catalog Component', () => {
       expect(sql.text).toContain('AS price_credits')
     })
 
+    // A client that wants to hide resales must be able to ask the SERVER for it. The feed is paginated
+    // and reports a total, so filtering rows out client-side yields short pages and an overstated count —
+    // the reason this filter exists rather than being left to the caller.
+    //
+    // Asserted by COUNTING the constraint, not by matching it: `mv.type = 'public_item_order'` already
+    // appears in the query's own joins, so a plain toContain would pass with no filter applied at all.
+    describe('and filtering by listing type', () => {
+      const occurrences = (text: string, needle: string) => text.split(needle).length - 1
+      const PRIMARY = "AND mv.type = 'public_item_order'"
+      const SECONDARY = "AND mv.type <> 'public_item_order'"
+
+      async function textFor(filters: Record<string, unknown>): Promise<string> {
+        query.mockClear()
+        await shopCatalog.getUnifiedListings(filters, RATE)
+        return query.mock.calls[0][0].text as string
+      }
+
+      // TWO added constraints, one per UNION branch (native + legacy). That is the point: a filter
+      // applied to only one branch would still let legacy resales through, which is exactly the leak a
+      // caller asking for `primary` would never notice.
+      it('should add a mint-only constraint to BOTH union branches when asked for primary', async () => {
+        const baseline = occurrences(await textFor({}), PRIMARY)
+
+        expect(occurrences(await textFor({ listingType: 'primary' }), PRIMARY)).toBe(baseline + 2)
+      })
+
+      it('should add the resale-only constraint to both union branches', async () => {
+        expect(occurrences(await textFor({ listingType: 'secondary' }), SECONDARY)).toBe(2)
+      })
+
+      it('should add a resale-only constraint when asked for secondary', async () => {
+        expect(await textFor({ listingType: 'secondary' })).toContain(SECONDARY)
+      })
+
+      it('should not constrain the type when omitted', async () => {
+        // Back-compat: every existing caller passes no listingType and must keep seeing both.
+        const text = await textFor({})
+
+        expect(occurrences(text, PRIMARY)).toBe(occurrences(await textFor({}), PRIMARY))
+        expect(text).not.toContain(SECONDARY)
+      })
+
+      it('should apply to the grouped item feed too, which is what the browse grid reads', async () => {
+        query.mockClear()
+        await shopCatalog.getShopItems({}, RATE)
+        const baseline = occurrences(query.mock.calls[0][0].text as string, PRIMARY)
+
+        query.mockClear()
+        await shopCatalog.getShopItems({ listingType: 'primary' }, RATE)
+
+        expect(occurrences(query.mock.calls[0][0].text as string, PRIMARY)).toBe(baseline + 2)
+      })
+    })
+
     it('should select the seller and issued id from the sent asset JSON in each branch', async () => {
       await shopCatalog.getUnifiedListings({}, RATE)
 


### PR DESCRIPTION
Groundwork for hiding secondary sales in the Shop. Server side first, so the client never has to filter a paginated feed itself.

## Why it has to be here

`GET /v3/catalog/unified` had no way to ask for primary only. I checked: `listingType` comes back **in** the response but is ignored as a **parameter** — `?listingType=primary`, `=secondary` and no filter all return the same result set in production. And `source` is no help, it is `native | legacy` (off-chain trade vs old MANA order), orthogonal to primary/secondary.

So the client's only option was filtering after the fetch. This feed is paginated and reports a `total`, so that returns short pages and an overstated count. Hence the filter.

## The change

`listingType=primary|secondary` on the unified feed. **Omitted keeps both**, so every existing caller is untouched.

It reuses the expression the row mapper already uses to report `listingType` — `mv.type = 'public_item_order'` is primary, anything else is a resale — so the filter and the value handed back cannot drift apart.

Invalid values **400** through the existing `getValue` set-validation instead of falling through unfiltered. That is the failure mode worth guarding: a typo silently serving resales to a client that asked to hide them.

## Both feeds, both branches

Applies to the per-listing feed and to the grouped item feed (`groupBy=item`) that the browse grid reads.

And because `appendUnifiedFilters` runs **once per UNION branch**, the constraint lands on the native and legacy branches alike. That is not incidental — a filter on only one branch would still let **legacy** resales through, and a caller asking for `primary` would have no way to notice. I found this while writing the tests (my first expectation assumed one constraint and got two), so the tests now assert it lands twice, with the reason.

## Tests

Five added, `809 passing` across 66 suites, `tsc --noEmit` clean.

Worth noting how they assert: by **counting** occurrences, not matching the string. `mv.type = 'public_item_order'` already appears in the query's own joins, so a plain `toContain` would have passed with no filter applied at all — my first version of the back-compat test did exactly that and failed for the right reason.

- primary adds the mint-only constraint to both branches
- secondary adds the resale-only constraint to both branches
- omitted adds neither (back-compat)
- the grouped item feed gets it too

## Next

The Shop PR consumes this: browse asks for `primary`, and the resale surfaces on the token page plus the sell action go behind a runtime flag.
