### PR TITLE
feat: related items endpoint for the shop pdp fallback rail

### DIFF
--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -5,6 +5,7 @@ import {
   ShopListingType,
   ShopSortBy,
   UnifiedListingSource,
+  RELATED_DEFAULT_LIMIT,
   SHOP_DEFAULT_PAGE_SIZE,
   SHOP_MAX_PAGE_SIZE
 } from '../../ports/shop-catalog/types'
@@ -184,6 +185,29 @@ export function createShopUnifiedHandler(
       const { data, total } =
         groupBy === 'item' ? await shopCatalog.getShopItems(filters, rate) : await shopCatalog.getUnifiedListings(filters, rate)
       return { data, total }
+    })
+  }
+}
+
+// GET /v3/catalog/related?contractAddress=0x...&itemId=3&first=10 -- items SIMILAR to one item, backing
+// the PDP's fallback rail for when the item's own collection has nothing else to show. Rows have the same
+// shape as /v3/catalog/unified?groupBy=item (item-unified, credit-priced) so the client renders them with
+// the same card. Unpaginated: returns { data } only. An unknown/missing item yields an empty rail rather
+// than an error -- a recommendation nobody can make is not a client mistake.
+export function createShopRelatedHandler(
+  components: Pick<AppComponents, 'shopCatalog' | 'manaUsdRate'>
+): IHttpServerComponent.IRequestHandler<Context<'/v3/catalog/related'>> {
+  const { shopCatalog, manaUsdRate } = components
+
+  return async context => {
+    const params = new Params(context.url.searchParams)
+    const contractAddress = params.getAddress('contractAddress')
+    const itemId = params.getString('itemId')
+    const first = params.getNumber('first', RELATED_DEFAULT_LIMIT) ?? RELATED_DEFAULT_LIMIT
+
+    return asJSON(async () => {
+      if (!contractAddress || !itemId) return { data: [] }
+      return shopCatalog.getRelatedItems({ contractAddress, itemId, first }, manaUsdRate.getRate())
     })
   }
 }

--- a/src/controllers/handlers/shop-catalog-handler.ts
+++ b/src/controllers/handlers/shop-catalog-handler.ts
@@ -206,7 +206,17 @@ export function createShopRelatedHandler(
     const first = params.getNumber('first', RELATED_DEFAULT_LIMIT) ?? RELATED_DEFAULT_LIMIT
 
     return asJSON(async () => {
-      if (!contractAddress || !itemId) return { data: [] }
+      // `itemId` is validated here, not just checked for presence, because the query casts it:
+      // `item.blockchain_id = ${itemId}::numeric`. A non-numeric value reaches Postgres, which raises
+      // `invalid input syntax for type numeric`, and asJSON turns that into a 500 — so `?itemId=abc`
+      // answered with a server error instead of the empty rail this endpoint promises for anything it
+      // cannot resolve. `Params.getAddress` already gives `contractAddress` that guarantee; this gives it
+      // to the other half.
+      //
+      // It is reachable from a bad URL rather than only from a hand-written request: the Shop reads the id
+      // straight out of `/item/:contractAddress/:itemId`, so a malformed deep link would 500 the rail.
+      // Blockchain ids are non-negative integers, so a digit check is the whole constraint.
+      if (!contractAddress || !itemId || !/^\d+$/.test(itemId)) return { data: [] }
       return shopCatalog.getRelatedItems({ contractAddress, itemId, first }, manaUsdRate.getRate())
     })
   }

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -26,6 +26,7 @@ import {
   createShopCatalogHandler,
   createShopImportableHandler,
   createShopLegacyHandler,
+  createShopRelatedHandler,
   createShopUnifiedHandler
 } from './handlers/shop-catalog-handler'
 import { getStatsHandler } from './handlers/stats-handler'
@@ -107,6 +108,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   router.get('/v3/catalog/legacy', createShopLegacyHandler(components))
   router.get('/v3/catalog/unified', createShopUnifiedHandler(components))
   router.get('/v3/catalog/items', createCatalogItemsHandler(components))
+  router.get('/v3/catalog/related', createShopRelatedHandler(components))
   router.get('/v3/catalog/importable', createShopImportableHandler(components))
 
   router.get('/v1/trades', getTradesHandler)

--- a/src/ports/shop-catalog/component.ts
+++ b/src/ports/shop-catalog/component.ts
@@ -1,5 +1,5 @@
 import SQL, { SQLStatement } from 'sql-template-strings'
-import { Network, TradeAssetType } from '@dcl/schemas'
+import { Network, Rarity, TradeAssetType } from '@dcl/schemas'
 import { MARKETPLACE_SQUID_SCHEMA } from '../../constants'
 import { getEthereumChainId, getPolygonChainId } from '../../logic/chainIds'
 import { AppComponents } from '../../types'
@@ -10,6 +10,10 @@ import {
   LegacyCatalogFilters,
   LegacyListing,
   LegacyListingRow,
+  ReferenceItem,
+  ReferenceItemRow,
+  RelatedItemRow,
+  RelatedItemsFilters,
   ShopCatalogFilters,
   ShopListing,
   ShopListingRow,
@@ -18,6 +22,8 @@ import {
   UnifiedItemRow,
   UnifiedListing,
   UnifiedListingRow,
+  RELATED_DEFAULT_LIMIT,
+  RELATED_MAX_LIMIT,
   SHOP_DEFAULT_PAGE_SIZE,
   SHOP_MAX_PAGE_SIZE,
   SHOP_MIN_PAGE_SIZE
@@ -421,6 +427,52 @@ function buildUnifiedInner(filters: UnifiedCatalogFilters, rateNumericString: st
   return inner
 }
 
+// The item-unified core: the UNION ALL of the source branches collapsed to ONE representative listing per
+// (contract, item). Layered so each concern stays a distinct, reviewable SQL level:
+//   u  -- the UNION ALL of the source branches (one row per open credit-buyable offer).
+//   f  -- drop free/broken offers (usd_wei > 0) and absurd ones (<= MAX_USD_WEI, which keeps the bigint cast
+//         below from aborting the whole query), then attach a per-item listing_count window; this is the
+//         "N listings" badge count and it is stable across every row of the same item.
+//   d  -- DISTINCT ON (contract_address, item_id) keeps exactly one representative offer per item.
+//         The ORDER BY makes the survivor: PRIMARY before secondary, then NATIVE (fixed USD) before
+//         LEGACY (rate-floating MANA), then cheapest usd_wei, then TRADE before STORE mint, then trade_id
+//         for determinism. That is precisely "primary price if present, else cheapest credit-buyable
+//         secondary", preferring a stable USD headline over a rate-floating one. price_credits is
+//         CEIL(usd_wei / C) of the survivor (same "Model B" rounding as every other feed).
+// Callers wrap this as `d` and add their own filtering/ordering/pagination on top. sent_item_id is
+// populated for secondary rows too (mv_trades), so grouping needs no extra joins.
+//
+// Shared by the browse feed and the related-items rail so the rail is drawn from exactly the same universe,
+// grouping and headline-price rules as the grid it is meant to mirror -- a divergence here would show the
+// same item at two different prices on two screens.
+function buildItemUnifiedCore(filters: UnifiedCatalogFilters, rateNumericString: string): SQLStatement {
+  const inner = buildUnifiedInner(filters, rateNumericString)
+
+  return SQL`SELECT DISTINCT ON (f.contract_address, f.item_id)
+          f.*,
+          CEIL(f.usd_wei / ${USD_WEI_PER_CREDIT.toString()}::numeric)::bigint AS price_credits
+        FROM (
+          SELECT
+            u.*,
+            COUNT(*) OVER (PARTITION BY u.contract_address, u.item_id) AS listing_count
+          FROM (`.append(inner).append(SQL`) u
+          WHERE u.usd_wei > 0 AND u.usd_wei <= ${MAX_USD_WEI}::numeric
+        ) f
+        ORDER BY
+          f.contract_address,
+          f.item_id,
+          (CASE WHEN f.trade_type = 'public_item_order' THEN 0 ELSE 1 END),
+          (CASE WHEN f.source = 'native' THEN 0 ELSE 1 END),
+          f.usd_wei ASC,
+          -- An item can be BOTH minting through the store and listed as an offchain primary trade, so the
+          -- two branches can produce rows for the same item at the same price. Break that tie towards the
+          -- trade: its price is signed into the order, whereas CollectionStore.buy re-validates the prices
+          -- argument against the item's live on-chain price and reverts if it moved. Same price, strictly
+          -- safer purchase. Below usd_wei so a genuinely cheaper store mint still wins on price.
+          (CASE WHEN f.acquisition = 'trade' THEN 0 ELSE 1 END),
+          f.trade_id`)
+}
+
 /**
  * Row -> model for both unified feeds. They differ only in `listingCount`, which the item feed spreads on top.
  *
@@ -428,7 +480,9 @@ function buildUnifiedInner(filters: UnifiedCatalogFilters, rateNumericString: st
  * would silently be missing from the other — the per-listing feed backs the PDP resale view while the item
  * feed backs the browse grid, so a divergence shows up as the same item described two different ways.
  */
-function mapUnifiedRow(r: UnifiedListingRow, polygonChainId: number, ethereumChainId: number): UnifiedListing {
+// `total` is omitted from the parameter (not read here) so the unpaginated related-items rail, whose rows
+// carry no COUNT(*) OVER(), can be mapped by this very function instead of a near-copy of it.
+function mapUnifiedRow(r: Omit<UnifiedListingRow, 'total'>, polygonChainId: number, ethereumChainId: number): UnifiedListing {
   const isPolygon = (r.network ?? Network.MATIC).toUpperCase() !== 'ETHEREUM'
   return {
     source: r.source,
@@ -459,6 +513,40 @@ function mapUnifiedRow(r: UnifiedListingRow, polygonChainId: number, ethereumCha
     chainId: isPolygon ? polygonChainId : ethereumChainId,
     createdAt: Number(r.created_at)
   }
+}
+
+// Row -> model for the item-GROUPED feeds (the browse grid and the related-items rail). Extends the shared
+// per-listing mapper with the one field grouping adds. Shared for the same reason mapUnifiedRow is: the rail
+// is meant to be indistinguishable from the grid, so the two must not map a row differently.
+function mapUnifiedItemRow(r: RelatedItemRow, polygonChainId: number, ethereumChainId: number): UnifiedItem {
+  return {
+    ...mapUnifiedRow(r, polygonChainId, ethereumChainId),
+    // The only field the grouped feed adds: how many rows the union produced for this item. NOTE it counts
+    // store mints alongside trades, so it is "credit-buyable offers" rather than strictly "listings" — a
+    // resale-only drill-down can legitimately come back empty for an item badged with a count.
+    listingCount: Number(r.listing_count)
+  }
+}
+
+// Rarity ranks, scarcest (0) first, sourced from @dcl/schemas so the scale can never drift from the enum.
+const RARITY_RANKS: Record<string, number> = Object.fromEntries(Rarity.getRarities().map((rarity, index) => [rarity, index]))
+// Sorts a row whose rarity is missing or unrecognised behind every known tier.
+const UNKNOWN_RARITY_DISTANCE = Rarity.getRarities().length
+
+// "Prioritise rarity" as a sortable distance from the anchor's tier rather than a same/different boolean.
+// Rarity is an ORDERED scale, so distance degrades gracefully: exact matches lead, and when there aren't
+// enough of them the next-closest tiers fill the rail instead of an arbitrary tail. Distances are computed
+// in JS and bound as params, so the CASE contains no arithmetic and no interpolated input. An anchor with
+// an unknown rarity yields a constant, which leaves the ordering to the tiebreakers below it.
+function rarityDistanceExpr(referenceRarity: string | null): SQLStatement {
+  const referenceRank = referenceRarity == null ? undefined : RARITY_RANKS[referenceRarity.toLowerCase()]
+  if (referenceRank === undefined) return SQL`0`
+
+  const expr = SQL`CASE lower(d.rarity)`
+  for (const [rarity, rank] of Object.entries(RARITY_RANKS)) {
+    expr.append(SQL` WHEN ${rarity} THEN ${Math.abs(rank - referenceRank)}`)
+  }
+  return expr.append(SQL` ELSE ${UNKNOWN_RARITY_DISTANCE} END`)
 }
 
 export function createShopCatalogComponent(components: Pick<AppComponents, 'dappsDatabase' | 'logs'>): IShopCatalogComponent {
@@ -821,54 +909,20 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
   }
 
   // The item-unified BROWSE feed: the same credit-buyable universe as getUnifiedListings, but collapsed
-  // to ONE row per (contract, item). Layered so each concern stays a distinct, reviewable SQL level:
-  //   u  -- the UNION ALL of the source branches (one row per open credit-buyable listing).
-  //   f  -- drop free/broken listings (usd_wei > 0) and attach a per-item listing_count window; this is
-  //         the "N listings" badge count and it is stable across every row of the same item.
-  //   d  -- DISTINCT ON (contract_address, item_id) keeps exactly one representative listing per item.
-  //         The ORDER BY makes the survivor: PRIMARY before secondary, then NATIVE (fixed USD) before
-  //         LEGACY (rate-floating MANA), then cheapest usd_wei, then trade_id for determinism. That is
-  //         precisely "primary price if present, else cheapest credit-buyable secondary", preferring a
-  //         stable USD headline over a rate-floating one. price_credits is CEIL(usd_wei / C) of the
-  //         survivor (same "Model B" rounding as every other feed).
-  // The outer query then applies the credit price-range on the HEADLINE price, the display sort, and
-  // pagination, exposing COUNT(*) OVER() as the total number of items. sent_item_id is populated for
-  // secondary rows too (mv_trades), so grouping needs no extra joins.
+  // to ONE row per (contract, item) by buildItemUnifiedCore. The outer query then applies the credit
+  // price-range on the HEADLINE price, the display sort, and pagination, exposing COUNT(*) OVER() as the
+  // total number of items.
   async function getShopItems(filters: UnifiedCatalogFilters, manaUsdRate: number): Promise<{ data: UnifiedItem[]; total: number }> {
     const first = clampCount(filters.first, SHOP_DEFAULT_PAGE_SIZE, SHOP_MIN_PAGE_SIZE, SHOP_MAX_PAGE_SIZE)
     const skip = clampCount(filters.skip, 0, 0, Number.MAX_SAFE_INTEGER)
     const rateNumericString = rateToNumericString(manaUsdRate)
-
-    const inner = buildUnifiedInner(filters, rateNumericString)
 
     const query = SQL`
       SELECT
         d.*,
         COUNT(*) OVER() AS total
       FROM (
-        SELECT DISTINCT ON (f.contract_address, f.item_id)
-          f.*,
-          CEIL(f.usd_wei / ${USD_WEI_PER_CREDIT.toString()}::numeric)::bigint AS price_credits
-        FROM (
-          SELECT
-            u.*,
-            COUNT(*) OVER (PARTITION BY u.contract_address, u.item_id) AS listing_count
-          FROM (`.append(inner).append(SQL`) u
-          WHERE u.usd_wei > 0 AND u.usd_wei <= ${MAX_USD_WEI}::numeric
-        ) f
-        ORDER BY
-          f.contract_address,
-          f.item_id,
-          (CASE WHEN f.trade_type = 'public_item_order' THEN 0 ELSE 1 END),
-          (CASE WHEN f.source = 'native' THEN 0 ELSE 1 END),
-          f.usd_wei ASC,
-          -- An item can be BOTH minting through the store and listed as an offchain primary trade, so the
-          -- two branches can produce rows for the same item at the same price. Break that tie towards the
-          -- trade: its price is signed into the order, whereas CollectionStore.buy re-validates the prices
-          -- argument against the item's live on-chain price and reverts if it moved. Same price, strictly
-          -- safer purchase. Below usd_wei so a genuinely cheaper store mint still wins on price.
-          (CASE WHEN f.acquisition = 'trade' THEN 0 ELSE 1 END),
-          f.trade_id
+        `.append(buildItemUnifiedCore(filters, rateNumericString)).append(SQL`
       ) d
       WHERE d.usd_wei > 0`)
 
@@ -903,16 +957,93 @@ export function createShopCatalogComponent(components: Pick<AppComponents, 'dapp
     const ethereumChainId = getEthereumChainId()
     const total = result.rows[0] ? Number(result.rows[0].total) : 0
 
-    const data: UnifiedItem[] = result.rows.map(r => ({
-      ...mapUnifiedRow(r, polygonChainId, ethereumChainId),
-      // The only field the grouped feed adds: how many rows the union produced for this item. NOTE it counts
-      // store mints alongside trades, so it is "credit-buyable offers" rather than strictly "listings" — a
-      // resale-only drill-down can legitimately come back empty for an item badged with a count.
-      listingCount: Number(r.listing_count)
-    }))
+    const data = result.rows.map(r => mapUnifiedItemRow(r, polygonChainId, ethereumChainId))
 
     return { data, total }
   }
 
-  return { getShopListings, getImportableListings, getLegacyListings, getUnifiedListings, getShopItems }
+  // The anchor item's similarity attributes. Read straight off the squid `item` row rather than passed in
+  // by the caller: the PDP knows the item's identity from its URL long before it has hydrated the item's
+  // rarity/category, so resolving here lets the rail be requested (and cached) on the first render.
+  // Returns null when the item is unknown, which the caller reports as "nothing similar".
+  async function getReferenceItem(contractAddress: string, itemId: string): Promise<ReferenceItem | null> {
+    const query = SQL`
+      SELECT
+        item.rarity AS rarity,
+        item.item_type AS item_type,
+        COALESCE(item.search_wearable_category, item.search_emote_category) AS wearable_category
+      FROM `
+      .append(MARKETPLACE_SQUID_SCHEMA)
+      .append(
+        SQL`.item item
+      WHERE item.collection_id = ${contractAddress.toLowerCase()}
+        AND item.blockchain_id = ${itemId}::numeric
+      LIMIT 1`
+      )
+
+    const result = await pg.query<ReferenceItemRow>(query)
+    const row = result.rows[0]
+    if (!row) return null
+
+    return {
+      category: topLevelCategory(row.item_type),
+      wearableCategory: row.wearable_category,
+      rarity: row.rarity
+    }
+  }
+
+  // Items SIMILAR to one item -- the fallback rail the PDP shows when the item's own collection has
+  // nothing else to offer.
+  //
+  // "Similar" is deliberately narrow for v1: SAME top-level category (wearable/emote) and, when the anchor
+  // has one, the SAME on-chain sub-category (hat, upper_body, dance, ...). Sub-category is the hard filter
+  // because "another wearable" is too broad to read as similar, while "another hat" does. Rarity is NOT a
+  // filter -- it only steers the ORDER, closest tier first (see rarityDistanceExpr), so a one-of-a-kind
+  // rarity still fills a full rail instead of returning two cards.
+  //
+  // Runs as two statements on purpose: the anchor lookup first, then the feed query built from the SAME
+  // shared browse-filter/grouping blocks as /v3/catalog/unified?groupBy=item. Folding the lookup into one
+  // statement would mean re-expressing those filters as SQL-side joins on the anchor row -- a second,
+  // divergent copy of logic the rest of this port already owns, to save a single-row indexed read.
+  async function getRelatedItems(filters: RelatedItemsFilters, manaUsdRate: number): Promise<{ data: UnifiedItem[] }> {
+    const { contractAddress, itemId } = filters
+    const first = clampCount(filters.first, RELATED_DEFAULT_LIMIT, SHOP_MIN_PAGE_SIZE, RELATED_MAX_LIMIT)
+    const rateNumericString = rateToNumericString(manaUsdRate)
+
+    const reference = await getReferenceItem(contractAddress, itemId)
+    if (!reference) return { data: [] }
+
+    const core = buildItemUnifiedCore(
+      {
+        category: reference.category,
+        wearableCategories: reference.wearableCategory ? [reference.wearableCategory] : undefined
+      },
+      rateNumericString
+    )
+
+    const query = SQL`
+      SELECT d.*
+      FROM (
+        `.append(core).append(SQL`
+      ) d
+      WHERE d.usd_wei > 0`)
+
+    // Drop the anchor itself. Written as a disjunction (not `NOT (a AND b)`) because item_id is nullable:
+    // a NULL item_id would make the negated form evaluate to NULL and silently discard the row.
+    query.append(SQL` AND (d.contract_address <> ${contractAddress.toLowerCase()} OR COALESCE(d.item_id, '') <> ${itemId})`)
+
+    // Rarity first (closest tier to the anchor), then newest, then trade_id so the rail is deterministic.
+    query
+      .append(SQL` ORDER BY `)
+      .append(rarityDistanceExpr(reference.rarity))
+      .append(SQL`, d.created_at DESC, d.trade_id LIMIT ${first}`)
+
+    const result = await pg.query<RelatedItemRow>(query)
+    const polygonChainId = getPolygonChainId()
+    const ethereumChainId = getEthereumChainId()
+
+    return { data: result.rows.map(r => mapUnifiedItemRow(r, polygonChainId, ethereumChainId)) }
+  }
+
+  return { getShopListings, getImportableListings, getLegacyListings, getUnifiedListings, getShopItems, getRelatedItems }
 }

--- a/src/ports/shop-catalog/types.ts
+++ b/src/ports/shop-catalog/types.ts
@@ -7,6 +7,11 @@ export const SHOP_DEFAULT_PAGE_SIZE = 48
 export const SHOP_MIN_PAGE_SIZE = 1
 export const SHOP_MAX_PAGE_SIZE = 1000
 
+// Bounds for the related-items rail. Kept separate from (and far below) the browse page size: this is a
+// single carousel, so a caller asking for hundreds would only widen a scan nothing can render.
+export const RELATED_DEFAULT_LIMIT = 10
+export const RELATED_MAX_LIMIT = 50
+
 export type ShopListingType = 'primary' | 'secondary'
 
 // Display gender, derived from a wearable's supported body shapes (BaseMale/BaseFemale). `null` for
@@ -174,6 +179,22 @@ export type UnifiedItem = UnifiedListing & {
   listingCount: number
 }
 
+// Identifies the item a related-items query is anchored on. Only the item's identity travels over the
+// wire: the similarity attributes (category/rarity) are resolved server-side so the rail is the same
+// whatever the client happens to have hydrated.
+export type RelatedItemsFilters = {
+  contractAddress: string
+  itemId: string
+  first?: number
+}
+
+// The anchor item's similarity attributes, resolved from the squid `item` row.
+export type ReferenceItem = {
+  category: string // top-level: 'wearable' | 'emote'
+  wearableCategory: string | null // on-chain category (upper_body, hat, ...) when applicable
+  rarity: string | null
+}
+
 export interface IShopCatalogComponent {
   getShopListings(filters: ShopCatalogFilters): Promise<{ data: ShopListing[]; total: number }>
   getImportableListings(seller: string): Promise<ImportableListing[]>
@@ -186,6 +207,11 @@ export interface IShopCatalogComponent {
   // (contract, item), priced primary-if-present else cheapest credit-buyable secondary, carrying a
   // per-item listingCount. This is the shop BROWSE feed; getUnifiedListings stays per-listing (PDP resale).
   getShopItems(filters: UnifiedCatalogFilters, manaUsdRate: number): Promise<{ data: UnifiedItem[]; total: number }>
+  // Items SIMILAR to one item, drawn from the same credit-buyable, item-unified universe as getShopItems
+  // so the client can render them with the very same card. Same top-level + on-chain category is the hard
+  // filter; rarity only steers the ORDER (closest tier first). Excludes the anchor item. Unpaginated --
+  // it backs a single carousel, so there is no total to report.
+  getRelatedItems(filters: RelatedItemsFilters, manaUsdRate: number): Promise<{ data: UnifiedItem[] }>
 }
 
 export type ImportableListingRow = {
@@ -260,6 +286,17 @@ export type UnifiedListingRow = {
 // (of the surviving representative listing) plus the per-item listing_count.
 export type UnifiedItemRow = UnifiedListingRow & {
   listing_count: string
+}
+
+// The related-items rail selects the same columns minus `total`: it is unpaginated, so there is no
+// COUNT(*) OVER() to carry.
+export type RelatedItemRow = Omit<UnifiedItemRow, 'total'>
+
+// Raw DB row for the anchor-item lookup that a related-items query starts from.
+export type ReferenceItemRow = {
+  rarity: string | null
+  item_type: string | null
+  wearable_category: string | null
 }
 
 // Raw DB row for the legacy (classic MANA) primary feed, before mapping to LegacyListing.

--- a/test/unit/shop-catalog-component.spec.ts
+++ b/test/unit/shop-catalog-component.spec.ts
@@ -1103,4 +1103,248 @@ describe('Shop Catalog Component', () => {
       expect(data[1]).toMatchObject({ listingType: 'primary', seller: null, issuedId: null })
     })
   })
+
+  // The related-items rail runs TWO statements: the anchor-item lookup, then the feed query. So every test
+  // here queues the anchor row first and reads query.mock.calls[1] for the feed SQL.
+  describe('when building the related items query', () => {
+    const RATE = 0.5
+    const CONTRACT = '0xCollection'
+    const ANCHOR = { contractAddress: CONTRACT, itemId: '3' }
+
+    function referenceRow(overrides: Record<string, unknown> = {}) {
+      return { rarity: 'rare', item_type: 'wearable_v2', wearable_category: 'hat', ...overrides }
+    }
+
+    function mockAnchor(overrides: Record<string, unknown> = {}) {
+      query.mockResolvedValueOnce({ rows: [referenceRow(overrides)] })
+      query.mockResolvedValueOnce({ rows: [] })
+    }
+
+    it('should resolve the anchor item from the squid item table by collection and blockchain id', async () => {
+      mockAnchor()
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const sql = query.mock.calls[0][0]
+      expect(sql.text).toContain('item.collection_id =')
+      expect(sql.text).toContain('item.blockchain_id =')
+      // The contract is lowercased so a checksummed address from the URL still matches the squid row.
+      expect(sql.values).toEqual(expect.arrayContaining([CONTRACT.toLowerCase(), '3']))
+    })
+
+    it('should return nothing and skip the feed query when the anchor item is unknown', async () => {
+      query.mockResolvedValueOnce({ rows: [] })
+
+      const { data } = await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      expect(data).toEqual([])
+      expect(query).toHaveBeenCalledTimes(1)
+    })
+
+    it('should hard-filter on the anchor top-level category and on-chain sub-category', async () => {
+      mockAnchor({ item_type: 'wearable_v2', wearable_category: 'hat' })
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const sql = query.mock.calls[1][0]
+      expect(sql.text).toContain("NOT ILIKE 'emote%'")
+      expect(sql.text).toContain('search_wearable_category')
+      expect(sql.values).toEqual(expect.arrayContaining([['hat']]))
+    })
+
+    it('should filter emotes to emotes when the anchor is an emote', async () => {
+      mockAnchor({ item_type: 'emote_v1', wearable_category: 'dance' })
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const sql = query.mock.calls[1][0]
+      expect(sql.text).toContain("ILIKE 'emote%'")
+      expect(sql.values).toEqual(expect.arrayContaining([['dance']]))
+    })
+
+    it('should fall back to the top-level category alone when the anchor has no sub-category', async () => {
+      mockAnchor({ wearable_category: null })
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const sql = query.mock.calls[1][0]
+      expect(sql.text).not.toContain('lower(COALESCE(item_p.search_wearable_category')
+      expect(sql.text).toContain("NOT ILIKE 'emote%'")
+    })
+
+    it('should exclude the anchor item with a NULL-safe disjunction, not a negated conjunction', async () => {
+      mockAnchor()
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const sql = query.mock.calls[1][0]
+      // `NOT (contract = x AND item_id = y)` evaluates to NULL — and so drops the row — whenever item_id
+      // is NULL, which would silently hide every secondary-only row from the rail.
+      expect(sql.text).toContain('d.contract_address <> ')
+      expect(sql.text).toContain("COALESCE(d.item_id, '') <> ")
+      expect(sql.text).not.toContain('NOT (d.contract_address')
+    })
+
+    it('should order by distance from the anchor rarity, then newest, then trade id', async () => {
+      mockAnchor({ rarity: 'rare' })
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const sql = query.mock.calls[1][0]
+      expect(sql.text).toContain('ORDER BY CASE lower(d.rarity)')
+      expect(sql.text).toContain('d.created_at DESC, d.trade_id')
+      // The CASE binds a precomputed distance per tier: the anchor's own rarity is 0 (so exact matches
+      // lead), its neighbours 1, and so on outwards along the scarcity scale.
+      const distances = sql.values.slice(sql.values.indexOf('unique'))
+      expect(distances).toEqual(expect.arrayContaining(['rare', 0, 'uncommon', 1, 'epic', 1, 'common', 2]))
+    })
+
+    it('should place an unrecognised rarity behind every known tier', async () => {
+      mockAnchor({ rarity: 'unique' })
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const sql = query.mock.calls[1][0]
+      // 8 known tiers -> the ELSE distance is 8, further than the widest real gap (unique..common = 7).
+      expect(sql.text).toContain('ELSE $')
+      expect(sql.values).toEqual(expect.arrayContaining([8]))
+    })
+
+    it('should apply no rarity preference when the anchor rarity is missing or unknown', async () => {
+      mockAnchor({ rarity: null })
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const sql = query.mock.calls[1][0]
+      expect(sql.text).toContain('ORDER BY 0, d.created_at DESC')
+      expect(sql.text).not.toContain('CASE lower(d.rarity)')
+    })
+
+    it('should reuse the item-unified grouping so the rail is one card per item', async () => {
+      mockAnchor()
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const text = query.mock.calls[1][0].text as string
+      expect(text).toContain('SELECT DISTINCT ON (f.contract_address, f.item_id)')
+      expect(text).toContain('COUNT(*) OVER (PARTITION BY u.contract_address, u.item_id) AS listing_count')
+      expect(text).toContain('CEIL(f.usd_wei /')
+      expect(text).toContain('UNION ALL')
+    })
+
+    // The rail is supposed to be indistinguishable from the browse grid, so every guard and tiebreak the
+    // grid applies has to reach it through the shared core. These are the assertions that fail if someone
+    // adds one to getShopItems' own SQL instead of to buildItemUnifiedCore.
+    it('should inherit the price bound that stops one absurd row aborting the query', async () => {
+      mockAnchor()
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const { text, values } = query.mock.calls[1][0]
+      expect(text).toContain('u.usd_wei <=')
+      expect(values).toContain('1000000000000000000000000000000')
+    })
+
+    it('should inherit the tie-break towards the trade over an equally-priced store mint', async () => {
+      mockAnchor()
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const text = query.mock.calls[1][0].text as string
+      const priceIdx = text.indexOf('f.usd_wei ASC')
+      const tieIdx = text.indexOf("f.acquisition = 'trade'")
+      expect(priceIdx).toBeGreaterThan(-1)
+      expect(tieIdx).toBeGreaterThan(priceIdx)
+    })
+
+    it('should draw from all three credit-buyable branches, store mints included', async () => {
+      mockAnchor({ item_type: 'emote_v1', wearable_category: 'dance' })
+
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+
+      const text = query.mock.calls[1][0].text as string
+      // native trade + legacy trade + CollectionStore mint. The similarity filter must land on all three —
+      // one occurrence per branch — or the rail would silently mix in unrelated store items.
+      expect(text.match(/UNION ALL/g)).toHaveLength(2)
+      expect(text).toContain('i.search_is_store_minter = true')
+      expect(text.match(/ILIKE 'emote%'/g)).toHaveLength(3)
+      expect(text.match(/lower\(COALESCE\(item_p\.search_wearable_category/g)).toHaveLength(3)
+    })
+
+    it('should clamp the limit to the related cap and never paginate', async () => {
+      mockAnchor()
+      await shopCatalog.getRelatedItems({ ...ANCHOR, first: 9999 }, RATE)
+
+      let sql = query.mock.calls[1][0]
+      expect(sql.text).toContain('LIMIT')
+      expect(sql.text).not.toContain('OFFSET')
+      expect(sql.text).not.toContain('COUNT(*) OVER() AS total')
+      expect(sql.values).toContain(50)
+
+      query.mockClear()
+      mockAnchor()
+      await shopCatalog.getRelatedItems(ANCHOR, RATE)
+      sql = query.mock.calls[1][0]
+      expect(sql.values).toContain(10)
+    })
+  })
+
+  describe('when mapping related item rows', () => {
+    // The anchor lookup, then the feed. `itemRow` is the SAME row factory the browse-grid tests use, minus
+    // `total` — the rail is unpaginated, so the mapper must not depend on a COUNT(*) OVER() column.
+    function mockRail(overrides: Record<string, unknown> = {}) {
+      const { total: _total, ...row } = itemRow(overrides)
+      query.mockResolvedValueOnce({ rows: [{ rarity: 'rare', item_type: 'wearable_v2', wearable_category: 'hat' }] })
+      query.mockResolvedValueOnce({ rows: [row] })
+    }
+
+    it('should return the same item-unified shape the browse grid renders', async () => {
+      mockRail({
+        trade_id: 'related-1',
+        contract_address: '0xother',
+        item_id: '7',
+        name: 'Another Hat',
+        price_credits: '4',
+        available: '2',
+        listing_count: '3'
+      })
+
+      const { data } = await shopCatalog.getRelatedItems({ contractAddress: '0xcollection', itemId: '3' }, 0.5)
+
+      expect(data).toHaveLength(1)
+      expect(data[0]).toMatchObject({
+        source: 'native',
+        acquisition: 'trade',
+        tradeId: 'related-1',
+        listingType: 'primary',
+        contractAddress: '0xother',
+        itemId: '7',
+        rarity: 'rare',
+        category: 'wearable',
+        wearableCategory: 'hat',
+        gender: 'unisex',
+        priceCredits: 4,
+        listingCount: 3,
+        available: 2
+      })
+    })
+
+    it('should drop the trade id for a store mint, which has none', async () => {
+      // Store mints reach the rail through the shared union, so the rail can surface a row with no trade.
+      // A fabricated id here would put a reference to a nonexistent trade into the purchase intent.
+      mockRail({ source: 'legacy', acquisition: 'store', trade_id: '0xcollection-3', mana_wei: '1000' })
+
+      const { data } = await shopCatalog.getRelatedItems({ contractAddress: '0xcollection', itemId: '3' }, 0.5)
+
+      expect(data[0]).toMatchObject({ acquisition: 'store', tradeId: null, source: 'legacy', manaWei: '1000' })
+    })
+
+    it('should carry the reseller and issued id through for a secondary row', async () => {
+      mockRail({ trade_type: 'public_nft_order', token_id: '99', item_id: null, seller: '0xreseller', issued_id: '5013' })
+
+      const { data } = await shopCatalog.getRelatedItems({ contractAddress: '0xcollection', itemId: '3' }, 0.5)
+
+      expect(data[0]).toMatchObject({ listingType: 'secondary', tokenId: '99', seller: '0xreseller', issuedId: '5013' })
+    })
+  })
 })

--- a/test/unit/shop-catalog-handler.spec.ts
+++ b/test/unit/shop-catalog-handler.spec.ts
@@ -1,5 +1,5 @@
 import { URL } from 'url'
-import { createShopUnifiedHandler } from '../../src/controllers/handlers/shop-catalog-handler'
+import { createShopRelatedHandler, createShopUnifiedHandler } from '../../src/controllers/handlers/shop-catalog-handler'
 
 // The unified handler is a factory: createShopUnifiedHandler(components) -> (context) => response. These
 // tests drive the `groupBy` dispatch (per-listing default vs item-unified) and confirm the parsed filters
@@ -69,6 +69,71 @@ describe('when handling the unified shop catalog endpoint', () => {
         sortBy: 'cheapest',
         search: 'cool'
       })
+    })
+  })
+})
+
+// The related handler answers the PDP's fallback rail. These tests cover what it lets through to the
+// component and, above all, what it refuses to guess when the anchor item is not fully identified.
+describe('when handling the related items endpoint', () => {
+  const CONTRACT = '0x1234567890123456789012345678901234567890'
+  let getRelatedItems: jest.Mock
+  let getRate: jest.Mock
+  let handler: ReturnType<typeof createShopRelatedHandler>
+
+  const noop = jest.fn()
+  const invoke = (url: string) => handler({ url: new URL(url), request: {} } as any, noop)
+
+  beforeEach(() => {
+    getRelatedItems = jest.fn().mockResolvedValue({ data: [{ tradeId: 'related-1' }] })
+    getRate = jest.fn().mockReturnValue(0.5)
+    handler = createShopRelatedHandler({ shopCatalog: { getRelatedItems }, manaUsdRate: { getRate } } as any)
+  })
+
+  describe('and the anchor item is fully identified', () => {
+    it('should forward the anchor and the live rate, and return the rail', async () => {
+      const result = await invoke(`http://localhost/v3/catalog/related?contractAddress=${CONTRACT}&itemId=3`)
+
+      expect(getRelatedItems).toHaveBeenCalledTimes(1)
+      expect(getRelatedItems.mock.calls[0][0]).toMatchObject({ contractAddress: CONTRACT, itemId: '3' })
+      expect(getRelatedItems.mock.calls[0][1]).toBe(0.5)
+      expect(result.body).toEqual({ data: [{ tradeId: 'related-1' }] })
+    })
+
+    it('should default the limit to the related rail size', async () => {
+      await invoke(`http://localhost/v3/catalog/related?contractAddress=${CONTRACT}&itemId=3`)
+
+      expect(getRelatedItems.mock.calls[0][0].first).toBe(10)
+    })
+
+    it('should pass an explicit limit through for the component to clamp', async () => {
+      await invoke(`http://localhost/v3/catalog/related?contractAddress=${CONTRACT}&itemId=3&first=20`)
+
+      expect(getRelatedItems.mock.calls[0][0].first).toBe(20)
+    })
+  })
+
+  describe('and the anchor item is missing or malformed', () => {
+    it('should return an empty rail without querying when the itemId is absent', async () => {
+      const result = await invoke(`http://localhost/v3/catalog/related?contractAddress=${CONTRACT}`)
+
+      expect(getRelatedItems).not.toHaveBeenCalled()
+      expect(result.body).toEqual({ data: [] })
+    })
+
+    it('should return an empty rail without querying when the contractAddress is absent', async () => {
+      const result = await invoke('http://localhost/v3/catalog/related?itemId=3')
+
+      expect(getRelatedItems).not.toHaveBeenCalled()
+      expect(result.body).toEqual({ data: [] })
+    })
+
+    it('should return an empty rail when the contractAddress is not an address', async () => {
+      // Params.getAddress validates the shape, so a junk contract never reaches a query.
+      const result = await invoke('http://localhost/v3/catalog/related?contractAddress=not-an-address&itemId=3')
+
+      expect(getRelatedItems).not.toHaveBeenCalled()
+      expect(result.body).toEqual({ data: [] })
     })
   })
 })

--- a/test/unit/shop-catalog-handler.spec.ts
+++ b/test/unit/shop-catalog-handler.spec.ts
@@ -135,5 +135,34 @@ describe('when handling the related items endpoint', () => {
       expect(getRelatedItems).not.toHaveBeenCalled()
       expect(result.body).toEqual({ data: [] })
     })
+
+    /**
+     * A non-numeric itemId used to reach the query, where `blockchain_id = ${itemId}::numeric` made Postgres
+     * raise `invalid input syntax for type numeric` — a 500 from a public GET, for a request this endpoint
+     * promises to answer with an empty rail. Asserting `not.toHaveBeenCalled()` is the point: being rejected
+     * in the handler is what keeps it away from SQL.
+     *
+     * Reachable from a bad URL, not only from a hand-written request: the Shop takes the id from
+     * `/item/:contractAddress/:itemId`, so a malformed deep link would have 500'd the rail.
+     */
+    it.each(['abc', '1e3', '-1', '1.5', '3; DROP TABLE item', ' ', '0x03'])(
+      'should return an empty rail without querying for the non-numeric itemId %p',
+      async itemId => {
+        const result = await invoke(`http://localhost/v3/catalog/related?contractAddress=${CONTRACT}&itemId=${encodeURIComponent(itemId)}`)
+
+        expect(getRelatedItems).not.toHaveBeenCalled()
+        expect(result.body).toEqual({ data: [] })
+      }
+    )
+
+    it('should still accept a large numeric itemId, which is a plain blockchain id and not junk', async () => {
+      // The guard must not reject legitimate ids: blockchain ids are unbounded integers, well past 2^53.
+      const big = '90071992547409910000'
+
+      await invoke(`http://localhost/v3/catalog/related?contractAddress=${CONTRACT}&itemId=${big}`)
+
+      expect(getRelatedItems).toHaveBeenCalledTimes(1)
+      expect(getRelatedItems.mock.calls[0][0]).toMatchObject({ itemId: big })
+    })
   })
 })


### PR DESCRIPTION
## Why

A Shop PDP shows a "More from this collection" carousel. When the collection holds only ONE item that rail renders nothing, leaving a large empty area below the fold. This adds the feed the client needs for a fallback rail of similar items.

## The endpoint

`GET /v3/catalog/related?contractAddress=0x…&itemId=3&first=10`

- `contractAddress` validated via `Params.getAddress`; junk or missing → `{ data: [] }`, never an error.
- `first` defaults to 10, capped at 50.
- Returns `{ data: UnifiedItem[] }` with no `total`, matching `/v3/catalog/importable`'s non-paginated precedent. Rows are byte-identical in shape to `/v3/catalog/unified?groupBy=item`, so the client reuses the existing mapper and card.
- Registered alongside the rest of the `/v3/catalog/*` family. No `/v1/*` route and no query shared with the legacy marketplace is touched.

## What "similar" means

**Hard filter:** same top-level category (wearable/emote) and, when the anchor item has one, the same on-chain sub-category (`hat`, `upper_body`, `dance`…). "Another wearable" is too broad to read as similar; "another hat" is not.

**Rarity sorts, it does not filter** — `ORDER BY <rarity distance>, d.created_at DESC, d.trade_id`. Rarity is an ordered scale, so "prioritise rarity" is expressed as distance from the anchor's tier rather than a same/different boolean: exact matches lead, and when there are fewer than `first` of them the next-closest tiers fill the rail instead of an arbitrary tail. Filtering on rarity instead would return 2 cards for a `unique` item. Ranks come from `Rarity.getRarities()` so the scale cannot drift from `@dcl/schemas`; the per-tier distances are computed in JS and bound as parameters, so the `CASE` contains no arithmetic and no interpolated input.

Not-buyable items are excluded for free: the shared universe is already "open credit-buyable listings with `usd_wei > 0`".

**Two statements, deliberately.** A single-row anchor lookup on the squid `item` table, then the feed query. Folding them into one would mean re-expressing the browse filters as SQL-side joins against the anchor row — a second, divergent copy of logic this port already owns — to save one indexed read.

**The anchor exclusion is a disjunction, not `NOT (a AND b)`.** `item_id` is nullable, and the negated form evaluates to `NULL`, which silently drops every secondary-only row. There is a test pinning that.

## Sharing the browse feed's query blocks

The rail must return what the grid would return, or the two diverge silently. So `buildItemUnifiedCore` and `mapUnifiedItemRow` are extracted from `getShopItems` and shared, rather than reimplemented.

That extraction was rebased across #375, #376, #378 and #379, and three upstream changes had to be carried into it:

- **The `MAX_USD_WEI` bound** (#379) is load-bearing, not cosmetic: without it `CEIL(usd_wei / C)::bigint` raises `bigint out of range` and aborts the *entire* query, so one absurdly-priced item would 500 the rail on every PDP. Carried, with a test.
- **The new `DISTINCT ON` tiebreaker** preferring `trade` over store rows, ordered below `f.usd_wei`. Carried, with a test asserting it sorts after the price.
- **`mapUnifiedRow`** — #379 extracted the same mapper this branch had written independently. The local copy is deleted in favour of upstream's, which correctly carries `acquisition`, `seller`, `issuedId` and the `tradeId: null` rule for store mints.

`buildUnifiedInner` now emits three union branches (store mints landed in #379), so the rail picks them up for free — correct, since they are credit-buyable. A test asserts the similarity filter reaches all three branches, because one that missed the store branch would quietly mix unrelated items into the rail.

`mapUnifiedRow`'s parameter is widened to `Omit<UnifiedListingRow, 'total'>` (it never reads `total`) so the unpaginated rail can use it instead of a near-copy.

## Tests

**849 passed / 66 suites**, 0 failures. 23 new (16 component + 7 handler). `tsc --noEmit` clean, `check:code` 0 errors, prettier clean on every touched file. The two pre-existing `check:prettier` warnings (`test/integration/TEST_COVERAGE.md`, `test/tsconfig.json`) are on `main` already and are not files this branch touches.

## Deliberately not done

- **No integration test.** There are none for any `/v3/catalog/*` endpoint and `test/integration/` needs a live squid/dapps Postgres. Unit specs asserting SQL shape are this port's convention.
- **No `docs/openapi.yaml` entry** — the whole `/v3/catalog/*` family is undocumented there.
- **Legacy secondary rows stay excluded**, inherited from `buildUnifiedInner`'s primary-only legacy branch. That is a separate decision, not this PR's to flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01939G3Nga5vvpb8v4T74EJD