### PR TITLE
feat: surface collection store mints in the unified shop feed

### DIFF
--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -35,6 +35,18 @@ const ERC20_ASSET_TYPE = TradeAssetType.ERC20
 // because the column is `numeric` and the value exceeds every JS number.
 const NO_PRICE_SENTINEL = '115792089237316195423570985008687907853269984665640564039457584007913129639935'
 
+/**
+ * Upper bound on a row's USD-wei price, applied before `price_credits` is cast to bigint.
+ *
+ * Without it an absurd price does not merely render badly — `CEIL(usd_wei / C)::bigint` raises
+ * `bigint out of range` and the ENTIRE query aborts, so one bad item 500s the catalogue for every user. The
+ * sentinel guard above does not cover this: `sentinel - 1` clears it and still overflows.
+ *
+ * 1e30 USD wei is $1e12, or 10 trillion credits — orders of magnitude above any real item, and ~1e6 below
+ * the bigint ceiling, so the cast has room. Rows above it are dropped rather than fatal.
+ */
+const MAX_USD_WEI = '1000000000000000000000000000000'
+
 // The metadata joins, keyed off whatever relation is aliased `mv`. Split out from `metadataJoins` so the
 // CollectionStore branch can reuse them verbatim over its own base relation (see `storeBaseRelation`):
 // every shared expression — `appendUnifiedFilters`, `genderExpr` — reads these aliases, so reusing the
@@ -115,16 +127,34 @@ function storeBaseRelation(): SQLStatement {
         FROM `
     .append(s)
     .append(
-      // `search_is_collection_approved` is NOT optional: /v2/catalog applies it as a base WHERE, so omitting
-      // it here would surface collections the marketplace hides. available > 0 drops sold-out mints (the
-      // supply is finite and shrinks as other buyers mint), price > 0 drops free claims, which are not
-      // sales and would otherwise be advertised as free items.
+      // Each predicate, and why it is here rather than assumed:
+      //
+      // `search_is_collection_approved` mirrors the base WHERE /v2/catalog applies. NOTE it constrains only
+      // THIS branch — the trade branches carry no approval check, so an unapproved collection with an open
+      // trade is still reachable through the feed. Narrowing that is a change to existing behaviour and is
+      // deliberately out of scope here; this stops the store branch from ADDING to the exposure.
+      //
+      // `available > 0` drops sold-out mints: store supply is finite and shrinks as other buyers mint, so it
+      // has to be read at query time rather than trusted from an earlier snapshot.
+      //
+      // `price > 0` drops free claims, which are not sales and would be advertised as free items.
+      //
+      // `search_emote_outcome_type IS NULL` excludes SOCIAL emotes, which the marketplace deliberately hides
+      // (its clients all send includeSocialEmotes=false). The store branch is where the bulk of the minting
+      // catalogue enters, so without this the Shop would surface what the marketplace suppresses.
+      //
+      // `network <> 'ETHEREUM'` is insurance, not a live fix: every store row is Polygon today. But this row
+      // tells the client to call CollectionStore.buy, which exists only on Polygon, so an L1 row would offer
+      // a purchase that cannot settle. The trade branches need no equivalent — their network is a real
+      // property of the trade.
       SQL`.item i
         WHERE i.search_is_store_minter = true
           AND i.search_is_collection_approved = true
           AND i.available > 0
           AND i.price > 0
           AND i.price IS DISTINCT FROM ${NO_PRICE_SENTINEL}::numeric
+          AND i.search_emote_outcome_type IS NULL
+          AND i.network <> 'ETHEREUM'
       ) mv
       `
     )
@@ -707,7 +737,7 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
         CEIL(sub.usd_wei / ${USD_WEI_PER_CREDIT.toString()}::numeric)::bigint AS price_credits,
         COUNT(*) OVER() AS total
       FROM (`.append(inner).append(SQL`) sub
-      WHERE sub.usd_wei > 0`)
+      WHERE sub.usd_wei > 0 AND sub.usd_wei <= ${MAX_USD_WEI}::numeric`)
 
     // minPriceCredits is a floor on the DISPLAYED price, which is CEIL(usd_wei / USD_WEI_PER_CREDIT).
     // CEIL(x / C) >= m  <=>  x > (m - 1) * C, so the correct bound on usd_wei is (minWei - USD_WEI_PER_CREDIT).
@@ -808,7 +838,7 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
             u.*,
             COUNT(*) OVER (PARTITION BY u.contract_address, u.item_id) AS listing_count
           FROM (`.append(inner).append(SQL`) u
-          WHERE u.usd_wei > 0
+          WHERE u.usd_wei > 0 AND u.usd_wei <= ${MAX_USD_WEI}::numeric
         ) f
         ORDER BY
           f.contract_address,

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -29,12 +29,20 @@ const USD_PEGGED_ASSET_TYPE = TradeAssetType.USD_PEGGED_MANA
 // A classic MANA-priced received asset: a listing that predates the Shop and can be imported.
 const ERC20_ASSET_TYPE = TradeAssetType.ERC20
 
-// The shared FROM + metadata joins used by the shop feed + the import feed. Resolves item metadata
-// for primary (item_p -> wearable/emote) and secondary (nft + item_s) listings.
-function metadataJoins() {
+// uint256 max, which the squid writes into `item.price` to mean "no price set" rather than leaving it NULL.
+// A `price > 0` guard does NOT exclude it, so a store item carrying the sentinel would be advertised at
+// ~1.16e42 credits. ports/catalog guards the same value the same way (`getMinPriceWhere`); kept as a string
+// because the column is `numeric` and the value exceeds every JS number.
+const NO_PRICE_SENTINEL = '115792089237316195423570985008687907853269984665640564039457584007913129639935'
+
+// The metadata joins, keyed off whatever relation is aliased `mv`. Split out from `metadataJoins` so the
+// CollectionStore branch can reuse them verbatim over its own base relation (see `storeBaseRelation`):
+// every shared expression — `appendUnifiedFilters`, `genderExpr` — reads these aliases, so reusing the
+// join chain is what makes the filters provably identical across branches rather than identical by
+// inspection.
+function metadataJoinsOn() {
   const s = MARKETPLACE_SQUID_SCHEMA
-  return SQL`FROM marketplace.mv_trades mv
-      LEFT JOIN `
+  return SQL`LEFT JOIN `
     .append(s)
     .append(
       SQL`.item item_p ON mv.type = 'public_item_order'
@@ -64,6 +72,63 @@ function metadataJoins() {
     )
     .append(s)
     .append(SQL`.item item_s ON mv.type = 'public_nft_order' AND item_s.id = nft.item_id`)
+}
+
+// The shared FROM + metadata joins used by the shop feed + the import feed. Resolves item metadata
+// for primary (item_p -> wearable/emote) and secondary (nft + item_s) listings.
+function metadataJoins() {
+  return SQL`FROM marketplace.mv_trades mv
+      `.append(metadataJoinsOn())
+}
+
+/**
+ * The CollectionStore branch's base relation, shaped like `mv_trades` and aliased `mv`.
+ *
+ * A store item is NOT a trade: primary minting has no order and no signed listing. It is a property of the
+ * item — the CollectionStore is a minter for its collection, and the buyer calls `CollectionStore.buy` at
+ * `item.price`. So it cannot be recovered by filtering `mv_trades`; it needs its own source relation, which
+ * is why the Shop's feed was missing it entirely.
+ *
+ * Projected into mv_trades' column names rather than given its own branch shape, so the metadata joins, the
+ * gender expression and every browse filter apply UNCHANGED. That is the point: the alternative is a parallel
+ * set of filter expressions that has to be kept in step by hand.
+ *
+ * The predicate mirrors `getIsOnSaleWithTrades` in ports/catalog (which backs the marketplace's "only
+ * available for minting"), minus its V3-minter half — that half is the offchain primary trade the existing
+ * branch already covers, and including it here would double-count every item.
+ */
+function storeBaseRelation(): SQLStatement {
+  const s = MARKETPLACE_SQUID_SCHEMA
+  return SQL`FROM (
+        SELECT
+          i.id AS id,
+          'public_item_order'::text AS type,
+          i.collection_id AS sent_contract_address,
+          i.blockchain_id::text AS sent_item_id,
+          NULL::text AS sent_token_id,
+          NULL::text AS sent_nft_id,
+          i.price AS amount_received,
+          i.available AS available,
+          i.network AS network,
+          to_timestamp(i.created_at) AS created_at,
+          NULL::jsonb AS assets
+        FROM `
+    .append(s)
+    .append(
+      // `search_is_collection_approved` is NOT optional: /v2/catalog applies it as a base WHERE, so omitting
+      // it here would surface collections the marketplace hides. available > 0 drops sold-out mints (the
+      // supply is finite and shrinks as other buyers mint), price > 0 drops free claims, which are not
+      // sales and would otherwise be advertised as free items.
+      SQL`.item i
+        WHERE i.search_is_store_minter = true
+          AND i.search_is_collection_approved = true
+          AND i.available > 0
+          AND i.price > 0
+          AND i.price IS DISTINCT FROM ${NO_PRICE_SENTINEL}::numeric
+      ) mv
+      `
+    )
+    .append(metadataJoinsOn())
 }
 
 // Display gender as a SELECT expression, derived from the item's supported body shapes
@@ -182,23 +247,31 @@ function appendUnifiedFilters(query: SQLStatement, filters: UnifiedCatalogFilter
 // rate. Columns are identical across branches so the two can be UNIONed and sorted/paginated as one.
 function unifiedBranch(opts: {
   source: 'native' | 'legacy'
+  /** How the buyer acquires it: an offchain trade (`accept`) or a CollectionStore mint (`buy`). */
+  acquisition: 'trade' | 'store'
   assetType: number
   primaryOnly: boolean
   applyRate: boolean
   rateNumericString: string
   filters: UnifiedCatalogFilters
 }): SQLStatement {
-  const { source, assetType, primaryOnly, applyRate, rateNumericString, filters } = opts
+  const { source, acquisition, assetType, primaryOnly, applyRate, rateNumericString, filters } = opts
+  const isStore = acquisition === 'store'
   const usdWei = applyRate ? SQL`(mv.amount_received::numeric * ${rateNumericString}::numeric)` : SQL`mv.amount_received::numeric`
 
   const query = SQL`
       SELECT
         ${source} AS source,
-        mv.id AS trade_id,
-        mv.type AS trade_type,
-        mv.sent_contract_address AS contract_address,
-        mv.sent_item_id AS item_id,
-        mv.sent_token_id AS token_id,
+        ${acquisition} AS acquisition,
+        -- ::text because the branches are UNIONed and their ids have different column types: mv_trades.id is
+        -- uuid, while the store relation carries item.id (varchar). Postgres refuses to match uuid with
+        -- varchar across a UNION. Casting both to text is invisible downstream — the row type was already
+        -- string — and keeps the ORDER BY tiebreaker deterministic.
+        mv.id::text AS trade_id,
+        mv.type::text AS trade_type,
+        mv.sent_contract_address::text AS contract_address,
+        mv.sent_item_id::text AS item_id,
+        mv.sent_token_id::text AS token_id,
         COALESCE(nft.name, w_p.name, e_p.name) AS name,
         COALESCE(nft.image, item_p.image, item_s.image) AS image,
         COALESCE(item_p.rarity, item_s.rarity, nft.search_wearable_rarity) AS rarity,
@@ -215,7 +288,7 @@ function unifiedBranch(opts: {
     .append(
       SQL` AS usd_wei,
         mv.available::text AS available,
-        mv.network AS network,
+        mv.network::text AS network,
         EXTRACT(EPOCH FROM mv.created_at)::bigint * 1000 AS created_at,
         `
     )
@@ -225,7 +298,23 @@ function unifiedBranch(opts: {
     .append(SQL`, `)
     .append(genderExpr())
     .append(SQL` `)
-    .append(metadataJoins()).append(SQL`
+    // The store branch brings its own base relation; both then share the identical join chain and filters.
+    .append(isStore ? storeBaseRelation() : metadataJoins())
+
+  if (isStore) {
+    // The store relation has already filtered itself (minter / approved / available / price) and has no
+    // `status` column, no per-trade asset rows and nothing to restrict to primary — it is primary by
+    // construction. So none of the trade-shaped predicates below apply.
+    //
+    // `WHERE TRUE` is load-bearing: appendUnifiedFilters emits ` AND <clause>` per filter, so it needs a
+    // WHERE to append to. Without it a filtered request is a syntax error while an unfiltered one parses,
+    // which is the worst failure shape — it works until someone picks a rarity.
+    query.append(SQL` WHERE TRUE`)
+    appendUnifiedFilters(query, filters)
+    return query
+  }
+
+  query.append(SQL`
       WHERE mv.status = 'open'
         AND (mv.available IS NULL OR mv.available > 0)`)
 
@@ -253,6 +342,7 @@ function buildUnifiedInner(filters: UnifiedCatalogFilters, rateNumericString: st
     parts.push(
       unifiedBranch({
         source: 'native',
+        acquisition: 'trade',
         assetType: USD_PEGGED_ASSET_TYPE,
         primaryOnly: false,
         applyRate: false,
@@ -265,6 +355,23 @@ function buildUnifiedInner(filters: UnifiedCatalogFilters, rateNumericString: st
     parts.push(
       unifiedBranch({
         source: 'legacy',
+        acquisition: 'trade',
+        assetType: ERC20_ASSET_TYPE,
+        primaryOnly: true,
+        applyRate: true,
+        rateNumericString,
+        filters
+      })
+    )
+    // CollectionStore mints. `source: 'legacy'` because they are MANA-priced and must inherit the legacy
+    // price treatment exactly — server-converted at the live rate, re-priced client-side at checkout, and
+    // hidden when no rate is available. What differs is only HOW you buy it, which is `acquisition`. Folding
+    // these two orthogonal facts into one `source` enum is what would force every existing
+    // `source === 'legacy'` branch to be re-audited.
+    parts.push(
+      unifiedBranch({
+        source: 'legacy',
+        acquisition: 'store',
         assetType: ERC20_ASSET_TYPE,
         primaryOnly: true,
         applyRate: true,
@@ -639,7 +746,9 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
       const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
       return {
         source: r.source,
-        tradeId: r.trade_id,
+        acquisition: r.acquisition,
+        // A store row has no trade; the SQL keeps the item id in trade_id only as a sort tiebreaker.
+        tradeId: r.acquisition === 'store' ? null : r.trade_id,
         listingType: r.trade_type === 'public_item_order' ? 'primary' : 'secondary',
         contractAddress: r.contract_address,
         itemId: r.item_id,
@@ -707,6 +816,12 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
           (CASE WHEN f.trade_type = 'public_item_order' THEN 0 ELSE 1 END),
           (CASE WHEN f.source = 'native' THEN 0 ELSE 1 END),
           f.usd_wei ASC,
+          -- An item can be BOTH minting through the store and listed as an offchain primary trade, so the
+          -- two branches can produce rows for the same item at the same price. Break that tie towards the
+          -- trade: its price is signed into the order, whereas CollectionStore.buy re-validates the prices
+          -- argument against the item's live on-chain price and reverts if it moved. Same price, strictly
+          -- safer purchase. Below usd_wei so a genuinely cheaper store mint still wins on price.
+          (CASE WHEN f.acquisition = 'trade' THEN 0 ELSE 1 END),
           f.trade_id
       ) d
       WHERE d.usd_wei > 0`)
@@ -746,7 +861,9 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
       const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
       return {
         source: r.source,
-        tradeId: r.trade_id,
+        acquisition: r.acquisition,
+        // A store row has no trade; the SQL keeps the item id in trade_id only as a sort tiebreaker.
+        tradeId: r.acquisition === 'store' ? null : r.trade_id,
         listingType: r.trade_type === 'public_item_order' ? 'primary' : 'secondary',
         contractAddress: r.contract_address,
         itemId: r.item_id,

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -123,6 +123,9 @@ function storeBaseRelation(): SQLStatement {
           i.available AS available,
           i.network AS network,
           to_timestamp(i.created_at) AS created_at,
+          -- No seller and no issued id for a mint. NULL::jsonb rather than an empty object because the shared
+          -- SELECT reads mv.assets->'sent'->>'owner' and ->>'issued_id': Postgres propagates NULL through both
+          -- JSON operators, so those columns come back null with no branch in the SELECT list.
           NULL::jsonb AS assets
         FROM `
     .append(s)
@@ -416,6 +419,46 @@ function buildUnifiedInner(filters: UnifiedCatalogFilters, rateNumericString: st
     inner.append(SQL` UNION ALL `).append(parts[i])
   }
   return inner
+}
+
+/**
+ * Row -> model for both unified feeds. They differ only in `listingCount`, which the item feed spreads on top.
+ *
+ * Shared because the two copies had already drifted apart in their comments, and the next field added to one
+ * would silently be missing from the other — the per-listing feed backs the PDP resale view while the item
+ * feed backs the browse grid, so a divergence shows up as the same item described two different ways.
+ */
+function mapUnifiedRow(r: UnifiedListingRow, polygonChainId: number, ethereumChainId: number): UnifiedListing {
+  const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
+  return {
+    source: r.source,
+    acquisition: r.acquisition,
+    // A store row has no trade; the SQL keeps the item id in trade_id only as a DISTINCT ON tiebreaker, and
+    // dropping it here is what stops a nonexistent trade reference reaching POST /credits/authorize.
+    tradeId: r.acquisition === 'store' ? null : r.trade_id,
+    listingType: r.trade_type === 'public_item_order' ? 'primary' : 'secondary',
+    contractAddress: r.contract_address,
+    itemId: r.item_id,
+    tokenId: r.token_id,
+    name: r.name ?? '',
+    thumbnail: r.image ?? '',
+    rarity: (r.rarity ?? 'common').toLowerCase(),
+    category: topLevelCategory(r.item_type),
+    wearableCategory: r.wearable_category,
+    gender: r.gender ?? null,
+    creator: r.creator ?? '',
+    // Seller + issued id come from `mv.assets`, which the store relation supplies as NULL::jsonb — Postgres
+    // propagates NULL through the -> and ->> operators, so both land as null without a special case. That is
+    // the right answer for a mint: nobody is reselling it and no token has been issued yet.
+    seller: r.seller ?? null,
+    issuedId: r.issued_id ?? null,
+    priceCredits: Number(r.price_credits),
+    manaWei: r.mana_wei ?? null,
+    available: r.available ? Number(r.available) : 1,
+    network: isPolygon ? Network.MATIC : Network.ETHEREUM,
+    chainId: isPolygon ? polygonChainId : ethereumChainId,
+    createdAt: Number(r.created_at)
+  }
 }
 
 export function createShopCatalogComponent(components: Pick<AppComponents, 'dappsDatabase' | 'logs'>): IShopCatalogComponent {
@@ -772,34 +815,7 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
     const ethereumChainId = getEthereumChainId()
     const total = result.rows[0] ? Number(result.rows[0].total) : 0
 
-    const data: UnifiedListing[] = result.rows.map(r => {
-      const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
-      return {
-        source: r.source,
-        acquisition: r.acquisition,
-        // A store row has no trade; the SQL keeps the item id in trade_id only as a sort tiebreaker.
-        tradeId: r.acquisition === 'store' ? null : r.trade_id,
-        listingType: r.trade_type === 'public_item_order' ? 'primary' : 'secondary',
-        contractAddress: r.contract_address,
-        itemId: r.item_id,
-        tokenId: r.token_id,
-        name: r.name ?? '',
-        thumbnail: r.image ?? '',
-        rarity: (r.rarity ?? 'common').toLowerCase(),
-        category: topLevelCategory(r.item_type),
-        wearableCategory: r.wearable_category,
-        gender: r.gender ?? null,
-        creator: r.creator ?? '',
-        seller: r.seller ?? null,
-        issuedId: r.issued_id ?? null,
-        priceCredits: Number(r.price_credits),
-        manaWei: r.mana_wei ?? null,
-        available: r.available ? Number(r.available) : 1,
-        network: isPolygon ? Network.MATIC : Network.ETHEREUM,
-        chainId: isPolygon ? polygonChainId : ethereumChainId,
-        createdAt: Number(r.created_at)
-      }
-    })
+    const data: UnifiedListing[] = result.rows.map(r => mapUnifiedRow(r, polygonChainId, ethereumChainId))
 
     return { data, total }
   }
@@ -887,37 +903,13 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
     const ethereumChainId = getEthereumChainId()
     const total = result.rows[0] ? Number(result.rows[0].total) : 0
 
-    const data: UnifiedItem[] = result.rows.map(r => {
-      const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
-      return {
-        source: r.source,
-        acquisition: r.acquisition,
-        // A store row has no trade; the SQL keeps the item id in trade_id only as a sort tiebreaker.
-        tradeId: r.acquisition === 'store' ? null : r.trade_id,
-        listingType: r.trade_type === 'public_item_order' ? 'primary' : 'secondary',
-        contractAddress: r.contract_address,
-        itemId: r.item_id,
-        tokenId: r.token_id,
-        name: r.name ?? '',
-        thumbnail: r.image ?? '',
-        rarity: (r.rarity ?? 'common').toLowerCase(),
-        category: topLevelCategory(r.item_type),
-        wearableCategory: r.wearable_category,
-        gender: r.gender ?? null,
-        creator: r.creator ?? '',
-        // Representative listing's seller + issued id (buildUnifiedInner carries both): populated when
-        // the headline listing is a secondary (resale), null when it's a primary (mint).
-        seller: r.seller ?? null,
-        issuedId: r.issued_id ?? null,
-        priceCredits: Number(r.price_credits),
-        manaWei: r.mana_wei ?? null,
-        listingCount: Number(r.listing_count),
-        available: r.available ? Number(r.available) : 1,
-        network: isPolygon ? Network.MATIC : Network.ETHEREUM,
-        chainId: isPolygon ? polygonChainId : ethereumChainId,
-        createdAt: Number(r.created_at)
-      }
-    })
+    const data: UnifiedItem[] = result.rows.map(r => ({
+      ...mapUnifiedRow(r, polygonChainId, ethereumChainId),
+      // The only field the grouped feed adds: how many rows the union produced for this item. NOTE it counts
+      // store mints alongside trades, so it is "credit-buyable offers" rather than strictly "listings" — a
+      // resale-only drill-down can legitimately come back empty for an item badged with a count.
+      listingCount: Number(r.listing_count)
+    }))
 
     return { data, total }
   }

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -109,13 +109,43 @@ export type LegacyCatalogFilters = {
 
 // Which liquidity pool a unified item comes from: 'native' = credit-buyable (USD-pegged) Shop listing,
 // 'legacy' = classic MANA-priced primary converted to credits server-side via the live MANA/USD rate.
+//
+// This answers "how is it PRICED", nothing else. CollectionStore mints are 'legacy' — MANA-priced, live-rate
+// converted — even though they are acquired completely differently; see UnifiedAcquisition.
 export type UnifiedListingSource = 'native' | 'legacy'
+
+/**
+ * How the buyer acquires the item — a SEPARATE question from how it is priced.
+ *
+ * - 'trade': an offchain-marketplace signed order, bought with `accept([trade])`.
+ * - 'store': a CollectionStore mint, bought with `CollectionStore.buy([{ collection, ids, prices,
+ *   beneficiaries }])`. Not a listing at all: no order, no signature, and the supply is finite.
+ *
+ * These two facts used to coincide — everything MANA-priced was a legacy trade — so one enum covered both.
+ * CollectionStore mints break the coincidence (MANA-priced AND not a trade), and collapsing them back into
+ * `source` would silently change the meaning of every existing `source === 'legacy'` check, several of which
+ * decide whether an item is priced from the live rate or rendered unbuyable.
+ *
+ * It also drives the buy path and the failure modes the client has to surface: a store buy re-validates the
+ * price on-chain (so it can revert on a price move) and can sell out between browse and checkout.
+ */
+export type UnifiedAcquisition = 'trade' | 'store'
 
 // A unified feed item: the same shape as a ShopListing (so the frontend consumes both uniformly) plus
 // the source discriminator. Legacy items always carry a server-computed priceCredits, converted from
 // their raw MANA price with the live rate and rounded UP to whole credits (same "Model B" as native).
-export type UnifiedListing = ShopListing & {
+export type UnifiedListing = Omit<ShopListing, 'tradeId'> & {
+  /**
+   * `null` for a CollectionStore mint, which has no trade — there is no order and nothing signed.
+   *
+   * Deliberately nullable rather than a synthetic id: this value is threaded into
+   * `POST /credits/authorize` and persisted on the purchase intent, so a fabricated id would put a
+   * reference to a nonexistent trade into the money ledger. Nullable makes the compiler point at every
+   * caller that has to branch, instead of leaving it to be spotted in review.
+   */
+  tradeId: string | null
   source: UnifiedListingSource
+  acquisition: UnifiedAcquisition
   // Raw MANA price (wei), present only for legacy items so the client can size the purchase at the live
   // rate at checkout. `null` for native (USD-pegged) items.
   manaWei: string | null
@@ -201,7 +231,10 @@ export type ShopListingRow = {
 // computed in SQL (CEIL of the USD-wei-equivalent) so the merged feed is sorted/paginated as one set.
 export type UnifiedListingRow = {
   source: UnifiedListingSource
-  trade_id: string
+  acquisition: UnifiedAcquisition
+  // NULL on a store row (no trade). The SQL still carries the item id in this column for the DISTINCT ON
+  // tiebreaker; the mapper is what drops it, so nothing downstream can mistake it for a trade.
+  trade_id: string | null
   trade_type: string
   contract_address: string
   item_id: string | null

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -489,17 +489,34 @@ describe('Shop Catalog Component', () => {
         return query.mock.calls[0][0].text as string
       }
 
-      // TWO added constraints, one per UNION branch (native + legacy). That is the point: a filter
-      // applied to only one branch would still let legacy resales through, which is exactly the leak a
-      // caller asking for `primary` would never notice.
-      it('should add a mint-only constraint to BOTH union branches when asked for primary', async () => {
+      /**
+       * One added constraint per UNION branch. Derived from the branch count rather than hardcoded: the
+       * invariant is "the filter reaches EVERY branch", and a literal silently stops testing that the
+       * moment a branch is added — which is what happened when the CollectionStore branch turned 2 into 3.
+       *
+       * The store branch gets the predicate too, and that is correct even though its `type` is a constant:
+       * for `primary` it is a tautology, and for `secondary` a contradiction that yields no store rows.
+       * A mint has no resale form, so "no store rows" is the right answer to a resale-only request.
+       */
+      const UNION_BRANCHES = 3
+
+      it('should add a mint-only constraint to every union branch when asked for primary', async () => {
         const baseline = occurrences(await textFor({}), PRIMARY)
 
-        expect(occurrences(await textFor({ listingType: 'primary' }), PRIMARY)).toBe(baseline + 2)
+        expect(occurrences(await textFor({ listingType: 'primary' }), PRIMARY)).toBe(baseline + UNION_BRANCHES)
       })
 
-      it('should add the resale-only constraint to both union branches', async () => {
-        expect(occurrences(await textFor({ listingType: 'secondary' }), SECONDARY)).toBe(2)
+      it('should add the resale-only constraint to every union branch', async () => {
+        expect(occurrences(await textFor({ listingType: 'secondary' }), SECONDARY)).toBe(UNION_BRANCHES)
+      })
+
+      it('should return no store rows for a resale-only request, since a mint has no resale form', async () => {
+        // The store branch's contradiction (`type` is the constant 'public_item_order' <> itself) is what
+        // makes this true, so a caller asking for resales never sees a mint offered as one.
+        const text = await textFor({ listingType: 'secondary' })
+
+        expect(text).toContain("'public_item_order'::text AS type")
+        expect(occurrences(text, SECONDARY)).toBe(UNION_BRANCHES)
       })
 
       it('should add a resale-only constraint when asked for secondary', async () => {
@@ -522,7 +539,7 @@ describe('Shop Catalog Component', () => {
         query.mockClear()
         await shopCatalog.getShopItems({ listingType: 'primary' }, RATE)
 
-        expect(occurrences(query.mock.calls[0][0].text as string, PRIMARY)).toBe(baseline + 2)
+        expect(occurrences(query.mock.calls[0][0].text as string, PRIMARY)).toBe(baseline + UNION_BRANCHES)
       })
     })
 
@@ -801,6 +818,33 @@ describe('Shop Catalog Component', () => {
       // `price > 0` does NOT exclude it, and an item carrying it would be advertised at ~1.16e42 credits.
       expect(text).toContain('i.price IS DISTINCT FROM')
       expect(values).toContain('115792089237316195423570985008687907853269984665640564039457584007913129639935')
+    })
+
+    it('should exclude social emotes, which the marketplace itself hides', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      // Every marketplace client sends includeSocialEmotes=false. The store branch is where the bulk of the
+      // minting catalogue enters, so without this the Shop surfaces what the marketplace suppresses.
+      expect(query.mock.calls[0][0].text).toContain('i.search_emote_outcome_type IS NULL')
+    })
+
+    it('should exclude L1 items, which cannot be minted through the Polygon-only store', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      // The row tells the client to call CollectionStore.buy; an ETHEREUM row would offer a purchase that
+      // cannot settle.
+      expect(query.mock.calls[0][0].text).toContain("i.network <> 'ETHEREUM'")
+    })
+
+    it('should bound the price before the bigint cast so one bad row cannot 500 the whole feed', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const { text, values } = query.mock.calls[0][0]
+      // CEIL(usd_wei / C)::bigint raises `bigint out of range` on an absurd price, aborting the ENTIRE
+      // query rather than dropping the row. The sentinel guard does not cover it — sentinel-1 clears that
+      // check and still overflows.
+      expect(text).toContain('u.usd_wei <=')
+      expect(values).toContain('1000000000000000000000000000000')
     })
 
     it('should cast the unioned id and enum columns to text so the branches can be merged', async () => {

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -53,6 +53,7 @@ function legacyRow(overrides: Record<string, unknown> = {}) {
 function unifiedRow(overrides: Record<string, unknown> = {}) {
   return {
     source: 'native',
+    acquisition: 'trade',
     trade_id: 'trade-1',
     trade_type: 'public_item_order',
     contract_address: '0xcollection',
@@ -594,9 +595,14 @@ describe('Shop Catalog Component', () => {
       await shopCatalog.getUnifiedListings({ source: 'legacy' }, RATE)
 
       const sql = query.mock.calls[0][0]
-      expect(sql.text).not.toContain('UNION ALL')
       expect(sql.values).toContain(1)
       expect(sql.values).not.toContain(2)
+      // `legacy` is TWO branches, not one: the MANA-priced offchain trade and the CollectionStore mint. Both
+      // are legacy-priced (live rate) and differ only in how they are bought, so a UNION ALL is expected here
+      // even though a single source was requested.
+      expect(sql.text).toContain('UNION ALL')
+      expect(sql.values).toContain('store')
+      expect(sql.values).toContain('trade')
     })
 
     it('should restrict to the native source only when source=native (no legacy branch)', async () => {
@@ -697,6 +703,160 @@ describe('Shop Catalog Component', () => {
     })
   })
 
+  describe('when mapping a CollectionStore row to a model', () => {
+    it('should carry acquisition through and drop the trade id, which does not exist for a mint', async () => {
+      query.mockResolvedValueOnce({
+        rows: [itemRow({ source: 'legacy', acquisition: 'store', trade_id: '0xcollection-3', mana_wei: '1000' })]
+      })
+
+      const { data } = await shopCatalog.getShopItems({}, 0.5)
+
+      expect(data[0].acquisition).toBe('store')
+      // The SQL keeps item.id in trade_id purely as a DISTINCT ON tiebreaker. It must NOT reach the model:
+      // tradeId is threaded into POST /credits/authorize and persisted on the purchase intent, so a
+      // fabricated id would put a reference to a nonexistent trade into the money ledger.
+      expect(data[0].tradeId).toBeNull()
+      // Still legacy-priced, so it keeps the raw MANA price for the client to re-quote at the live rate.
+      expect(data[0].source).toBe('legacy')
+      expect(data[0].manaWei).toBe('1000')
+      expect(data[0].listingType).toBe('primary')
+    })
+
+    it('should keep the trade id on a trade row', async () => {
+      query.mockResolvedValueOnce({ rows: [itemRow({ acquisition: 'trade', trade_id: 'trade-7' })] })
+
+      const { data } = await shopCatalog.getShopItems({}, 0.5)
+
+      expect(data[0].acquisition).toBe('trade')
+      expect(data[0].tradeId).toBe('trade-7')
+    })
+
+    it('should do the same on the per-listing feed', async () => {
+      query.mockResolvedValueOnce({
+        rows: [unifiedRow({ source: 'legacy', acquisition: 'store', trade_id: '0xcollection-3' })]
+      })
+
+      const { data } = await shopCatalog.getUnifiedListings({}, 0.5)
+
+      expect(data[0].acquisition).toBe('store')
+      expect(data[0].tradeId).toBeNull()
+    })
+  })
+
+  /**
+   * The CollectionStore branch. These items are the majority of the sellable catalogue and they are NOT
+   * trades: primary minting has no order and nothing signed, so it cannot be recovered by filtering
+   * mv_trades. The branch therefore brings its own base relation, and what these tests pin is that it stays
+   * shaped like the others (so the shared filters keep applying) while carrying the facts that differ.
+   */
+  describe('when building the CollectionStore branch of the unified feed', () => {
+    const RATE = 0.5
+
+    beforeEach(() => {
+      query.mockResolvedValue({ rows: [] })
+    })
+
+    it('should read from the item table rather than from trades', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      expect(text).toContain('search_is_store_minter = true')
+      // Shaped like mv_trades and aliased `mv`, which is what lets the metadata joins and every browse
+      // filter apply to it unchanged instead of needing a parallel set of expressions.
+      expect(text).toContain(') mv')
+      expect(text).toContain("'public_item_order'::text AS type")
+    })
+
+    it('should tag store rows with acquisition=store while keeping them legacy-priced', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const { values } = query.mock.calls[0][0]
+      // Three branches: native trade, legacy trade, legacy store.
+      expect(values).toContain('store')
+      expect(values.filter((v: unknown) => v === 'legacy')).toHaveLength(2)
+      expect(values).toContain('native')
+    })
+
+    it('should exclude collections the marketplace itself hides', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      // /v2/catalog applies this as a base WHERE; omitting it would surface unapproved collections that the
+      // marketplace does not show.
+      expect(query.mock.calls[0][0].text).toContain('search_is_collection_approved = true')
+    })
+
+    it('should exclude sold-out mints and free claims', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      // Store supply is finite and shrinks as others mint, so available must be checked at read time.
+      expect(text).toContain('i.available > 0')
+      expect(text).toContain('i.price > 0')
+    })
+
+    it('should exclude the uint256-max sentinel the squid uses for "no price"', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const { text, values } = query.mock.calls[0][0]
+      // `price > 0` does NOT exclude it, and an item carrying it would be advertised at ~1.16e42 credits.
+      expect(text).toContain('i.price IS DISTINCT FROM')
+      expect(values).toContain('115792089237316195423570985008687907853269984665640564039457584007913129639935')
+    })
+
+    it('should cast the unioned id and enum columns to text so the branches can be merged', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      // mv_trades.id is uuid and item.id is varchar; mv_trades.type is an enum. Postgres refuses to match
+      // those across a UNION, and the failure is a runtime error no type checker would catch.
+      expect(text).toContain('mv.id::text AS trade_id')
+      expect(text).toContain('mv.type::text AS trade_type')
+    })
+
+    it('should give the store branch a WHERE for the shared filters to append to', async () => {
+      await shopCatalog.getShopItems({ rarities: ['rare'] }, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      // appendUnifiedFilters emits ` AND <clause>`, so without a WHERE a FILTERED request is a syntax error
+      // while an unfiltered one parses — it would work until someone picked a rarity.
+      expect(text).toContain('WHERE TRUE')
+      expect(text.match(/lower\(COALESCE\(item_p\.rarity/g)).toHaveLength(3)
+    })
+
+    it('should apply the shared browse filters to the store branch as well', async () => {
+      await shopCatalog.getShopItems({ category: 'emote', creator: '0xAbC', search: 'hat' }, RATE)
+
+      const { text, values } = query.mock.calls[0][0]
+      // One occurrence per branch — the point of reusing the join chain is that this holds by construction.
+      expect(text.match(/ILIKE 'emote%'/g)).toHaveLength(3)
+      expect(values.filter((v: unknown) => v === '0xabc')).toHaveLength(3)
+      expect(values.filter((v: unknown) => v === '%hat%')).toHaveLength(3)
+    })
+
+    it('should not apply trade-only predicates to the store branch', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      // The store relation has no status column and no per-trade asset rows. Two branches are trades, so
+      // these appear twice, not three times.
+      expect(text.match(/mv\.status = 'open'/g)).toHaveLength(2)
+      expect(text.match(/FROM marketplace\.trade_assets/g)).toHaveLength(2)
+    })
+
+    it('should break a price tie towards the trade, whose price is signed', async () => {
+      await shopCatalog.getShopItems({}, RATE)
+
+      const text = query.mock.calls[0][0].text as string
+      // An item can be both minting and listed as a primary trade at the same price. CollectionStore.buy
+      // re-validates the price on-chain and reverts if it moved; a trade cannot. Ordered BELOW usd_wei so a
+      // genuinely cheaper mint still wins on price.
+      const priceIdx = text.indexOf('f.usd_wei ASC')
+      const tieIdx = text.indexOf("f.acquisition = 'trade'")
+      expect(priceIdx).toBeGreaterThan(-1)
+      expect(tieIdx).toBeGreaterThan(priceIdx)
+    })
+  })
+
   // An item-unified row: a UnifiedListingRow (the surviving representative listing) plus listing_count.
   function itemRow(overrides: Record<string, unknown> = {}) {
     return unifiedRow({ listing_count: '1', ...overrides })
@@ -760,19 +920,24 @@ describe('Shop Catalog Component', () => {
       expect(sql.values).toContain(1)
     })
 
-    it('should restrict to a single source (no UNION ALL) when source is set', async () => {
+    it('should restrict to the requested source, native being the only single-branch one', async () => {
+      // native is one branch: USD-pegged trades. No legacy asset type, no store.
       await shopCatalog.getShopItems({ source: 'native' }, RATE)
       let sql = query.mock.calls[0][0]
       expect(sql.text).not.toContain('UNION ALL')
       expect(sql.values).toContain(2)
       expect(sql.values).not.toContain(1)
+      expect(sql.values).not.toContain('store')
 
       query.mockClear()
+      // legacy is TWO branches — the MANA-priced trade and the CollectionStore mint — so it unions even
+      // though one source was asked for. Still no native asset type.
       await shopCatalog.getShopItems({ source: 'legacy' }, RATE)
       sql = query.mock.calls[0][0]
-      expect(sql.text).not.toContain('UNION ALL')
+      expect(sql.text).toContain('UNION ALL')
       expect(sql.values).toContain(1)
       expect(sql.values).not.toContain(2)
+      expect(sql.values).toContain('store')
     })
 
     it('should apply the MANA/USD rate to legacy amounts only', async () => {


### PR DESCRIPTION
## Why

The Shop's browse feed shows **211 items**. The on-sale universe on prod is **7,262**. Measured live:

| Query | Total |
| --- | --- |
| `/v2/catalog?isOnSale=true` — everything sellable | **7,262** |
| `/v2/catalog?isOnSale=true&onlyMinting=true` — primary | **4,460** |
| `/v3/catalog/unified?groupBy=item` — what the Shop shows | **211** |

Not a filter or pagination bug. `getUnifiedListings` / `getShopItems` build their whole universe from
`marketplace.mv_trades`, and **a CollectionStore mint is not a trade**: primary minting has no order and
nothing signed. It is a property of the item — the store is a minter for the collection, `available > 0`, and
the buyer calls `CollectionStore.buy` at `item.price`. There is nothing to join to, so no filter change can
recover these rows.

The 211 the Shop does show are exactly `onlyMinting`'s *other* half — items whose creators listed them as
offchain `public_item_order` trades. 4,460 − 211 = 4,249 store-only items, none of them reachable today.

## What changes

A third branch in the unified UNION, reading `marketplace.item`. Coverage goes from ~3% to ~64% of the on-sale
catalogue.

The branch is projected into `mv_trades`' column names and aliased `mv`, so the metadata joins, the gender
expression and **every browse filter apply unchanged**. That is the design point: the alternative is a parallel
set of filter expressions that has to be kept in step by hand. The tests assert one occurrence of each filter
per branch rather than trusting inspection.

Its predicate mirrors `getIsOnSaleWithTrades` in `ports/catalog` (which backs the marketplace's "only
available for minting") minus the V3-minter half — that half is the offchain trade the existing branch already
covers, and including it would double-count every item.

### `source` vs the new `acquisition`

These were one field because two facts happened to coincide: everything MANA-priced was a legacy trade. A store
mint breaks that — MANA-priced **and** not a trade. So they are split:

- **`source`** answers *how is it priced*. Store mints are `legacy`, and that matters: they inherit the legacy
  treatment exactly — server-converted at the live rate, re-quoted client-side at checkout, hidden when no rate
  is available.
- **`acquisition`** (new: `'trade' | 'store'`) answers *how do you buy it*. `accept([trade])` vs
  `CollectionStore.buy([...])`.

Folding store rows into `source` instead would silently change the meaning of every existing
`source === 'legacy'` check, several of which decide whether an item is priced from the live rate or rendered
unbuyable at all.

### `tradeId` is now nullable on the unified types

A mint has no trade, so `UnifiedListing.tradeId` is `string | null` and store rows carry `null`. Deliberately
nullable rather than a synthetic id: this value is threaded into `POST /credits/authorize` and persisted on the
purchase intent, so a fabricated id would put a reference to a nonexistent trade into the money ledger. The SQL
still keeps `item.id` in the `trade_id` column as a DISTINCT ON tiebreaker; the mapper is what drops it.

### Things found while building this, each with a test

- **The uint256-max sentinel.** The squid writes `2^256-1` into `item.price` to mean "no price set". `price > 0`
  does **not** exclude it, so a store item carrying it would have been advertised at ~1.16e42 credits. One row
  in dev has it today. `ports/catalog` guards the same value the same way.
- **UNION type mismatches.** `mv_trades.id` is `uuid` while `item.id` is `varchar`, and `mv_trades.type` is an
  enum. Postgres refuses to match either across a UNION — a runtime error no type checker catches. Both sides
  are cast to `text`, which is invisible downstream since the row type was already `string`.
- **The store branch needs its own `WHERE TRUE`.** `appendUnifiedFilters` emits ` AND <clause>`, so without it
  a *filtered* request is a syntax error while an unfiltered one parses — it would have worked until someone
  picked a rarity.
- **Dedup tie-break.** An item can be both minting and listed as a primary trade at the same price. The tie now
  breaks towards the trade: its price is signed into the order, whereas `CollectionStore.buy` re-validates the
  price on-chain and reverts if it moved. Ordered *below* `usd_wei`, so a genuinely cheaper mint still wins.
- **`available > 0` is read at query time**, since store supply is finite and shrinks as other buyers mint.

### Two existing tests changed meaning, not strictness

`source=legacy` now produces **two** branches (MANA trade + store mint), so "no UNION ALL when a source is set"
is no longer true for it — it still is for `native`. Both tests now assert the new semantics explicitly.

## Verified against the real database

The generated SQL was executed against a live dapps database, not just asserted as a string — which is how the
two UNION type errors and the price sentinel were found. Result by branch:

| acquisition | source | rows | min credits | max credits |
| --- | --- | --- | --- | --- |
| store | legacy | 42 | 1 | 150 |
| trade | legacy | 13 | 1 | — |
| trade | native | 45 | 1 | 5,500 |

42, not 43: the sentinel row is correctly excluded.

## Out of scope, noted while measuring

- **`listingType` is never read by this handler.** The Shop sends it and the server ignores it, which is why
  `listingType=primary` and `listingType=secondary` both return the same total. Not touched here.
- **Legacy ERC20 secondary stays excluded.** `secondarySalesAllowed()` is `false` on the mainnet
  CreditsManager, so listing those items would advertise purchases that revert on-chain.

## Test plan

- [x] `check:code`, `fix:prettier`, `build` clean
- [x] Full unit suite: 66 suites, 817 tests passing
- [x] 17 new tests over the branch, its guards, filter parity across branches, the tie-break ordering and the
      row mapping
- [x] Generated SQL executed against a real database; row counts per branch above
- [ ] Confirm the on-prod item total jumps once deployed